### PR TITLE
Use built-in earpiece as default handset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed the issue that `listAudioDevices` does not return built-in handset for some devices 
+
 ## [0.7.1] - 2020-08-13
 
 ## [0.7.0] - 2020-07-31

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -45,6 +45,7 @@ enum class MediaDeviceType {
                 AudioDeviceInfo.TYPE_WIRED_HEADSET,
                 AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> AUDIO_WIRED_HEADSET
                 AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AUDIO_BUILTIN_SPEAKER
+                AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
                 AudioDeviceInfo.TYPE_TELEPHONY -> AUDIO_HANDSET
                 else -> OTHER
             }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
@@ -34,7 +34,10 @@ class DefaultDeviceControllerTest {
     private lateinit var speakerInfo: AudioDeviceInfo
 
     @MockK
-    private lateinit var receiverInfo: AudioDeviceInfo
+    private lateinit var earpieceInfo: AudioDeviceInfo
+
+    @MockK
+    private lateinit var telephonyInfo: AudioDeviceInfo
 
     @MockK
     private lateinit var wiredHeadsetInfo: AudioDeviceInfo
@@ -89,8 +92,10 @@ class DefaultDeviceControllerTest {
     private fun commonSetup() {
         every { speakerInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
         every { speakerInfo.productName } returns "default speaker"
-        every { receiverInfo.type } returns AudioDeviceInfo.TYPE_TELEPHONY
-        every { receiverInfo.productName } returns "default receiver"
+        every { earpieceInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
+        every { earpieceInfo.productName } returns "default receiver"
+        every { telephonyInfo.type } returns AudioDeviceInfo.TYPE_TELEPHONY
+        every { telephonyInfo.productName } returns "telephony receiver"
         every { wiredHeadsetInfo.type } returns AudioDeviceInfo.TYPE_WIRED_HEADSET
         every { wiredHeadsetInfo.productName } returns "my wired headset"
         every { bluetoothInfo.type } returns AudioDeviceInfo.TYPE_BLUETOOTH_SCO
@@ -124,7 +129,7 @@ class DefaultDeviceControllerTest {
     fun `listAudioDevices should return a list of connected devices with product name when build version is high`() {
         setupForNewAPILevel()
         every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns arrayOf(
-            speakerInfo, receiverInfo, bluetoothInfo
+            speakerInfo, earpieceInfo, bluetoothInfo
         )
 
         val devices = deviceController.listAudioDevices()
@@ -167,7 +172,7 @@ class DefaultDeviceControllerTest {
     fun `listAudioDevices should not return both wired headset and receiver when build version is high`() {
         setupForNewAPILevel()
         every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns arrayOf(
-            speakerInfo, receiverInfo, wiredHeadsetInfo
+            speakerInfo, earpieceInfo, wiredHeadsetInfo
         )
 
         val devices = deviceController.listAudioDevices()
@@ -178,6 +183,18 @@ class DefaultDeviceControllerTest {
                         it.type == MediaDeviceType.AUDIO_BUILTIN_SPEAKER
             )
         }
+    }
+
+    @Test
+    fun `listAudioDevices should return one handset when multiple handset available (only apply to higher API level)`() {
+        setupForNewAPILevel()
+        every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns arrayOf(
+            earpieceInfo, telephonyInfo
+        )
+
+        val devices = deviceController.listAudioDevices()
+        assertEquals(1, devices.size)
+        assertEquals(MediaDeviceType.AUDIO_HANDSET, devices[0].type)
     }
 
     @Test

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/DeviceAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/DeviceAdapter.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdkdemo.adapter
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+
+class DeviceAdapter(
+    context: Context,
+    resource: Int,
+    private val devices: List<MediaDevice>
+) :
+    ArrayAdapter<MediaDevice>(context, resource, devices) {
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = super.getView(position, convertView, parent)
+        view.contentDescription = devices[position].type.name
+        return view
+    }
+}

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -14,7 +14,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
-import android.widget.ArrayAdapter
 import android.widget.EditText
 import android.widget.ImageButton
 import android.widget.LinearLayout
@@ -51,6 +50,7 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
 import com.amazonaws.services.chime.sdkdemo.R
 import com.amazonaws.services.chime.sdkdemo.activity.HomeActivity
 import com.amazonaws.services.chime.sdkdemo.activity.MeetingActivity
+import com.amazonaws.services.chime.sdkdemo.adapter.DeviceAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.MessageAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.MetricAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.RosterAdapter
@@ -118,7 +118,7 @@ class MeetingFragment : Fragment(),
     private lateinit var recyclerViewVideoCollection: RecyclerView
     private lateinit var recyclerViewScreenShareCollection: RecyclerView
     private lateinit var recyclerViewMessages: RecyclerView
-    private lateinit var deviceListAdapter: ArrayAdapter<String>
+    private lateinit var deviceListAdapter: DeviceAdapter
     private lateinit var metricsAdapter: MetricAdapter
     private lateinit var rosterAdapter: RosterAdapter
     private lateinit var videoTileAdapter: VideoAdapter
@@ -327,9 +327,10 @@ class MeetingFragment : Fragment(),
     private fun setupAudioDeviceSelectionDialog() {
         meetingModel.currentMediaDevices =
             audioVideo.listAudioDevices().filter { device -> device.type != MediaDeviceType.OTHER }
-        deviceListAdapter =
-            ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, android.R.id.text1)
-        deviceListAdapter.addAll(meetingModel.currentMediaDevices.map { device -> device.label })
+        deviceListAdapter = DeviceAdapter(
+            requireContext(),
+            android.R.layout.simple_list_item_1,
+            meetingModel.currentMediaDevices)
         deviceAlertDialogBuilder = AlertDialog.Builder(activity)
         deviceAlertDialogBuilder.setTitle(R.string.alert_title_choose_audio)
         deviceAlertDialogBuilder.setNegativeButton(R.string.cancel) { dialog, _ ->
@@ -353,9 +354,8 @@ class MeetingFragment : Fragment(),
     override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
         meetingModel.currentMediaDevices = freshAudioDeviceList
             .filter { device -> device.type != MediaDeviceType.OTHER }
-        val deviceNameList = meetingModel.currentMediaDevices.map { device -> device.label }
         deviceListAdapter.clear()
-        deviceListAdapter.addAll(deviceNameList)
+        deviceListAdapter.addAll(meetingModel.currentMediaDevices)
         deviceListAdapter.notifyDataSetChanged()
     }
 
@@ -638,12 +638,8 @@ class MeetingFragment : Fragment(),
 
     private fun createVideoCollectionTile(tileState: VideoTileState): VideoCollectionTile {
         val attendeeId = tileState.attendeeId
-        attendeeId?.let {
-            val attendeeName = meetingModel.currentRoster[attendeeId]?.attendeeName ?: ""
-            return VideoCollectionTile(attendeeName, tileState)
-        }
-
-        return VideoCollectionTile("", tileState)
+        val attendeeName = meetingModel.currentRoster[attendeeId]?.attendeeName ?: ""
+        return VideoCollectionTile(attendeeName, tileState)
     }
 
     override fun onAudioSessionStartedConnecting(reconnecting: Boolean) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,6 @@
     <!-- toggle tab -->
     <string name="toggle_camera">Toggle Camera</string>
     <string name="toggle_mute">Toggle Mute</string>
-    <string name="toggle_screen">Screen Tab</string>
-    <string name="toggle_attendees_list">Attendee Tab</string>
-    <string name="toggle_metrics">Metrics Tab</string>
 
     <!-- Alert -->
     <string name="cancel">Cancel</string>


### PR DESCRIPTION
### Issue #, if available:
Chime-29902

### Description of changes:
- Use ```TYPE_BUILTIN_EARPIECE``` as default handset, some SumSang devices don't have ```TYPE_TELEPHONY```, which led to no access to default earpiece/handset. 
- Add accessibility labels for audio devices in demo app for automation test.
- Remove unused strings & checks.

### Testing done:
- Tested on specific devices that customer reported issue with
- Wrote automation test to verify there're always built-in speaker and built-in handset available in a meeting, ran 10+ times on different devices without regression
#### Unit test coverage
* Class coverage: 89%
* Line coverage: 77%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
