### PR TITLE
Encode the parameters in URL

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/Extensions.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/Extensions.kt
@@ -9,7 +9,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.LayoutRes
+import java.net.URLEncoder
 
 fun ViewGroup.inflate(@LayoutRes layoutRes: Int, attachToRoot: Boolean = false): View {
     return LayoutInflater.from(context).inflate(layoutRes, this, attachToRoot)
+}
+
+fun encodeURLParam(string: String?): String {
+    return URLEncoder.encode(string, "utf-8")
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/MeetingHomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/MeetingHomeActivity.kt
@@ -23,7 +23,6 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
-import java.net.URLEncoder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -190,9 +189,5 @@ class MeetingHomeActivity : AppCompatActivity() {
                 null
             }
         }
-    }
-
-    private fun encodeURLParam(string: String?): String {
-        return URLEncoder.encode(string, "utf-8")
     }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/MeetingHomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/MeetingHomeActivity.kt
@@ -23,6 +23,7 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -155,7 +156,11 @@ class MeetingHomeActivity : AppCompatActivity() {
     ): String? {
         return withContext(ioDispatcher) {
             val serverUrl =
-                URL("${meetingUrl}join?title=$meetingId&name=$attendeeName&region=$MEETING_REGION")
+                URL(
+                    "${meetingUrl}join?title=${encodeURLParam(meetingId)}&name=${encodeURLParam(
+                        attendeeName
+                    )}&region=${encodeURLParam(MEETING_REGION)}"
+                )
 
             try {
                 val response = StringBuffer()
@@ -185,5 +190,9 @@ class MeetingHomeActivity : AppCompatActivity() {
                 null
             }
         }
+    }
+
+    private fun encodeURLParam(string: String?): String {
+        return URLEncoder.encode(string, "utf-8")
     }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/RosterViewFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/RosterViewFragment.kt
@@ -45,7 +45,6 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
-import java.net.URLEncoder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -337,10 +336,6 @@ class RosterViewFragment : Fragment(),
                 null
             }
         }
-    }
-
-    private fun encodeURLParam(string: String?): String {
-        return URLEncoder.encode(string, "utf-8")
     }
 
     private fun toggleMuteMeeting() {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/RosterViewFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/RosterViewFragment.kt
@@ -45,6 +45,7 @@ import java.io.BufferedReader
 import java.io.InputStreamReader
 import java.net.HttpURLConnection
 import java.net.URL
+import java.net.URLEncoder
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -312,7 +313,7 @@ class RosterViewFragment : Fragment(),
     ): String? {
         return withContext(ioDispatcher) {
             val serverUrl =
-                URL("${meetingUrl}attendee?title=$meetingId&attendee=$attendeeId")
+                URL("${meetingUrl}attendee?title=${encodeURLParam(meetingId)}&attendee=${encodeURLParam(attendeeId)}")
             try {
                 val response = StringBuffer()
                 with(serverUrl.openConnection() as HttpURLConnection) {
@@ -336,6 +337,10 @@ class RosterViewFragment : Fragment(),
                 null
             }
         }
+    }
+
+    private fun encodeURLParam(string: String?): String {
+        return URLEncoder.encode(string, "utf-8")
     }
 
     private fun toggleMuteMeeting() {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Use url encoder to escape the parameters.
### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] Mute self
* [x] Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
