### PR TITLE
Fix issue of missing PSTN attendee events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed the issue that `listAudioDevices` does not return built-in handset for some devices 
+* Fixed a bug that attendee events got filtered out due to absence of `externalUserId`
 
 ## [0.7.1] - 2020-08-13
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSession.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSession.kt
@@ -39,7 +39,8 @@ class DefaultMeetingSession(
         val audioClientObserver =
             DefaultAudioClientObserver(
                 logger,
-                metricsCollector
+                metricsCollector,
+                configuration
             )
 
         val audioClient =


### PR DESCRIPTION
### Issue #, if available:
Chime-29742

### Description of changes:
- Remove filter for attendees with empty external user Id, which could from PSTN
- Fill in external user Id for local attendee before notify audio callbacks

### Testing done:

#### VoiceConnector meeting
Joined meeting with both VOIP and PSTN attendees and verified
* Receive presence, volume, signal strength events for PSTN attendee
* No other attendee in callbacks are having empty external user Id

#### Unit test coverage
* Class coverage: 89%
* Line coverage: 78%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [ ] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
