### PR TITLE
Make scaling type publically accessible, add logging to render views and renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release includes support for custom video sources, and therefore includes a
     * Builders with a custom `VideoTile` will have to update APIs correspondingly.
     * Currently the buffer type of all frames coming from the MediaSDK should be `VideoFrameI420Buffer` which should have the same API as the legacy, closed source buffer used.
   * **Breaking** `VideoRenderView.initialize` and `VideoRenderView.finalize` have been abstracted away to `EglVideoRenderView` and are now named `init` and `release` respectively.
+  * **Breaking** `DefaultVideoRenderView.setMirror` is now a class variable `mirror`.  `DefaultVideoRenderView.setScalingType` is now a class variable `scalingType`, and takes `VideoScalingType`
   * `DefaultVideoRenderView` now inherits from `SurfaceTextureView`.
 * If no custom source is provided, the SDK level video client will use a `DefaultCameraCaptureSource` instead of relying on capture implementations within the MediaSDK; though behavior should be identical, please open an issue if any differences are noticed..
 * Added additional, optional `id` (unique ID) parameter to `MediaDevice` for video capture devices.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
@@ -1,17 +1,28 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 
 /**
  * [VideoScalingType] describes the scaling type of how video is rendered.  Certain types
  * may effect how much of a video is cropped.
  */
-enum class VideoScalingType {
+enum class VideoScalingType(val visibleFraction: Float) {
     /**
      * Fit the frame to the surrounding view to avoid any cropping.
      */
-    AspectFit,
+    AspectFit(1.0f),
+
+    /**
+     * Attempt to avoid cropping seen using [AspectFill] while showing more
+     * of the image then [AspectFit]; this may crop if the aspect ratios do not match.
+     */
+    AspectBalanced(0.5625f),
 
     /**
      * Fill the surrounding view; this may crop if the aspect ratios do not match.
      */
-    AspectFill
+    AspectFill(0.0f)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
@@ -1,0 +1,17 @@
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
+
+/**
+ * [VideoScalingType] describes the scaling type of how video is rendered.  Certain types
+ * may effect how much of a video is cropped.
+ */
+enum class VideoScalingType {
+    /**
+     * Fit the frame to the surrounding view to avoid any cropping.
+     */
+    AspectFit,
+
+    /**
+     * Fill the surrounding view; this may crop if the aspect ratios do not match.
+     */
+    AspectFill
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoScalingType.kt
@@ -7,7 +7,9 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 
 /**
  * [VideoScalingType] describes the scaling type of how video is rendered.  Certain types
- * may effect how much of a video is cropped.
+ * may effect how much of a video is cropped. [visibleFraction] refers to the minimum amount
+ * of a video frame required to be shown per scaling type (e.g. [AspectFit] indicates showing
+ * the whole frame, no cropping).
  */
 enum class VideoScalingType(val visibleFraction: Float) {
     /**

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
@@ -44,8 +44,9 @@ open class SurfaceRenderView @JvmOverloads constructor(
     // (Required for View implementations) which determines the actual size of the view
     private val videoLayoutMeasure: VideoLayoutMeasure = VideoLayoutMeasure()
 
+    // Lazy so we can allow builders to set their own loggers using self.logger
+    // If no logger is passed in we will fallback on ConsoleLogger
     private val renderer by lazy {
-        // Lazy so we can allow builders to set their own loggers
         DefaultEglRenderer(logger)
     }
 
@@ -159,7 +160,8 @@ open class SurfaceRenderView @JvmOverloads constructor(
             val width = min(width, drawnFrameWidth)
             val height = min(height, drawnFrameHeight)
 
-            logger.debug(TAG, "Updating surface size frame size: ${rotatedFrameWidth}x$rotatedFrameHeight, requested surface size: ${width}x$height, old surface size: ${surfaceWidth}x$surfaceHeight")
+            logger.debug(TAG, "Updating surface size frame size: ${rotatedFrameWidth}x$rotatedFrameHeight, " +
+                    "requested surface size: ${width}x$height, old surface size: ${surfaceWidth}x$surfaceHeight")
             if (width != surfaceWidth || height != surfaceHeight) {
                 surfaceWidth = width
                 surfaceHeight = height

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
@@ -127,18 +127,17 @@ open class SurfaceRenderView @JvmOverloads constructor(
                 rotatedFrameHeight != frame.getRotatedHeight() ||
                 frameRotation != frame.rotation
         ) {
-            logger.info(TAG, "Video frame rotated size changed to ${rotatedFrameWidth}x$rotatedFrameHeight")
-
             rotatedFrameWidth = frame.getRotatedWidth()
             rotatedFrameHeight = frame.getRotatedHeight()
             frameRotation = frame.rotation
+
+            logger.info(TAG, "Video frame rotated size changed to ${rotatedFrameWidth}x$rotatedFrameHeight with rotation $frameRotation")
 
             CoroutineScope(Dispatchers.Main).launch {
                 updateSurfaceSize()
                 requestLayout()
             }
         }
-
         renderer.onVideoFrameReceived(frame)
     }
 
@@ -160,7 +159,7 @@ open class SurfaceRenderView @JvmOverloads constructor(
             val width = min(width, drawnFrameWidth)
             val height = min(height, drawnFrameHeight)
 
-            logger.debug(TAG, "Updating surface size frame size: ${rotatedFrameWidth}x$rotatedFrameHeight, " +
+            logger.info(TAG, "Updating surface size frame size: ${rotatedFrameWidth}x$rotatedFrameHeight, " +
                     "requested surface size: ${width}x$height, old surface size: ${surfaceWidth}x$surfaceHeight")
             if (width != surfaceWidth || height != surfaceHeight) {
                 surfaceWidth = width

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
@@ -12,6 +12,7 @@ import android.view.SurfaceHolder
 import android.view.SurfaceView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRotation
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.VideoLayoutMeasure
 import com.amazonaws.services.chime.sdk.meetings.internal.video.gl.DefaultEglRenderer
 import kotlin.math.min
@@ -46,6 +47,12 @@ open class SurfaceRenderView @JvmOverloads constructor(
     var mirror: Boolean = false
         set(value) {
             renderer.mirror = value
+            field = value
+        }
+
+    var scalingType: VideoScalingType = VideoScalingType.AspectFill
+        set(value) {
+            videoLayoutMeasure.scalingType = value
             field = value
         }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
@@ -24,7 +24,10 @@ import kotlinx.coroutines.launch
 
 /**
  * [SurfaceRenderView] is an implementation of [EglVideoRenderView] which uses EGL14 and OpenGLES2
- * to draw any incoming video buffer types to the surface provided by the inherited [SurfaceView]
+ * to draw any incoming video buffer types to the surface provided by the inherited [SurfaceView].
+ *
+ * Note that since most [SurfaceRenderView] objects will not be constructed in code, builders must
+ * pass in the [Logger] directly before initialization by setting [logger]
  */
 open class SurfaceRenderView @JvmOverloads constructor(
     context: Context,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
@@ -24,6 +24,9 @@ import kotlinx.coroutines.launch
 /**
  * [TextureRenderView] is an implementation of [EglVideoRenderView] which uses EGL14 and OpenGLES2
  * to draw any incoming video buffer types to the surface provided by the inherited [TextureView]
+ *
+ * Note that since most [TextureRenderView] objects will not be constructed in code, builders must
+ * pass in the [Logger] directly before initialization by setting [logger]
  */
 open class TextureRenderView @JvmOverloads constructor(
     context: Context,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
@@ -12,6 +12,7 @@ import android.util.AttributeSet
 import android.view.TextureView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRotation
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.VideoLayoutMeasure
 import com.amazonaws.services.chime.sdk.meetings.internal.video.gl.DefaultEglRenderer
 import kotlinx.coroutines.CoroutineScope
@@ -42,6 +43,12 @@ open class TextureRenderView @JvmOverloads constructor(
     var mirror: Boolean = false
         set(value) {
             renderer.mirror = value
+            field = value
+        }
+
+    var scalingType: VideoScalingType = VideoScalingType.AspectFill
+        set(value) {
+            videoLayoutMeasure.scalingType = value
             field = value
         }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
@@ -15,6 +15,8 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRotation
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.VideoLayoutMeasure
 import com.amazonaws.services.chime.sdk.meetings.internal.video.gl.DefaultEglRenderer
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.ConsoleLogger
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -38,16 +40,26 @@ open class TextureRenderView @JvmOverloads constructor(
     // (Required for View implementations) which determines the actual size of the view
     private val videoLayoutMeasure: VideoLayoutMeasure = VideoLayoutMeasure()
 
-    private val renderer = DefaultEglRenderer()
+    private val renderer by lazy {
+        // Lazy so we can allow builders to set their own loggers
+        DefaultEglRenderer(logger)
+    }
+
+    // Public so it can be set, since most users will not be using constructor directly
+    var logger: Logger = ConsoleLogger()
+
+    private val TAG = "TextureRenderView"
 
     var mirror: Boolean = false
         set(value) {
+            logger.debug(TAG, "Setting mirror from $field to $value")
             renderer.mirror = value
             field = value
         }
 
     var scalingType: VideoScalingType = VideoScalingType.AspectFill
         set(value) {
+            logger.debug(TAG, "Setting scaling type from $field to $value")
             videoLayoutMeasure.scalingType = value
             field = value
         }
@@ -60,16 +72,19 @@ open class TextureRenderView @JvmOverloads constructor(
         rotatedFrameWidth = 0
         rotatedFrameHeight = 0
 
+        logger.info(TAG, "Initializing render view")
         renderer.init(eglCoreFactory)
     }
 
     override fun release() {
+        logger.info(TAG, "Releasing render view")
         renderer.release()
     }
 
     override fun onMeasure(widthSpec: Int, heightSpec: Int) {
         val size: Point =
                 videoLayoutMeasure.measure(widthSpec, heightSpec, rotatedFrameWidth, rotatedFrameHeight)
+        logger.debug(TAG, "Setting measured dimensions ${size.x}x${size.y}")
         setMeasuredDimension(size.x, size.y)
     }
 
@@ -89,6 +104,7 @@ open class TextureRenderView @JvmOverloads constructor(
                 rotatedFrameHeight != frame.getRotatedHeight() ||
                 frameRotation != frame.rotation
         ) {
+            logger.info(TAG, "Video frame rotated size changed to ${rotatedFrameWidth}x$rotatedFrameHeight")
             rotatedFrameWidth = frame.getRotatedWidth()
             rotatedFrameHeight = frame.getRotatedHeight()
             frameRotation = frame.rotation
@@ -110,6 +126,7 @@ open class TextureRenderView @JvmOverloads constructor(
     }
 
     override fun onSurfaceTextureDestroyed(surface: SurfaceTexture?): Boolean {
+        logger.info(TAG, "Surface destroyed, releasing EGL surface")
         renderer.releaseEglSurface()
         return true
     }
@@ -117,6 +134,7 @@ open class TextureRenderView @JvmOverloads constructor(
     override fun onSurfaceTextureAvailable(surface: SurfaceTexture?, width: Int, height: Int) {
         // Create the EGL surface and set it as current
         surface?.let {
+            logger.info(TAG, "Surface created, creating EGL surface with resource")
             renderer.createEglSurface(it)
         }
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/VideoLayoutMeasure.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/VideoLayoutMeasure.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import android.graphics.Point
 import android.view.View
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import kotlin.math.roundToInt
 
 /**
@@ -14,10 +15,7 @@ import kotlin.math.roundToInt
  * layout requirements, scaling type, and video aspect ratio.
  */
 class VideoLayoutMeasure {
-    enum class ScalingType { SCALE_ASPECT_FIT, SCALE_ASPECT_FILL }
-
-    // Default value, currently not exposed
-    val scalingType = ScalingType.SCALE_ASPECT_FILL
+    var scalingType = VideoScalingType.AspectFill
 
     /**
      * Measure desired layout size based off provided parameters
@@ -66,10 +64,10 @@ class VideoLayoutMeasure {
      * Each scaling type has a one-to-one correspondence to a numeric minimum fraction of the video
      * that must remain visible.
      */
-    private fun convertScalingTypeToVisibleFraction(scalingType: ScalingType): Float {
+    private fun convertScalingTypeToVisibleFraction(scalingType: VideoScalingType): Float {
         return when (scalingType) {
-            ScalingType.SCALE_ASPECT_FIT -> 1.0f
-            ScalingType.SCALE_ASPECT_FILL -> 0.0f
+            VideoScalingType.AspectFit -> 1.0f
+            VideoScalingType.AspectFill -> 0.0f
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/VideoLayoutMeasure.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/VideoLayoutMeasure.kt
@@ -43,7 +43,7 @@ class VideoLayoutMeasure {
         val frameAspect = frameWidth / frameHeight.toFloat()
         val layoutSize: Point =
                 getDisplaySize(
-                        convertScalingTypeToVisibleFraction(scalingType),
+                        scalingType.visibleFraction,
                         frameAspect,
                         maxWidth,
                         maxHeight
@@ -58,17 +58,6 @@ class VideoLayoutMeasure {
             layoutSize.y = maxHeight
         }
         return layoutSize
-    }
-
-    /**
-     * Each scaling type has a one-to-one correspondence to a numeric minimum fraction of the video
-     * that must remain visible.
-     */
-    private fun convertScalingTypeToVisibleFraction(scalingType: VideoScalingType): Float {
-        return when (scalingType) {
-            VideoScalingType.AspectFit -> 1.0f
-            VideoScalingType.AspectFill -> 0.0f
-        }
     }
 
     /**

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -14,6 +14,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.CameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.amazonaws.services.chime.sdkdemo.R
 import com.amazonaws.services.chime.sdkdemo.data.VideoCollectionTile
 import com.amazonaws.services.chime.sdkdemo.utils.inflate
@@ -26,14 +27,14 @@ class VideoAdapter(
     private val videoCollectionTiles: Collection<VideoCollectionTile>,
     private val audioVideoFacade: AudioVideoFacade,
     private val cameraCaptureSource: CameraCaptureSource?,
-    private val context: Context?
-) :
-    RecyclerView.Adapter<VideoHolder>() {
+    private val context: Context?,
+    private val logger: Logger
+) : RecyclerView.Adapter<VideoHolder>() {
     private val VIDEO_ASPECT_RATIO_16_9 = 0.5625
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoHolder {
         val inflatedView = parent.inflate(R.layout.item_video, false)
-        return VideoHolder(inflatedView, audioVideoFacade, cameraCaptureSource)
+        return VideoHolder(inflatedView, audioVideoFacade, logger, cameraCaptureSource)
     }
 
     override fun getItemCount(): Int {
@@ -57,10 +58,15 @@ class VideoAdapter(
 class VideoHolder(
     private val view: View,
     private val audioVideo: AudioVideoFacade,
+    private val logger: Logger,
     private val cameraCaptureSource: CameraCaptureSource?
 ) : RecyclerView.ViewHolder(view) {
 
     val tileContainer: RelativeLayout = view.findViewById(R.id.tile_container)
+
+    init {
+        view.video_surface.logger = logger
+    }
 
     fun bindVideoTile(videoCollectionTile: VideoCollectionTile) {
         audioVideo.bindVideoView(view.video_surface, videoCollectionTile.videoTileState.tileId)

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -155,6 +155,7 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
             it.layoutParams.width = width
             it.layoutParams.height = height
 
+            it.logger = logger
             it.init((activity as MeetingActivity).getEglCoreFactory())
             cameraCaptureSource.addVideoSink(it)
             videoPreview = it

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -226,7 +226,8 @@ class MeetingFragment : Fragment(),
             meetingModel.currentVideoTiles.values,
             audioVideo,
             cameraCaptureSource,
-            context
+            context,
+            logger
         )
         recyclerViewVideoCollection.adapter = videoTileAdapter
         recyclerViewVideoCollection.visibility = View.GONE
@@ -239,7 +240,8 @@ class MeetingFragment : Fragment(),
                 meetingModel.currentScreenTiles.values,
                 audioVideo,
                 null,
-                context
+                context,
+                logger
             )
         recyclerViewScreenShareCollection.adapter = screenTileAdapter
         recyclerViewScreenShareCollection.visibility = View.GONE


### PR DESCRIPTION
### Issue #, if available:
None
### Description of changes:
Originally did not make this public because with demo it was hard to test correctness (since our layouts don't center the view, among other things).  Including it now to unblock customer and smoke test.

### Testing done:
Smoke tested switching to ASPECT_RATIO_FIT.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [ ] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
