### PR TITLE
Fix memory leak in Demo CPU video processor

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/CpuVideoProcessor.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/CpuVideoProcessor.kt
@@ -129,9 +129,10 @@ class CpuVideoProcessor(private val logger: Logger, eglCoreFactory: EglCoreFacto
             convertToBlackAndWhite(rgbaBuffer)
 
             val processedFrame = VideoFrame(frame.timestampNs, rgbaBuffer)
+            frame.release()
 
             sinks.forEach { it.onVideoFrameReceived(processedFrame) }
-            frame.release()
+            processedFrame.release()
         }
     }
 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes: Properly release modified frame so that its resources can be released.

### Testing done:  Along with MediaSDK change, confirmed with profiler that there is no longer a leak.

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [ ] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
