### PR TITLE
Fix camera start when switching between internal and external APIs without stopping

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -97,11 +97,15 @@ class DefaultVideoClientController(
     override fun startLocalVideo(source: VideoSource) {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
+        if (isUsingInternalCaptureSource) {
+            cameraCaptureSource.stop()
+            isUsingInternalCaptureSource = false
+        }
+
         videoSourceAdapter.source = source
         logger.info(TAG, "Setting external video source in media client to custom source")
         videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
         videoClient?.setSending(true)
-        isUsingInternalCaptureSource = false
     }
 
     override fun stopLocalVideo() {

--- a/app/src/main/res/layout/fragment_device_management.xml
+++ b/app/src/main/res/layout/fragment_device_management.xml
@@ -43,6 +43,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
+                android:contentDescription="@string/audio_device_spinner"
                 android:paddingLeft="32dp"
                 android:paddingRight="32dp" />
 
@@ -60,6 +61,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
+                android:contentDescription="@string/video_device_spinner"
                 android:paddingLeft="32dp"
                 android:paddingRight="32dp" />
 
@@ -77,6 +79,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
+                android:contentDescription="@string/video_format_spinner"
                 android:paddingLeft="32dp"
                 android:paddingRight="32dp" />
 
@@ -93,6 +96,7 @@
                 android:id="@+id/videoPreview"
                 android:layout_width="match_parent"
                 android:layout_height="10dp"
+                android:contentDescription="@string/video_preview_view"
                 android:visibility="visible" />
 
             <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,13 @@
     <string name="device_management_title">Select devices</string>
     <string name="device_selection_layout">Device Selection Layout</string>
     <string name="audio_device_title">Audio Device</string>
+    <string name="audio_device_spinner">Audio Device Spinner</string>
     <string name="video_device_title">Video Device</string>
+    <string name="video_device_spinner">Video Device Spinner</string>
     <string name="video_format_title">Video Format</string>
+    <string name="video_format_spinner">Video Format Spinner</string>
     <string name="video_preview_title">Video Preview</string>
+    <string name="video_preview_view">Video Preview View</string>
     <string name="meeting_join">Join</string>
     <string name="preview_meeting_info">Ready to join meeting %1$s as %2$s.</string>
 


### PR DESCRIPTION
### Issue #, if available:
None
### Description of changes:
Basically we need to turn off previous capture if switching between APIs.  On android the new capturer will actually override the old one so this doesn't actually have any impact, but it is a good practice.

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [ ] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
