### PR TITLE
Added built-in earpiece and microphone as handset type devices

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -160,6 +160,8 @@ class DefaultDeviceController(
             AudioDeviceInfo.TYPE_WIRED_HEADSET -> "Wired Headset"
             AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "Speaker"
             AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Wired Headphone"
+            AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+            AudioDeviceInfo.TYPE_BUILTIN_MIC,
             AudioDeviceInfo.TYPE_TELEPHONY -> "Handset"
             AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
             AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "Bluetooth"

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -45,6 +45,8 @@ enum class MediaDeviceType {
                 AudioDeviceInfo.TYPE_WIRED_HEADSET,
                 AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> AUDIO_WIRED_HEADSET
                 AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AUDIO_BUILTIN_SPEAKER
+                AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
+                AudioDeviceInfo.TYPE_BUILTIN_MIC,
                 AudioDeviceInfo.TYPE_TELEPHONY -> AUDIO_HANDSET
                 else -> OTHER
             }


### PR DESCRIPTION
### Issue #, if available:
No Issue opened, but can open an issue if required.

### Description of changes:
Added built-in earpiece and microphone as handset type devices as they were before returned as `Unknown/Other` by Chime

### Testing done:

#### Manual test cases (add more as needed):
* [x] See list of audio devices

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
