### PR TITLE
Fix EGL surface lifecycle management in renderer

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -79,13 +79,15 @@ class DefaultVideoTileController(
             // Ignore any frames which come to an already paused tile
             if (tile.state.pauseState == VideoPauseState.Unpaused) {
                 frame?.run { tile.onVideoFrameReceived(frame) }
+            } else {
+                logger.verbose(TAG, "Ignoring video frame received on paused tile")
             }
         } else {
             if (frame != null || pauseState != VideoPauseState.Unpaused) {
                 run {
                     logger.info(
                         TAG,
-                        "Adding video tile with videoId = $videoId & attendeeId = $attendeeId"
+                        "Adding video tile with videoId = $videoId, attendeeId = $attendeeId, pauseState = $pauseState"
                     )
                     onAddVideoTile(videoId, attendeeId, pauseState, videoStreamContentWidth, videoStreamContentHeight)
                 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
@@ -208,13 +208,6 @@ class DefaultSurfaceTextureCaptureSource(
         surfaceTexture.release()
         surface.release()
 
-        EGL14.eglMakeCurrent(
-            eglCore.eglDisplay,
-            EGL14.EGL_NO_SURFACE,
-            EGL14.EGL_NO_SURFACE,
-            EGL14.EGL_NO_CONTEXT
-        )
-        EGL14.eglDestroySurface(eglCore.eglDisplay, eglCore.eglSurface)
         eglCore.release()
 
         timestampAligner.dispose()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/DefaultEglCore.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/DefaultEglCore.kt
@@ -57,6 +57,11 @@ class DefaultEglCore(
     }
 
     override fun release() {
+        if (eglSurface != EGL14.EGL_NO_SURFACE) {
+            EGL14.eglDestroySurface(eglDisplay, eglSurface)
+            eglSurface = EGL14.EGL_NO_SURFACE
+        }
+
         if (eglDisplay != EGL14.EGL_NO_DISPLAY) {
             // Android is unusual in that it uses a reference-counted EGLDisplay. So for
             // every eglInitialize() we need an eglTerminate().

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -153,13 +153,14 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
     }
 
     private fun renderPendingFrame() {
-        // View could be updating and surface may not be valid
         if (eglCore == null) {
+            // May have been called after release
             logger.warn(TAG, "Skipping frame render, no EGL core")
         }
 
         if (eglCore?.eglSurface == EGL14.EGL_NO_SURFACE) {
-            logger.warn(TAG, "Skipping frame render, no EGL surface")
+            // Verbose since this happens normally when running in background or when view is updating
+            logger.verbose(TAG, "Skipping frame render, no EGL surface")
             return
         }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -87,8 +87,8 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
 
             // Protect this within lock since onVideoFrameReceived can
             // occur from any frame
-            this.renderHandler?.looper?.quitSafely()
-            this.renderHandler = null
+            validRenderHandler.looper.quitSafely()
+            renderHandler = null
         }
     }
 
@@ -123,6 +123,7 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
     }
 
     override fun releaseEglSurface() {
+        surface = null // Can occur outside of init/release cycle
         val validRenderHandler = this.renderHandler ?: return
         runBlocking(validRenderHandler.asCoroutineDispatcher().immediate) {
             logger.info(TAG, "Releasing EGL surface")
@@ -135,7 +136,6 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
             )
             EGL14.eglDestroySurface(eglCore?.eglDisplay, eglCore?.eglSurface)
             eglCore?.eglSurface = EGL14.EGL_NO_SURFACE
-            surface = null
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -156,6 +156,7 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
         if (eglCore == null) {
             // May have been called after release
             logger.warn(TAG, "Skipping frame render, no EGL core")
+            return
         }
 
         if (eglCore?.eglSurface == EGL14.EGL_NO_SURFACE) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -146,13 +146,20 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
                 pendingFrame = frame
                 pendingFrame?.retain()
                 renderHandler?.post(::renderPendingFrame)
+            } else {
+                logger.warn(TAG, "Skipping frame render request, no render handler thread")
             }
         }
     }
 
     private fun renderPendingFrame() {
         // View could be updating and surface may not be valid
+        if (eglCore == null) {
+            logger.warn(TAG, "Skipping frame render, no EGL core")
+        }
+
         if (eglCore?.eglSurface == EGL14.EGL_NO_SURFACE) {
+            logger.warn(TAG, "Skipping frame render, no EGL surface")
             return
         }
 
@@ -160,6 +167,7 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
         var frame: VideoFrame
         synchronized(pendingFrameLock) {
             if (pendingFrame == null) {
+                logger.info(TAG, "Skipping frame render, no pending frame to render")
                 return
             }
             frame = pendingFrame as VideoFrame


### PR DESCRIPTION
### Issue #, if available:
None
### Description of changes:
We were not properly handling the lifecycle of EGLSurface objects in the renderer (we do not reuse tiles in the demo).
Added some (verbose level, for the most part) logs to help debug issues like this in the future.

### Testing done:
Smoke tested using demo client.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
