### PR TITLE
Revert structured concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+### Fixed
+* Revert structured concurrency which can lead to deadlock
+
 ## [0.7.4] - 2020-10-08
 
 ### Changed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -14,12 +14,10 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 
 class DefaultAudioClientController(
     private val context: Context,
@@ -35,7 +33,6 @@ class DefaultAudioClientController(
     private val AUDIO_CLIENT_RESULT_SUCCESS = AudioClient.AUDIO_CLIENT_OK
 
     private val uiScope = CoroutineScope(Dispatchers.Main)
-    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
     private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioModePreCall: Int = audioManager.mode
     private var speakerphoneStatePreCall: Boolean = audioManager.isSpeakerphoneOn
@@ -168,13 +165,7 @@ class DefaultAudioClientController(
             return
         }
 
-        runBlocking {
-            stopAsync()
-        }
-    }
-
-    private suspend fun stopAsync() {
-        withContext(defaultDispatcher) {
+        GlobalScope.launch {
             val res = audioClient.stopSession()
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -22,9 +22,8 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCod
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AttendeeUpdate
 import com.xodee.client.audio.audioclient.AudioClient
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 class DefaultAudioClientObserver(
     private val logger: Logger,
@@ -360,9 +359,9 @@ class DefaultAudioClientObserver(
         }
     }
 
-    private fun handleOnAudioSessionFailed(statusCode: MeetingSessionStatusCode?) = runBlocking {
+    private fun handleOnAudioSessionFailed(statusCode: MeetingSessionStatusCode?) {
         if (audioClient != null) {
-            launch(Dispatchers.Default) {
+            GlobalScope.launch {
                 audioClient?.stopSession()
                 DefaultAudioClientController.audioClientState = AudioClientState.STOPPED
                 notifyAudioClientObserver { observer ->

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -17,9 +17,8 @@ import com.xodee.client.video.VideoClient
 import com.xodee.client.video.VideoClientCapturer
 import com.xodee.client.video.VideoDevice
 import java.security.InvalidParameterException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class DefaultVideoClientController constructor(
     private val context: Context,
@@ -56,13 +55,7 @@ class DefaultVideoClientController constructor(
     }
 
     override fun stopAndDestroy() {
-        runBlocking {
-            stopAsync()
-        }
-    }
-
-    private suspend fun stopAsync() {
-        withContext(Dispatchers.Default) {
+        GlobalScope.launch {
             videoClientStateController.stop()
         }
     }


### PR DESCRIPTION
### Issue #, if available:
Chime-31464
### Description of changes:
`runBlocking` can lead to deadlock, so it is safe to just use `GlobalScope.launch`

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [ ] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [X] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
