### PR TITLE
Pass correct sample rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
+* Pass correct IO sample rate for audio client in `DefaultAudioClientController` to distorted audio in some of Android devices when using bluetooth devices
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
-* Pass correct IO sample rate for audio client in `DefaultAudioClientController` to distorted audio in some of Android devices when using bluetooth devices
+* Pass correct IO sample rate for audio client in `DefaultAudioClientController` for better audio handling when using Bluetooth
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ## [0.7.3] - 2020-09-10
 
 ### Fixed
-* Pass correct value for audio client in `DefaultAudioClientController`
+* Pass correct microphone input value for audio client in `DefaultAudioClientController` for better audio input quality
 
 ### Changed
 * Replace usage of GlobalScope with structured concurrency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
-* Fix audio issue when using Bluetooth device by forcing the sample rate to 16kHz, which should be supported in most of devices
+* Fix audio issue when using Bluetooth device by changing the sample rate to 16kHz
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
-* Pass correct IO sample rate for audio client in `DefaultAudioClientController` for better audio handling when using Bluetooth
+* Fix audio issue when using Bluetooth device by forcing the sample rate to 16kHz, which should be supported in most of devices
 
 ## [0.7.5] - 2020-10-23
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -49,7 +49,7 @@ class DefaultAudioClientController(
         audioClient.sendMessage(AudioClient.MESS_SET_HARDWARE_SAMPLE_RATE, nativeSR)
 
         // This IO_SAMPLE_RATE is used to create OpenSLES:
-        audioClient.sendMessage(AudioClient.MESS_SET_IO_SAMPLE_RATE, nativeSR)
+        audioClient.sendMessage(AudioClient.MESS_SET_IO_SAMPLE_RATE, AudioClient.AUDIO_CLIENT_SAMPLE_RATE)
 
         // Result is in bytes, so we divide by 2 (16-bit samples)
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(


### PR DESCRIPTION
### Issue #, if available:
CR-25791152
### Description of changes:
We should be passing correct value for IO rate.
### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
