### PR TITLE
Fix attaching custom source to sink multiple times, don't trigger resubscribe on filter change

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -45,7 +45,7 @@ class DefaultVideoClientController(
     private val gson = Gson()
 
     private val cameraCaptureSource: CameraCaptureSource
-    private var videoSourceAdapter: VideoSourceAdapter? = null
+    private var videoSourceAdapter = VideoSourceAdapter()
     private var isUsingInternalCaptureSource = false
 
     init {
@@ -85,10 +85,7 @@ class DefaultVideoClientController(
     override fun startLocalVideo() {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
-        videoSourceAdapter =
-            VideoSourceAdapter(
-                cameraCaptureSource
-            )
+        videoSourceAdapter.source = cameraCaptureSource
         logger.info(TAG, "Setting external video source in media client to internal camera source")
         videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
         videoClient?.setSending(true)
@@ -100,10 +97,7 @@ class DefaultVideoClientController(
     override fun startLocalVideo(source: VideoSource) {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
-        videoSourceAdapter =
-            VideoSourceAdapter(
-                source
-            )
+        videoSourceAdapter.source = source
         logger.info(TAG, "Setting external video source in media client to custom source")
         videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
         videoClient?.setSending(true)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
@@ -19,7 +19,7 @@ import java.security.InvalidParameterException
 /**
  * [VideoSourceAdapter] provides two classes to adapt [VideoSource] to [com.xodee.client.video.VideoSource].
  */
-class VideoSourceAdapter(private val source: VideoSource) : VideoSink,
+class VideoSourceAdapter : VideoSink,
     com.xodee.client.video.VideoSource {
 
     class VideoFrameTextureBufferAdapter(
@@ -65,11 +65,14 @@ class VideoSourceAdapter(private val source: VideoSource) : VideoSink,
         override fun release() = i420Buffer.release()
     }
 
-    private var sinks = mutableSetOf<com.xodee.client.video.VideoSink>()
+    var source: VideoSource? = null
+        set(value) {
+            source?.removeVideoSink(this)
+            field = value
+            source?.addVideoSink(this)
+        }
 
-    init {
-        source.addVideoSink(this)
-    }
+    private var sinks = mutableSetOf<com.xodee.client.video.VideoSink>()
 
     override fun addSink(sink: com.xodee.client.video.VideoSink) {
         sinks.add(sink)
@@ -80,11 +83,12 @@ class VideoSourceAdapter(private val source: VideoSource) : VideoSink,
     }
 
     override fun getContentHint(): com.xodee.client.video.ContentHint {
-        return when (source.contentHint) {
+        return when (source?.contentHint) {
             VideoContentHint.None -> com.xodee.client.video.ContentHint.NONE
             VideoContentHint.Motion -> com.xodee.client.video.ContentHint.MOTION
             VideoContentHint.Detail -> com.xodee.client.video.ContentHint.DETAIL
             VideoContentHint.Text -> com.xodee.client.video.ContentHint.TEXT
+            else -> com.xodee.client.video.ContentHint.NONE
         }
     }
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapterTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapterTest.kt
@@ -61,19 +61,16 @@ class VideoSourceAdapterTest {
 
     @Test
     fun `Content hint is passed through`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
+
         assertEquals(adapter.contentHint, testMediaContentHint)
     }
 
     @Test
     fun `Timestamp and rotation is passed through`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
         adapter.addSink(mockMediaVideoSink)
 
         adapter.onVideoFrameReceived(VideoFrame(testTimestamp, mockSdkVideoFrameTextureBuffer, testRotation))
@@ -86,10 +83,8 @@ class VideoSourceAdapterTest {
 
     @Test
     fun `Passing a generic SDK buffer results in an exception`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
         adapter.addSink(mockMediaVideoSink)
 
         var exceptionThrown = false
@@ -103,10 +98,8 @@ class VideoSourceAdapterTest {
 
     @Test
     fun `Passing an I420 SDK buffer results in an I420 Media buffer`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
         adapter.addSink(mockMediaVideoSink)
 
         adapter.onVideoFrameReceived(VideoFrame(testTimestamp, mockSdkVideoFrameI420Buffer, testRotation))
@@ -118,10 +111,8 @@ class VideoSourceAdapterTest {
 
     @Test
     fun `Passing an RGBA SDK buffer results in an RGBA Media buffer`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
         adapter.addSink(mockMediaVideoSink)
 
         adapter.onVideoFrameReceived(VideoFrame(testTimestamp, mockSdkVideoFrameRGBABuffer, testRotation))
@@ -133,10 +124,8 @@ class VideoSourceAdapterTest {
 
     @Test
     fun `Passing a texture SDK buffer results in a texture Media buffer`() {
-        val adapter =
-            VideoSourceAdapter(
-                mockSdkVideoSource
-            )
+        val adapter = VideoSourceAdapter()
+        adapter.source = mockSdkVideoSource
         adapter.addSink(mockMediaVideoSink)
 
         adapter.onVideoFrameReceived(VideoFrame(testTimestamp, mockSdkVideoFrameTextureBuffer, testRotation))

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -688,7 +688,6 @@ class MeetingFragment : Fragment(),
         )
         meetingModel.isUsingCpuVideoProcessor = !meetingModel.isUsingCpuVideoProcessor
         if (meetingModel.isLocalVideoStarted) {
-            stopLocalVideo()
             startLocalVideo()
         }
     }
@@ -718,7 +717,6 @@ class MeetingFragment : Fragment(),
         )
         meetingModel.isUsingGpuVideoProcessor = !meetingModel.isUsingGpuVideoProcessor
         if (meetingModel.isLocalVideoStarted) {
-            stopLocalVideo()
             startLocalVideo()
         }
     }
@@ -734,7 +732,6 @@ class MeetingFragment : Fragment(),
             if (wasUsingCameraCaptureSource) {
                 cameraCaptureSource.stop()
             }
-            stopLocalVideo()
             startLocalVideo()
         }
     }


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:
See title.  If we don't reuse the adapter it will attach multiple adapters to the source.  Also removed the `stopLocalVideo` from demo as this is the better way for builders to accomplish switching filters.  Otherwise on the remote end the video will flash off and on when filters are changed.

### Testing done:
Tested using send and receive, and video options toggling in demo.

#### Unit test coverage
* Class coverage: 80
* Line coverage: 68

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
