### PR TITLE
Fix video rotation and EglRenderer issue

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -112,6 +112,8 @@ class MeetingActivity : AppCompatActivity(),
     }
 
     override fun onBackPressed() {
+        meetingSessionModel.audioVideo.stopLocalVideo()
+        meetingSessionModel.audioVideo.stopRemoteVideo()
         meetingSessionModel.audioVideo.stop()
         meetingSessionModel.cameraCaptureSource.stop()
         meetingSessionModel.gpuVideoProcessor.release()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -207,7 +207,7 @@ class MeetingFragment : Fragment(),
             ?.setOnClickListener { toggleSpeaker() }
 
         view.findViewById<ImageButton>(R.id.buttonLeave)
-            ?.setOnClickListener { listener.onLeaveMeeting() }
+            ?.setOnClickListener { endMeeting() }
     }
 
     private fun setupSubViews(view: View) {
@@ -886,7 +886,7 @@ class MeetingFragment : Fragment(),
             "${sessionStatus.statusCode}"
         )
         if (sessionStatus.statusCode != MeetingSessionStatusCode.OK) {
-            listener.onLeaveMeeting()
+            endMeeting()
         }
     }
 
@@ -1131,12 +1131,16 @@ class MeetingFragment : Fragment(),
         audioVideo.removeActiveSpeakerObserver(this)
     }
 
+    private fun endMeeting() {
+        meetingModel.currentVideoTiles.forEach { (tileId, tileData) ->
+            audioVideo.unbindVideoView(tileId)
+        }
+        listener.onLeaveMeeting()
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         deviceDialog?.dismiss()
         unsubscribeFromAttendeeChangeHandlers()
-        meetingModel.currentVideoTiles.forEach { (tileId, _) ->
-            audioVideo.unbindVideoView(tileId)
-        }
     }
 }


### PR DESCRIPTION
### Issue #, if available:
#74 and when we rotate there was issue with video just showing black screen.
This happens because we unbind it manually when Fragment is destroyed.
Also some people may just click back button, so we should call stopRemoteVideo/stopLocalVideo.
### Description of changes:
Handle stop and rotation properly.

### Testing done:
#### Unit test coverage
* Class coverage: 86%
* Line coverage: 77%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [X] See signal strength changes
* [X] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [X] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [X] First time audio permissions
* [X] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
