### PR TITLE
Fix video tile size changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 ### Fixed
-* **Breaking** Fix a bug where `videoTileSizeChanged` is called with width=0 and height=0 when the video is paused.
+* **Breaking** Changed behavior to no longer call `videoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 ### Fixed
-* Fix `VideoTileSizeChanged` called even when frame is null
+* **Breaking** Fix a bug where `videoTileSizeChanged` is called with width=0 and height=0 when the video is paused.
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 ### Fixed
-* **Breaking** Changed behavior to no longer call `videoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
+* **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
 
 ## [0.7.5] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+### Unreleased
+
+### Fixed
+* Fix `VideoTileSizeChanged` called even when frame is null
+
 ## [0.7.5] - 2020-10-23
 
 ### Fixed
 * Revert structured concurrency which can lead to deadlock
-* Fix `VideoTileSizeChanged` called even when frame is null
 
 ## [0.7.4] - 2020-10-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Revert structured concurrency which can lead to deadlock
+* Fix `VideoTileSizeChanged` called even when frame is null
 
 ## [0.7.4] - 2020-10-08
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -69,8 +69,8 @@ class DefaultVideoTileController(
                 return
             }
 
-            if (videoStreamContentWidth != tile.state.videoStreamContentWidth ||
-                videoStreamContentHeight != tile.state.videoStreamContentHeight) {
+            if (frame != null && (videoStreamContentWidth != tile.state.videoStreamContentWidth ||
+                videoStreamContentHeight != tile.state.videoStreamContentHeight)) {
                 tile.state.videoStreamContentWidth = videoStreamContentWidth
                 tile.state.videoStreamContentHeight = videoStreamContentHeight
                 forEachObserver { observer -> observer.onVideoTileSizeChanged(tile.state) }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
When we call `pauseRemoteVideoTile(tileId)`, it notifies builder the videoTileSizeChanged with 0x0. This should fix that issue. Verify that I am no longer receiving callback when frame is null.

### Testing done:
Verify that I am no longer receiving callback when I call pause on remote video tiles.
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [ ] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [X] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
