### PR TITLE
Put hardware scaling on renderer behind bool flag as before

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
@@ -53,6 +53,9 @@ open class TextureRenderView @JvmOverloads constructor(
 
     private val TAG = "TextureRenderView"
 
+    /**
+     * If true, rendered frames will be mirrored across the vertical axis
+     */
     var mirror: Boolean = false
         set(value) {
             logger.debug(TAG, "Setting mirror from $field to $value")
@@ -60,6 +63,9 @@ open class TextureRenderView @JvmOverloads constructor(
             field = value
         }
 
+    /**
+     * [VideoScalingType] used to render on this view.  May impact cropping.
+     */
     var scalingType: VideoScalingType = VideoScalingType.AspectFill
         set(value) {
             logger.debug(TAG, "Setting scaling type from $field to $value")


### PR DESCRIPTION
### Issue #, if available:
None
### Description of changes:
Originally this was basically set to true as default (similar code (https://chromium.googlesource.com/external/webrtc/+/b1e6d5efa67edda6b06377b1b9cb50d295514a3d%5E%21/#F0) noted that it may be 'buggy', but i though maybe that those would be resolved by now (and that QA would catch anything weird.  However one of my devices (samsung galaxy s9), would return old values when querying the surface for width/height until the first swap buffers, leading to cropping if the resolution was changing.  Therefore for now I am leaving the option in but false (same as before).

WebRTC authors tried using the `onSurfaceChanged` callback once (https://webrtc.googlesource.com/src/+/d1aaaaa125cea9968d101721a109ab9918a871f4) and then said 'This logic doesn't really work. Application should mask the view while the surface size is being changed.' implying that this could be useful only in self video where we know the resolution won't change.

### Testing done:
Smoke tested using two devices.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
