### PR TITLE
Add logging when AudioClient state changes

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -58,6 +58,8 @@ class DefaultAudioClientObserver(
     private var currentAttendeeSignalMap = mapOf<String, SignalUpdate>()
 
     override fun onAudioClientStateChange(newInternalAudioState: Int, newInternalAudioStatus: Int) {
+        logger.verbose(TAG, "AudioClient State: $newInternalAudioState Status: $newInternalAudioStatus")
+
         val newAudioState: SessionStateControllerAction = toAudioClientState(newInternalAudioState)
         val newAudioStatus: MeetingSessionStatusCode? = toAudioStatus(newInternalAudioStatus)
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -62,7 +62,7 @@ class DefaultAudioClientObserver(
         val newAudioStatus: MeetingSessionStatusCode? = toAudioStatus(newInternalAudioStatus)
 
         if (newAudioStatus == null) {
-            logger.warn(TAG, "AudioClient State: $newAudioState Unknown Status raw value: $newInternalAudioStatus")
+            logger.warn(TAG, "AudioClient State raw value: $newInternalAudioState Unknown Status raw value: $newInternalAudioStatus")
         } else {
             logger.info(TAG, "AudioClient State: $newAudioState Status: $newAudioStatus")
         }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -58,10 +58,14 @@ class DefaultAudioClientObserver(
     private var currentAttendeeSignalMap = mapOf<String, SignalUpdate>()
 
     override fun onAudioClientStateChange(newInternalAudioState: Int, newInternalAudioStatus: Int) {
-        logger.verbose(TAG, "AudioClient State: $newInternalAudioState Status: $newInternalAudioStatus")
-
         val newAudioState: SessionStateControllerAction = toAudioClientState(newInternalAudioState)
         val newAudioStatus: MeetingSessionStatusCode? = toAudioStatus(newInternalAudioStatus)
+
+        if (newAudioStatus == null) {
+            logger.warn(TAG, "AudioClient State: $newAudioState Unknown Status raw value: $newInternalAudioStatus")
+        } else {
+            logger.info(TAG, "AudioClient State: $newAudioState Status: $newAudioStatus")
+        }
 
         if (newAudioState == SessionStateControllerAction.Unknown) return
         if (newAudioState == currentAudioState && newAudioStatus == currentAudioStatus) return


### PR DESCRIPTION
### Issue #, if available:
Chime-30933
### Description of changes:

### Testing done:
Tested that the log shows us in Verbose level only


#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
