### PR TITLE
Implemented new method for VideoClientDelegate in DefaultVideoClientO…

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -153,6 +153,10 @@ class DefaultVideoClientObserver(
         clientMetricsCollector.processVideoClientMetrics(metricMap)
     }
 
+    override fun getAvailableDnsServers(): Array<String> {
+        return emptyArray()
+    }
+
     override fun onLogMessage(logLevel: Int, message: String?) {
         if (message == null) return
         // Only print error and fatal as the Media team's request to avoid noise


### PR DESCRIPTION
…bserver

### Issue #, if available:
Chime-32564

### Description of changes:
Media library has added a new method in `VideoClientDelegate`, so we will need to implement this new method in `DefaultVideoClientObserver`. This is because the logic for getting DNS servers is being moved from media library to SDK. This change is focused on fixing the build. There should be another change later to add more logic for getting the DNS server.

If media library was not able to get DNS servers via `getAvailableDnsServers` then it will fall back to its default DNS server. This is the same as the previous behavior and media library has been falling back to the default DNS server before the changes

### Testing done:
* Tested with an updated SDK media AAR that contains the new method (See issue for more details on builds)

#### Unit test coverage
* Class coverage: 89%
* Line coverage: 78%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [ ] See signal strength changes
* [X] See media metrics received
* [X] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [X] Switch camera
* [X] See remote screen sharing content with attendee name
* [X] Pause remote video tile
* [X] Resume remote video tile
* [X] First time audio permissions
* [X] First time video permissions

#### Screenshots, if available:
* N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
