### PR TITLE
Add content description on tab layout

### DIFF
--- a/app/src/main/res/layout/fragment_meeting.xml
+++ b/app/src/main/res/layout/fragment_meeting.xml
@@ -34,6 +34,7 @@
         android:id="@+id/tabLayoutMeetingView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:contentDescription="@string/tab_layout"
         app:tabMode="scrollable" />
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,5 @@
     <string name="user_notification_meeting_start_error">There was an error starting the meeting. Please try again</string>
     <string name="enter_message">Enter message</string>
     <string name="send_message">Send Message</string>
+    <string name="tab_layout">Tab Layout</string>
 </resources>


### PR DESCRIPTION
### Issue #, if available:
This is to add content description on tab layout so that we can find it through accessibility for testing
### Description of changes:

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
