### PR TITLE
Extend timeout for verifying corountine

### DIFF
--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/TestConstant.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/TestConstant.kt
@@ -1,0 +1,7 @@
+package com.amazonaws.services.chime.sdk.meetings
+
+class TestConstant {
+    companion object {
+        const val globalScopeTimeoutMs = 5000L
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -321,7 +321,7 @@ class DefaultAudioClientControllerTest {
 
         audioClientController.stop()
 
-        verify(exactly = 1) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
         verify { audioManager.setBluetoothScoOn(false) }
         verify { audioManager.stopBluetoothSco() }
         verify { audioManager.setMode(AudioManager.MODE_NORMAL) }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -11,6 +11,7 @@ import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioTrack
 import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
 import io.mockk.MockKAnnotations
@@ -321,7 +322,7 @@ class DefaultAudioClientControllerTest {
 
         audioClientController.stop()
 
-        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
         verify { audioManager.setBluetoothScoOn(false) }
         verify { audioManager.stopBluetoothSco() }
         verify { audioManager.setMode(AudioManager.MODE_NORMAL) }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
@@ -689,8 +689,8 @@ class DefaultAudioClientObserverTest {
             )
         }
 
-        verify(exactly = 1) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
-        verify(exactly = 1) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = 5000L) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
     }
 
     @Test
@@ -708,8 +708,8 @@ class DefaultAudioClientObserverTest {
                 AudioClient.AUDIO_CLIENT_ERR_SERVICE_UNAVAILABLE
             )
         }
-        coVerify(exactly = 1) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
-        verify(exactly = 1) { mockAudioClient.stopSession() }
+        coVerify(exactly = 1, timeout = 5000L) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
 import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AttendeeInfo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.SignalStrength
@@ -689,8 +690,8 @@ class DefaultAudioClientObserverTest {
             )
         }
 
-        verify(exactly = 1, timeout = 5000L) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
-        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
     }
 
     @Test
@@ -708,8 +709,8 @@ class DefaultAudioClientObserverTest {
                 AudioClient.AUDIO_CLIENT_ERR_SERVICE_UNAVAILABLE
             )
         }
-        coVerify(exactly = 1, timeout = 5000L) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
-        verify(exactly = 1, timeout = 5000L) { mockAudioClient.stopSession() }
+        coVerify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
@@ -80,7 +80,7 @@ class DefaultVideoClientControllerTest {
             testVideoClientController.stopAndDestroy()
         }
 
-        coVerify { mockVideoClientStateController.stop() }
+        coVerify(exactly = 1, timeout = 5000L) { mockVideoClientStateController.stop() }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.video
 import android.content.Context
 import android.content.pm.PackageInfo
 import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.video.VideoClient
@@ -80,7 +81,7 @@ class DefaultVideoClientControllerTest {
             testVideoClientController.stopAndDestroy()
         }
 
-        coVerify(exactly = 1, timeout = 5000L) { mockVideoClientStateController.stop() }
+        coVerify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockVideoClientStateController.stop() }
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:
Chime-32246

### Description of changes:
Extend timeout when verifying methods get called in a GlobalScope, since it does not blocking the caller thread any more.

### Testing done:
20 consecutive unit test run.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
