### PR TITLE
enable probing adaptive subscribe to help improve video QoS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Changed
+* Eable ProbingAdaptiveSubscribe, VideoShiftSingleSimulcastStream, VideoRaiseAdaptiveSubscribeThreshold and VideoRaiseDownlinkKeepThreshold feature flags to help improve video QoS
 * Changed `MAX_TILE_COUNT` in the demo app from 4 to 16. Now the demo app can support at most 16 remote video tiles.
 
 ## [0.7.3] - 2020-09-10

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -36,9 +36,29 @@ class DefaultVideoClientController constructor(
     private val TAG = "DefaultVideoClientController"
 
     /**
+     * This flag will enable adaptive probing subscription for videos
+     */
+    private val VIDEO_CLIENT_FLAG_ENABLE_PROBING_ADAPTIVE_SUBSCRIBE = 0x10
+
+    /**
      * This flag will enable higher resolution for videos
      */
-    private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 4096
+    private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 0x1000
+
+    /**
+     * This flag Raise the threshold for lowering target rate to WebRTC rate to 0.04 average packet loss and 0.5 unit variance
+     */
+    private val VIDEO_CLIENT_FLAG_SHIFT_SINGLE_SIMULCAST_STREAM = 0x8000
+
+    /**
+     * This flag raises the threshold for keeping same subscribe streams below a given change of target rate to 30 when below 200
+     */
+    private val VIDEO_CLIENT_FLAG_RAISE_ADAPTIVE_SUBSCRIBE_SUBSCRIBE_THRESHOLD = 0x10000
+
+    /**
+     * This flag will shift up the lowest simulcast stream so that receivers with good connections won't have to resubscribe.
+     */
+    private val VIDEO_CLIENT_FLAG_RAISE_DOWNLINK_KEEP_THRESHOLD = 0x20000
 
     private val gson = Gson()
     private val permissions = arrayOf(
@@ -180,8 +200,11 @@ class DefaultVideoClientController constructor(
     override fun startVideoClient() {
         logger.info(TAG, "Starting video client")
         videoClient?.setReceiving(false)
-        var flag = 0
-        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
+        var flag = 0x0
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS or VIDEO_CLIENT_FLAG_ENABLE_PROBING_ADAPTIVE_SUBSCRIBE
+        flag = flag or VIDEO_CLIENT_FLAG_SHIFT_SINGLE_SIMULCAST_STREAM or VIDEO_CLIENT_FLAG_RAISE_ADAPTIVE_SUBSCRIBE_SUBSCRIBE_THRESHOLD
+        flag = flag or VIDEO_CLIENT_FLAG_RAISE_DOWNLINK_KEEP_THRESHOLD
+        logger.debug(TAG, "Features: enable two_simulcast_streams, probing_adaptive_subscript, shift_single_simulcast, raise_adptive_subscribe_threshold and downraise_downlink_keep_threshold")
         videoClient?.startServiceV2(
             "",
             "",


### PR DESCRIPTION
### Issue #, if available:
https://issues.amazon.com/issues/ChimeVideo-761

### Description of changes:
Take advantage of native app's probing adaptive subscribe to help improve QoS

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
