### PR TITLE
Add debug logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 * Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus
 * Added Voice Focus feature in Android demo app
 
+### Added
+* Added more verbose logging from media layer to SDK layer for builders to control log level
+
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
 * Fix audio issue when using Bluetooth device by changing the sample rate to 16kHz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Added Voice Focus feature in Android demo app
 
 ### Added
-* Added more verbose logging from media layer to SDK layer for builders to control log level
+* Added more verbose logging from media layer to SDK layer for builders to control log level. Set `LogLevel` to `INFO` or above for production application to not be bombarded with logs.
 
 ### Fixed
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * **Breaking** Changed behavior to no longer call `onVideoTileSizeChanged` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
 * Fix audio issue when using Bluetooth device by changing the sample rate to 16kHz
 
+### Changed
+* **Breaking** Changed the log level of `ConsoleLogger` to INFO level.
+
 ## [0.7.5] - 2020-10-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Fix audio issue when using Bluetooth device by changing the sample rate to 16kHz
 
 ### Changed
-* **Breaking** Changed the log level of `ConsoleLogger` to INFO level.
+* **Breaking** Changed the default log level of `ConsoleLogger` to `INFO` level from `WARN`
 
 ## [0.7.5] - 2020-10-23
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -217,12 +217,10 @@ class DefaultAudioClientObserver(
     override fun onLogMessage(logLevel: Int, message: String?) {
         if (message == null) return
 
-        // Only print error and fatal as the Media team's request to avoid noise
-        // Will be changed back to respect logger settings once sanitize the logs
+        // Only print error and fatal as the Media team's request to avoid noise for application
+        // that has log level set to INFO or higher. All other cases, print as verbose
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
-        } else if (logLevel == AudioClient.L_INFO || logLevel == AudioClient.L_WARNING) {
-            logger.debug(TAG, message)
         } else {
             logger.verbose(TAG, message)
         }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -221,9 +221,7 @@ class DefaultAudioClientObserver(
         // Will be changed back to respect logger settings once sanitize the logs
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
-        } else if (logLevel == AudioClient.L_WARNING) {
-            logger.warn(TAG, message)
-        } else if (logLevel == AudioClient.L_INFO) {
+        } else if (logLevel == AudioClient.L_INFO || logLevel == AudioClient.L_WARNING) {
             logger.debug(TAG, message)
         } else {
             logger.verbose(TAG, message)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -221,6 +221,12 @@ class DefaultAudioClientObserver(
         // Will be changed back to respect logger settings once sanitize the logs
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
+        } else if (logLevel == AudioClient.L_WARNING) {
+            logger.warn(TAG, message)
+        } else if (logLevel == AudioClient.L_INFO) {
+            logger.debug(TAG, message)
+        } else {
+            logger.verbose(TAG, message)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -160,11 +160,11 @@ class DefaultVideoClientObserver(
     override fun onLogMessage(logLevel: Int, message: String?) {
         if (message == null) return
         // Only print error and fatal as the Media team's request to avoid noise for application
-        // that has log level set to INFO or higher. All other cases, print as debug
+        // that has log level set to INFO or higher. All other cases, print as verbose
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
         } else {
-            logger.debug(TAG, message)
+            logger.verbose(TAG, message)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -159,14 +159,12 @@ class DefaultVideoClientObserver(
 
     override fun onLogMessage(logLevel: Int, message: String?) {
         if (message == null) return
-        // Only print error and fatal as the Media team's request to avoid noise
-        // Will be changed back to respect logger settings once sanitize the logs
+        // Only print error and fatal as the Media team's request to avoid noise for application
+        // that has log level set to INFO or higher. All other cases, print as debug
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
-        } else if (logLevel == AudioClient.L_INFO || logLevel == AudioClient.L_WARNING) {
-            logger.debug(TAG, message)
         } else {
-            logger.verbose(TAG, message)
+            logger.debug(TAG, message)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -163,9 +163,7 @@ class DefaultVideoClientObserver(
         // Will be changed back to respect logger settings once sanitize the logs
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
-        } else if (logLevel == AudioClient.L_WARNING) {
-            logger.warn(TAG, message)
-        } else if (logLevel == AudioClient.L_INFO) {
+        } else if (logLevel == AudioClient.L_INFO || logLevel == AudioClient.L_WARNING) {
             logger.debug(TAG, message)
         } else {
             logger.verbose(TAG, message)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -163,6 +163,12 @@ class DefaultVideoClientObserver(
         // Will be changed back to respect logger settings once sanitize the logs
         if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
             logger.error(TAG, message)
+        } else if (logLevel == AudioClient.L_WARNING) {
+            logger.warn(TAG, message)
+        } else if (logLevel == AudioClient.L_INFO) {
+            logger.debug(TAG, message)
+        } else {
+            logger.verbose(TAG, message)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/logger/ConsoleLogger.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/logger/ConsoleLogger.kt
@@ -25,7 +25,7 @@ import android.util.Log
  * logger.debug("debug"); // print
  * ```
  */
-class ConsoleLogger(private var level: LogLevel = LogLevel.WARN) : Logger {
+class ConsoleLogger(private var level: LogLevel = LogLevel.INFO) : Logger {
 
     override fun verbose(tag: String, msg: String) {
         this.log(LogLevel.VERBOSE, tag, msg)

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/utils/logger/ConsoleLoggerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/utils/logger/ConsoleLoggerTest.kt
@@ -35,7 +35,7 @@ class ConsoleLoggerTest {
     fun `constructor should use default log level when no parameters`() {
         val logger = ConsoleLogger()
 
-        assertEquals(LogLevel.WARN, logger.getLogLevel())
+        assertEquals(LogLevel.INFO, logger.getLogLevel())
     }
 
     @Test
@@ -68,7 +68,7 @@ class ConsoleLoggerTest {
 
         verify(exactly = 0) { Log.v(any(), any()) }
         verify(exactly = 0) { Log.d(any(), any()) }
-        verify(exactly = 0) { Log.i(any(), any()) }
+        verify(exactly = 1) { Log.i(any(), any()) }
         verify(exactly = 1) { Log.w(testTag, testWarnMsg) }
         verify(exactly = 1) { Log.e(testTag, testErrorMsg) }
     }


### PR DESCRIPTION
### Issue #, if available:
Chime-32053
### Description of changes:
Add more debug logging from media layer to SDK layer.

### Testing done:
```
2020-10-28 11:18:05.833 27730-27910/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: used_ids.h: [006:774] [27910] (line 55): Duplicate id found. Reassigning from 111 to 121
2020-10-28 11:18:05.833 27730-27910/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: used_ids.h: [006:775] [27910] (line 55): Duplicate id found. Reassigning from 113 to 120
2020-10-28 11:18:05.833 27730-27910/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: used_ids.h: [006:775] [27910] (line 55): Duplicate id found. Reassigning from 109 to 119
2020-10-28 11:18:05.833 27730-27910/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: used_ids.h: [006:775] [27910] (line 55): Duplicate id found. Reassigning from 1 to 14
2020-10-28 11:18:05.833 27730-27910/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: used_ids.h: [006:775] [27910] (line 55): Duplicate id found. Reassigning from 3 to 13
2020-10-28 11:18:05.951 27730-27911/com.amazonaws.services.chime.sdkdemo W/DefaultVideoClientObserver: thread.cc: [006:892] [27911] (line 793): Waiting for the thread to join, but blocking calls have been disallowed
```
#### Unit test coverage
Passed


#### Manual test cases (add more as needed):
* [x] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
