### PR TITLE
Support usb headset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 
 ### Added
-* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client.
-* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like headphone jack wired with USB.
+* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client
+* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like USB-C headphone.
 * Added `AUDIO_USB_HEADSET` for `USB_HEADSET`.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@ This release includes support for custom video sources, and therefore includes a
 * Added additional, optional `id` (unique ID) parameter to `MediaDevice` for video capture devices.
 * **Breaking** Changed the default log level of `ConsoleLogger` to `INFO` level from `WARN`.
 
+### Added
+* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like headphone jack wired with USB.
+
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.
 * Fix audio issue when using Bluetooth device by changing the sample rate to 16kHz.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## [Unreleased]
 
 ### Added
-* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client
-* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like USB-C headphone.
-* Added `AUDIO_USB_HEADSET` for `USB_HEADSET`.
+* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client.
+* Added support for `TYPE_USB_HEADSET` in `DefaultDeviceController` for cases like USB-C headphone.
+* Added `AUDIO_USB_HEADSET` as a new enum in `MediaDeviceType`.
 
 ### Fixed
 * Fixed `DefaultCameraCaptureSource`, `DefaultSurfaceTextureCaptureSource` concurrency issue (Issue #221).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
+
 ### Added
 * Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client.
+* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like headphone jack wired with USB.
 
 ### Fixed
 * Fixed `DefaultCameraCaptureSource`, `DefaultSurfaceTextureCaptureSource` concurrency issue (Issue #221).
@@ -117,9 +119,6 @@ This release includes support for custom video sources, and therefore includes a
 * If no custom source is provided, the SDK level video client will use a `DefaultCameraCaptureSource` instead of relying on capture implementations within the AmazonChimeSDKMedia library; though behavior should be identical, please open an issue if any differences are noticed..
 * Added additional, optional `id` (unique ID) parameter to `MediaDevice` for video capture devices.
 * **Breaking** Changed the default log level of `ConsoleLogger` to `INFO` level from `WARN`.
-
-### Added
-* Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like headphone jack wired with USB.
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 * Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client.
 * Added `TYPE_USB_HEADSET` to `DefaultDeviceController` for cases like headphone jack wired with USB.
+* Added `AUDIO_USB_HEADSET` for `USB_HEADSET`.
 
 ### Fixed
 * Fixed `DefaultCameraCaptureSource`, `DefaultSurfaceTextureCaptureSource` concurrency issue (Issue #221).

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -85,6 +85,7 @@ class DefaultDeviceController(
             )
 
             val audioDevices = mutableListOf<MediaDevice>()
+            var wiredDeviceCount = 0
             for (device in audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)) {
                 // System will select wired headset over receiver
                 // so we want to filter receiver out when wired headset is connected
@@ -93,6 +94,7 @@ class DefaultDeviceController(
                     device.type == AudioDeviceInfo.TYPE_USB_HEADSET
                 ) {
                     isWiredHeadsetOn = true
+                    wiredDeviceCount++
                 }
 
                 // Return only one handset device to avoid confusion
@@ -114,6 +116,7 @@ class DefaultDeviceController(
                     )
                 )
             }
+            if (wiredDeviceCount > 1) audioDevices.removeIf { it.type == MediaDeviceType.AUDIO_USB_HEADSET }
             return if (isWiredHeadsetOn) audioDevices.filter { it.type != MediaDeviceType.AUDIO_HANDSET } else audioDevices
         } else {
             val res = mutableListOf<MediaDevice>()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -116,6 +116,9 @@ class DefaultDeviceController(
                     )
                 )
             }
+
+            // It doesn't look like Android can switch between two wired connection, so we'll assume WIRED_HEADSET
+            // is where audio is routed.
             if (wiredDeviceCount > 1) audioDevices.removeIf { it.type == MediaDeviceType.AUDIO_USB_HEADSET }
             return if (isWiredHeadsetOn) audioDevices.filter { it.type != MediaDeviceType.AUDIO_HANDSET } else audioDevices
         } else {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -89,7 +89,8 @@ class DefaultDeviceController(
                 // System will select wired headset over receiver
                 // so we want to filter receiver out when wired headset is connected
                 if (device.type == AudioDeviceInfo.TYPE_WIRED_HEADSET ||
-                    device.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+                    device.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES ||
+                    device.type == AudioDeviceInfo.TYPE_USB_HEADSET
                 ) {
                     isWiredHeadsetOn = true
                 }
@@ -231,6 +232,7 @@ class DefaultDeviceController(
             AudioDeviceInfo.TYPE_WIRED_HEADSET -> "Wired Headset"
             AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "Speaker"
             AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Wired Headphone"
+            AudioDeviceInfo.TYPE_USB_HEADSET -> "USB Headset"
             AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
             AudioDeviceInfo.TYPE_TELEPHONY -> "Handset"
             AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DeviceController.kt
@@ -20,6 +20,8 @@ interface DeviceController {
     /**
      * Lists currently available audio devices.
      *
+     * Note: If there are both USB and earphone jack connected. The device will only show earphone.
+     *
      * @return a list of currently available audio devices.
      */
     fun listAudioDevices(): List<MediaDevice>

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -127,6 +127,7 @@ enum class MediaDeviceType {
                 AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
                 AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> AUDIO_BLUETOOTH
                 AudioDeviceInfo.TYPE_WIRED_HEADSET,
+                AudioDeviceInfo.TYPE_USB_HEADSET,
                 AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> AUDIO_WIRED_HEADSET
                 AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AUDIO_BUILTIN_SPEAKER
                 AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -29,6 +29,7 @@ data class MediaDevice(
     val order: Int = when (type) {
         MediaDeviceType.AUDIO_BLUETOOTH -> 0
         MediaDeviceType.AUDIO_WIRED_HEADSET -> 1
+        MediaDeviceType.AUDIO_USB_HEADSET -> 1
         MediaDeviceType.AUDIO_BUILTIN_SPEAKER -> 2
         MediaDeviceType.AUDIO_HANDSET -> 3
         MediaDeviceType.VIDEO_FRONT_CAMERA -> 4
@@ -101,6 +102,7 @@ data class MediaDevice(
 enum class MediaDeviceType {
     AUDIO_BLUETOOTH,
     AUDIO_WIRED_HEADSET,
+    AUDIO_USB_HEADSET,
     AUDIO_BUILTIN_SPEAKER,
     AUDIO_HANDSET,
     VIDEO_FRONT_CAMERA,
@@ -112,6 +114,7 @@ enum class MediaDeviceType {
         return when (this) {
             AUDIO_BLUETOOTH -> "Bluetooth"
             AUDIO_WIRED_HEADSET -> "Wired Headset"
+            AUDIO_USB_HEADSET -> "USB Headset"
             AUDIO_BUILTIN_SPEAKER -> "Builtin Speaker"
             AUDIO_HANDSET -> "Handset"
             VIDEO_FRONT_CAMERA -> "Front Camera"
@@ -127,8 +130,8 @@ enum class MediaDeviceType {
                 AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
                 AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> AUDIO_BLUETOOTH
                 AudioDeviceInfo.TYPE_WIRED_HEADSET,
-                AudioDeviceInfo.TYPE_USB_HEADSET,
                 AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> AUDIO_WIRED_HEADSET
+                AudioDeviceInfo.TYPE_USB_HEADSET -> AUDIO_USB_HEADSET
                 AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> AUDIO_BUILTIN_SPEAKER
                 AudioDeviceInfo.TYPE_BUILTIN_EARPIECE,
                 AudioDeviceInfo.TYPE_TELEPHONY -> AUDIO_HANDSET


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:
Some of devices that does not have earphone jack could use USB plug for earphone jack.
![image-56f29919-a46b-4a27-9c21-a941f2a551a9](https://user-images.githubusercontent.com/57926812/97399819-2722d300-18ab-11eb-9dd6-8eb069bc14a8.jpg)

Connect USB and see the usb as shown in the device list.

However, this could cause cases like two wired earphone devices connected, which we do not support.

Few case scenarios that could cause issue.

1. Phone does have connection, but it doesn't support call with usb-c.
Behavior: This will show usb-c as an option in the list, but the audio will not be routed.
2. Phone with both usb-c and earphone jack.
Behavior: This will show only earphone jack as based on testing, these devices seem to route to earphone jack and not support usb-c.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [ ] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
