### PR TITLE
Use structured concurrency

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -14,10 +14,12 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 class DefaultAudioClientController(
     private val context: Context,
@@ -33,6 +35,7 @@ class DefaultAudioClientController(
     private val AUDIO_CLIENT_RESULT_SUCCESS = AudioClient.AUDIO_CLIENT_OK
 
     private val uiScope = CoroutineScope(Dispatchers.Main)
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioModePreCall: Int = audioManager.mode
     private var speakerphoneStatePreCall: Boolean = audioManager.isSpeakerphoneOn
@@ -165,7 +168,13 @@ class DefaultAudioClientController(
             return
         }
 
-        GlobalScope.launch {
+        runBlocking {
+            stopAsync()
+        }
+    }
+
+    private suspend fun stopAsync() {
+        withContext(defaultDispatcher) {
             val res = audioClient.stopSession()
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -22,8 +22,9 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCod
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AttendeeUpdate
 import com.xodee.client.audio.audioclient.AudioClient
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 class DefaultAudioClientObserver(
     private val logger: Logger,
@@ -353,9 +354,9 @@ class DefaultAudioClientObserver(
         }
     }
 
-    private fun handleOnAudioSessionFailed(statusCode: MeetingSessionStatusCode?) {
+    private fun handleOnAudioSessionFailed(statusCode: MeetingSessionStatusCode?) = runBlocking {
         if (audioClient != null) {
-            GlobalScope.launch {
+            launch(Dispatchers.Default) {
                 audioClient?.stopSession()
                 DefaultAudioClientController.audioClientState = AudioClientState.STOPPED
                 notifyAudioClientObserver { observer ->

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -17,8 +17,9 @@ import com.xodee.client.video.VideoClient
 import com.xodee.client.video.VideoClientCapturer
 import com.xodee.client.video.VideoDevice
 import java.security.InvalidParameterException
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 class DefaultVideoClientController constructor(
     private val context: Context,
@@ -55,7 +56,13 @@ class DefaultVideoClientController constructor(
     }
 
     override fun stopAndDestroy() {
-        GlobalScope.launch {
+        runBlocking {
+            stopAsync()
+        }
+    }
+
+    private suspend fun stopAsync() {
+        withContext(Dispatchers.Default) {
             videoClientStateController.stop()
         }
     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -918,7 +918,7 @@ class MeetingFragment : Fragment(),
     override fun onDestroy() {
         super.onDestroy()
         unsubscribeFromAttendeeChangeHandlers()
-        meetingModel.currentVideoTiles.forEach { (tileId, tileData) ->
+        meetingModel.currentVideoTiles.forEach { (tileId, _) ->
             audioVideo.unbindVideoView(tileId)
         }
     }


### PR DESCRIPTION
### Issue #, if available:
Chime-29629

### Description of changes:
Use structured concurrency instead of global scope.
According to [official guide](https://kotlinlang.org/docs/reference/coroutines/basics.html#structured-concurrency) and [the developer blog](https://medium.com/@elizarov/the-reason-to-avoid-globalscope-835337445abc), 
*The launch(Dispatchers.Default) creates children coroutines in runBlocking scope, so runBlocking waits for their completion automatically. However, GlobalScope.launch creates global coroutines, which is developer's responsibility to keep track of their lifetime.*

### Testing done:
* 30 consecutive successful unit test by running ```gradlew clean build``` 

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [x] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
