### PR TITLE
Implement video tile pagination with active speaker-policy in demo app, and add documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Added video pagination feature in the Android demo app. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
 * Added active speaker-based video tile feature in the Android demo app. Video tiles of active speakers will be promoted to the top of the list automatically.
 
+### Fixed
+* Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.
+* Fixed a demo app issue that `mirror` property was not reset when `VideoHolder` is recycled.
+
 ## [0.8.1] - 2020-11-20
 
 ## [0.8.0] - 2020-11-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+* Added video pagination feature in the Android demo app. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
+* Added active speaker-based video tile feature in the Android demo app. Video tiles of active speakers will be promoted to the top of the list automatically.
+
 ## [0.8.1] - 2020-11-20
 
 ## [0.8.0] - 2020-11-17

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ And review the following guides:
 
 * [API Overview](guides/api_overview.md)
 * [Getting Started](guides/getting_started.md)
+* [Custom Video Sources, Processors, and Sinks](guides/custom_video.md)
+* [Video Pagination with Active Speaker-Based Policy](guides/video_pagination.md)
 
 ## Setup
 
@@ -87,7 +89,7 @@ To run the demo application, follow these steps.
 
 ### 1. Deploy serverless demo
 
-Deploy the serverless demo from [amazon-chime-sdk-js](https://github.com/aws/amazon-chime-sdk-js), which returns `https://xxxxx.xxxxx.xxx.com/Prod/
+Deploy the serverless demo from [amazon-chime-sdk-js](https://github.com/aws/amazon-chime-sdk-js), which returns `https://xxxxx.xxxxx.xxx.com/Prod/`
 
 Provide `https://xxxxx.xxxxx.xxx.com/Prod/` for mobile demo app.
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -25,7 +25,7 @@ import kotlinx.android.synthetic.main.item_video.view.video_surface
 
 class VideoAdapter(
     private val videoCollectionTiles: Collection<VideoCollectionTile>,
-    private val userPausedVideoTileIds: MutableSet<Int>?,
+    private val userPausedVideoTileIds: MutableSet<Int>,
     private val audioVideoFacade: AudioVideoFacade,
     private val cameraCaptureSource: CameraCaptureSource?,
     private val context: Context?,
@@ -59,7 +59,7 @@ class VideoAdapter(
 class VideoHolder(
     private val view: View,
     private val audioVideo: AudioVideoFacade,
-    private val userPausedVideoTileIds: MutableSet<Int>?,
+    private val userPausedVideoTileIds: MutableSet<Int>,
     private val logger: Logger,
     private val cameraCaptureSource: CameraCaptureSource?
 ) : RecyclerView.ViewHolder(view) {
@@ -112,11 +112,11 @@ class VideoHolder(
                 val tileId = videoCollectionTile.videoTileState.tileId
                 if (videoCollectionTile.videoTileState.pauseState == VideoPauseState.Unpaused) {
                     audioVideo.pauseRemoteVideoTile(tileId)
-                    userPausedVideoTileIds?.add(tileId)
+                    userPausedVideoTileIds.add(tileId)
                     view.on_tile_button.setImageResource(R.drawable.ic_resume_video)
                 } else {
                     audioVideo.resumeRemoteVideoTile(tileId)
-                    userPausedVideoTileIds?.remove(tileId)
+                    userPausedVideoTileIds.remove(tileId)
                     view.on_tile_button.setImageResource(R.drawable.ic_pause_video)
                 }
             }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -25,6 +25,7 @@ import kotlinx.android.synthetic.main.item_video.view.video_surface
 
 class VideoAdapter(
     private val videoCollectionTiles: Collection<VideoCollectionTile>,
+    private val userPausedVideoTileIds: MutableSet<Int>?,
     private val audioVideoFacade: AudioVideoFacade,
     private val cameraCaptureSource: CameraCaptureSource?,
     private val context: Context?,
@@ -34,7 +35,7 @@ class VideoAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoHolder {
         val inflatedView = parent.inflate(R.layout.item_video, false)
-        return VideoHolder(inflatedView, audioVideoFacade, logger, cameraCaptureSource)
+        return VideoHolder(inflatedView, audioVideoFacade, userPausedVideoTileIds, logger, cameraCaptureSource)
     }
 
     override fun getItemCount(): Int {
@@ -58,6 +59,7 @@ class VideoAdapter(
 class VideoHolder(
     private val view: View,
     private val audioVideo: AudioVideoFacade,
+    private val userPausedVideoTileIds: MutableSet<Int>?,
     private val logger: Logger,
     private val cameraCaptureSource: CameraCaptureSource?
 ) : RecyclerView.ViewHolder(view) {
@@ -70,6 +72,10 @@ class VideoHolder(
 
     fun bindVideoTile(videoCollectionTile: VideoCollectionTile) {
         audioVideo.bindVideoView(view.video_surface, videoCollectionTile.videoTileState.tileId)
+        // Save the bound VideoRenderView in order to explicitly control the visibility of SurfaceView.
+        // This is to bypass the issue where we cannot hide a SurfaceView that overlaps with another one.
+        videoCollectionTile.videoRenderView = view.video_surface
+
         if (videoCollectionTile.videoTileState.isContent) {
             view.video_surface.contentDescription = "ScreenTile"
         } else {
@@ -92,6 +98,7 @@ class VideoHolder(
                 updateLocalVideoMirror()
             }
         } else {
+            view.video_surface.mirror = false
             view.attendee_name.text = videoCollectionTile.attendeeName
             view.attendee_name.visibility = View.VISIBLE
             view.on_tile_button.visibility = View.VISIBLE
@@ -102,11 +109,14 @@ class VideoHolder(
             }
 
             view.on_tile_button.setOnClickListener {
+                val tileId = videoCollectionTile.videoTileState.tileId
                 if (videoCollectionTile.videoTileState.pauseState == VideoPauseState.Unpaused) {
-                    audioVideo.pauseRemoteVideoTile(videoCollectionTile.videoTileState.tileId)
+                    audioVideo.pauseRemoteVideoTile(tileId)
+                    userPausedVideoTileIds?.add(tileId)
                     view.on_tile_button.setImageResource(R.drawable.ic_resume_video)
                 } else {
-                    audioVideo.resumeRemoteVideoTile(videoCollectionTile.videoTileState.tileId)
+                    audioVideo.resumeRemoteVideoTile(tileId)
+                    userPausedVideoTileIds?.remove(tileId)
                     view.on_tile_button.setImageResource(R.drawable.ic_pause_video)
                 }
             }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/data/VideoCollectionTile.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/data/VideoCollectionTile.kt
@@ -4,9 +4,11 @@
  */
 package com.amazonaws.services.chime.sdkdemo.data
 
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileState
 
 data class VideoCollectionTile(
     val attendeeName: String,
-    val videoTileState: VideoTileState
+    val videoTileState: VideoTileState,
+    var videoRenderView: DefaultVideoRenderView?
 )

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -6,19 +6,28 @@
 package com.amazonaws.services.chime.sdkdemo.model
 
 import androidx.lifecycle.ViewModel
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.AttendeeInfo
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdkdemo.data.Message
 import com.amazonaws.services.chime.sdkdemo.data.MetricData
 import com.amazonaws.services.chime.sdkdemo.data.RosterAttendee
 import com.amazonaws.services.chime.sdkdemo.data.VideoCollectionTile
+import kotlin.math.ceil
+import kotlin.math.min
 
 // This will be used for keeping state after rotation
 class MeetingModel : ViewModel() {
+    val localTileId = 0
+    private val videoTileCountPerPage = 4
+
     val currentMetrics = mutableMapOf<String, MetricData>()
     val currentRoster = mutableMapOf<String, RosterAttendee>()
-    val currentVideoTiles = mutableMapOf<Int, VideoCollectionTile>()
-    val currentScreenTiles = mutableMapOf<Int, VideoCollectionTile>()
-    val nextVideoTiles = LinkedHashMap<Int, VideoCollectionTile>()
+    var localVideoTileState: VideoCollectionTile? = null
+    val remoteVideoTileStates = mutableListOf<VideoCollectionTile>()
+    val videoStatesInCurrentPage = mutableListOf<VideoCollectionTile>()
+    val userPausedVideoTileIds = mutableSetOf<Int>()
+    val currentScreenTiles = mutableListOf<VideoCollectionTile>()
+    var currentVideoPageIndex = 0
     var currentMediaDevices = listOf<MediaDevice>()
     var currentMessages = mutableListOf<Message>()
 
@@ -32,4 +41,47 @@ class MeetingModel : ViewModel() {
     var isLocalVideoStarted = false
     var isUsingGpuVideoProcessor = false
     var isUsingCpuVideoProcessor = false
+
+    fun updateVideoStatesInCurrentPage() {
+        videoStatesInCurrentPage.clear()
+
+        if (localVideoTileState != null) {
+            videoStatesInCurrentPage.add(localVideoTileState!!)
+        }
+
+        val remoteVideoTileCountPerPage = if (localVideoTileState == null) videoTileCountPerPage else (videoTileCountPerPage - 1)
+        val remoteVideoStartIndex = currentVideoPageIndex * remoteVideoTileCountPerPage
+        val remoteVideoEndIndex = min(remoteVideoTileStates.size, remoteVideoStartIndex + remoteVideoTileCountPerPage) - 1
+        if (remoteVideoStartIndex <= remoteVideoEndIndex) {
+            videoStatesInCurrentPage.addAll(remoteVideoTileStates.slice(remoteVideoStartIndex..remoteVideoEndIndex))
+        }
+    }
+
+    fun updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: Array<AttendeeInfo>) {
+        val activeSpeakerIds = activeSpeakers.map { it.attendeeId }.toHashSet()
+        remoteVideoTileStates.sortWith(Comparator<VideoCollectionTile> { lhs, rhs ->
+            val lhsIsActiveSpeaker = activeSpeakerIds.contains(lhs.videoTileState.attendeeId)
+            val rhsIsActiveSpeaker = activeSpeakerIds.contains(rhs.videoTileState.attendeeId)
+
+            when {
+                lhsIsActiveSpeaker && !rhsIsActiveSpeaker -> -1
+                !lhsIsActiveSpeaker && rhsIsActiveSpeaker -> 1
+                else -> 0
+            }
+        })
+    }
+
+    fun remoteVideoCountInCurrentPage(): Int {
+        return videoStatesInCurrentPage.filter { !it.videoTileState.isLocalTile }.size
+    }
+
+    fun canGoToPrevVideoPage(): Boolean {
+        return currentVideoPageIndex > 0
+    }
+
+    fun canGoToNextVideoPage(): Boolean {
+        val remoteVideoTileCountPerPage = if (localVideoTileState == null) videoTileCountPerPage else (videoTileCountPerPage - 1)
+        val maxVideoPageIndex = ceil(remoteVideoTileStates.size.toDouble() / remoteVideoTileCountPerPage).toInt() - 1
+        return currentVideoPageIndex < maxVideoPageIndex
+    }
 }

--- a/app/src/main/res/layout/fragment_meeting.xml
+++ b/app/src/main/res/layout/fragment_meeting.xml
@@ -43,6 +43,53 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
+        <LinearLayout
+            android:id="@+id/subViewVideo"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewVideoCollection"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:contentDescription="@string/video_view"
+                android:visibility="visible"
+                android:layout_weight="1"/>
+
+            <LinearLayout
+                android:id="@+id/videoPaginationControlView"
+                style="?android:attr/buttonBarStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:weightSum="1.0">
+
+                <Button
+                    android:id="@+id/prevVideoPageButton"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:enabled="false"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.5"
+                    android:insetLeft="10dp"
+                    android:insetRight="10dp"
+                    android:text="@string/prev_video_page" />
+
+                <Button
+                    android:id="@+id/nextVideoPageButton"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:enabled="false"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="0.5"
+                    android:insetLeft="10dp"
+                    android:insetRight="10dp"
+                    android:text="@string/next_video_page" />
+            </LinearLayout>
+
+        </LinearLayout>
+
         <TextView
             android:id="@+id/noVideoOrScreenShareAvailable"
             android:layout_width="0dp"
@@ -59,17 +106,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:visibility="visible"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerViewVideoCollection"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:contentDescription="@string/video_view"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,8 @@
     <string name="no_videos_available">No videos available</string>
     <string name="enable_voice_focus">Turn on Voice Focus</string>
     <string name="disable_voice_focus">Turn off Voice Focus</string>
+    <string name="next_video_page">Next Page &gt;&gt;</string>
+    <string name="prev_video_page">&lt;&lt; Prev Page</string>
 
     <!-- device selection -->
     <string name="device_management_title">Select devices</string>

--- a/guides/api_overview.md
+++ b/guides/api_overview.md
@@ -231,6 +231,40 @@ To pause a remote attendee's video tile, call meetingSession.audioVideo.[pauseRe
 
 To resume a remote attendee's video tile, call meetingSession.audioVideo.[resumeRemoteVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-controller-facade/resume-remote-video-tile.html).
 
+### 8g. In-depth look and comparison between video APIs
+
+#### Start/Stop Local Video
+
+As the names suggest, `startLocalVideo()` and `stopLocalVideo()` will start and stop sending local attendee’s video respectively. `startLocalVideo()` will first check if the video client is initialized and the application has permission to access device camera, then it will update the service type of video client and turn on its *sending* mode, so that local video can be sent to server and forwarded to other peers.
+
+You should call `startLocalVideo()` when you want to start sending local video to others, and call `stopLocalVideo()` when you want to stop sending local video to others (e.g. when the app is in background). Stopping local video will save uplink bandwidth and computation resource for encoding video.
+
+#### Start/Stop Remote Video
+
+Similar to `startLocalVideo()` and `stopLocalVideo()`, `startRemoteVideo()` and `stopRemoteVideo()` will start and stop receiving remote attendees’ videos by setting the service type of video client and turning on/off its *receiving* mode.
+
+Note that when the application calls `stopRemoteVideo()`, all the resources in the render pipeline will be released, and it takes some time to re-initialize all these resources. You should call `stopRemoteVideo()` only when you want to stop receiving remote videos for a *considerable amount of time*. If you want to temporarily stop remote videos, consider iterating through remote videos and call `pauseRemoteVideoTile(tileId)` instead.
+
+#### Pause/Resume Remote Video Tile
+
+You can call `pauseRemoteVideoTile(tileId)` to temporarily pause a remote video stream. When you call `pauseRemoteVideoTile(tileId)`, the video client will add the tile id to a local block list, so that server will not forward video frames from the paused stream to the client. In that case, you can save downlink bandwidth and computation resource for decoding video. You can call `pauseRemoteVideoTile(tileId)` to remove a video from the local block list and resume streaming.
+
+You should call `pauseRemoteVideoTile(tileId)` when you want to temporarily pause remote video (e.g. when user is not in the video view and remote videos are not actively being showed), or when you want to stop *some* remote videos (e.g. in the video pagination example in the following sections, where we want to render videos on the current page, but stop invisible videos on other pages).
+
+#### Bind/Unbind Video View
+
+To display video, you need to bind a video tile to a video view. You can call `bindVideoView(videoView, tileId)` to bind a video tile to a view, and call `unbindVideoView(tileId)` to unbind a video tile from a view.
+
+Note that bind/unbind only impacts *UI layer*, which means these APIs only control when and where the video stream will be displayed in your application UI. If you unbind a video tile, the server will keep sending video frames to the client, and the client will continue consuming resources to receive and decode video. If you want to reduce unnecessary data consumption and CPU usage of your application by stopping remote videos, you should call `pauseRemoteVideoTile(tileId)` first.
+
+### 8h. Rendering selected remote videos
+
+You can render some of the available remote videos instead of rendering them all at the same time.
+
+To selectively render some remote videos, call meetingSession.audioVideo.[resumeRemoteVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-controller-facade/resume-remote-video-tile.html) on the videos you care about, and call meetingSession.audioVideo.[pauseRemoteVideoTile(tileId)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-controller-facade/pause-remote-video-tile.html) to pause other videos.
+
+See the [Video Pagination with Active Speaker-Based Policy](video_pagination.md) guide for more information about related APIs and sample code.
+
 ## 9. Receiving metrics (optional)
 
 You can receive events about available audio and video metrics by implementing a [MetricsObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.metric/-metrics-observer/index.html)
@@ -275,7 +309,7 @@ Amazon Voice Focus reduces the sound levels of noises that can intrude on a meet
 
 *Note:* Amazon Voice Focus doesn't eliminate those types of noises; it reduces their sound levels. To ensure privacy during a meeting, call meetingSession.audioVideo.[realtimeLocalMute()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-local-mute.html) to silence yourself.
 
-You must start the audio session before enabling/disabling Amazon Voice Focus or before checking if Amazon Voice Focus is enabled. To enable/disable Amazon Voice Focus, call call meetingSession.audioVideo.[realtimeSetVoiceFocusEnabled(enabled: Boolean)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-set-voice-focus-enabled.html). To check if Amazon Voice Focus is enabled, call [meetingSession.audioVideo.realtimeIsVoiceFocusEnabled()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-is-voice-focus-enabled.html).
+You must start the audio session before enabling/disabling Amazon Voice Focus or before checking if Amazon Voice Focus is enabled. To enable/disable Amazon Voice Focus, call call meetingSession.audioVideo.[realtimeSetVoiceFocusEnabled(enabled)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-set-voice-focus-enabled.html). To check if Amazon Voice Focus is enabled, call [meetingSession.audioVideo.realtimeIsVoiceFocusEnabled()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-is-voice-focus-enabled.html).
 
 When Amazon Voice Focus is running, a CPU usage increase is expected, but the performance impact is small on modern devices (on average, we observed around 5-7% CPU increase). If your app will be running on resource-critical devices, you should take this into consideration before enabling Amazon Voice Focus.
 
@@ -283,4 +317,4 @@ Note that if you want to share music or background sounds with others in the cal
 
 ## 12. Using a custom video source, sink or processing step (optional)
 
-Builders using the Amazon Chime SDK for video can produce, modify, and consume raw video frames transmitted or received during the call. You can allow the facade to manage its own camera capture source, provide your own custom source, or use a provided SDK capture source as the first step in a video processing pipeline which modifies frames before transmission. See the [Custom Video Sources, Processors, and Sinks](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md) guide for more information.
+Builders using the Amazon Chime SDK for video can produce, modify, and consume raw video frames transmitted or received during the call. You can allow the facade to manage its own camera capture source, provide your own custom source, or use a provided SDK capture source as the first step in a video processing pipeline which modifies frames before transmission. See the [Custom Video Sources, Processors, and Sinks](custom_video.md) guide for more information.

--- a/guides/video_pagination.md
+++ b/guides/video_pagination.md
@@ -1,0 +1,117 @@
+# Video Pagination with Active Speaker-Based Policy
+
+## Overview
+
+Amazon Chime SDK currently supports [multiple video tiles](https://docs.aws.amazon.com/chime/latest/dg/meetings-sdk.html#mtg-limits) in a meeting. However, in many cases, the application may not want to render all the available video streams, because of the following reasons:
+
+* **Hardware limitation** - On mobile devices, screen sizes are relatively small and network as well as computation resources are rather limited. If an application renders all the available videos on the same screen at the same time, it will consume a lot of network bandwidth and CPU to subscribe to video streams and decode video frames. Each video tile will be extremely small and barely visible, which results in a bad user experience.
+* **Use cases do not require multiple videos** - An application could have specific use cases that do not require multiple videos being rendered at the same time. For example, an online fitness training application may only want to show the video from the instructor and the student themselves, and ignore all the video streams from other students.
+
+In the following example, we will show you how to selectively render some of the available video streams using `pauseRemoteVideoTile(tileId)` and `pauseRemoteVideoTile(tileId)` APIs. We will implement the following features:
+
+* Remote videos will be paginated into several pages. Each page contains at most 4 remote videos.
+* User can switch between different pages.
+* User can manually pause/resume specific video tiles.
+* Video tiles from active speakers will be promoted to the top of the list automatically.
+
+## Prerequisite
+
+Amazon Chime SDK provides multiple APIs for sending, receiving, and displaying videos. Before we jump into code implementation, please read [In-depth Look and Comparison Between Video APIs](api_overview.md#8g-in-depth-look-and-comparison-between-video-apis) to understand what these video APIs do under the hood and when you want to call them.
+
+You should also have basic knowledge about how to render an ordered collection of data items and present them using customizable layouts.
+
+## Implementation - Video Pagination
+
+To implement basic video pagination feature, we need to maintain the following states in the application:
+
+```kotlin
+// How many remote videos to render at most per page
+private val remoteVideoTileCountPerPage = 4
+
+// Index of the page that the user is currently viewing
+private var currentRemoteVideoPageIndex = 0
+
+// An ordered list of VideoTileState for remote videos
+private val remoteVideoTileStates = mutableListOf<VideoTileState>()
+
+// An ordered list of VideoTileState for remote videos on the current page
+private val remoteVideoStatesOnCurrentPage = mutableListOf<VideoTileState>()
+
+// Ids of the video tiles that user paused manually
+private val userPausedVideoTileIds = mutableSetOf<Int>()
+```
+
+Given 1) the page number that the user is on; and 2) the number of remote videos per page, we can calculate the slice of `VideoTileState`s to render:
+
+```kotlin
+private fun updateRemoteVideoStatesOnCurrentPage() {
+    remoteVideoStatesOnCurrentPage.clear()
+
+    val remoteVideoStartIndex = currentRemoteVideoPageIndex * remoteVideoTileCountPerPage
+    val remoteVideoEndIndex = min(remoteVideoTileStates.size, remoteVideoStartIndex + remoteVideoTileCountPerPage) - 1
+    if (remoteVideoStartIndex <= remoteVideoEndIndex) {
+        remoteVideoStatesOnCurrentPage.addAll(remoteVideoTileStates.slice(remoteVideoStartIndex..remoteVideoEndIndex))
+    }
+}
+```
+
+Once we have the current page calculated, we can resume videos on the current page and pause rest of the videos. Note that user may also explicitly pause remote videos, and we will not resume those videos even they are on the current page.
+
+```kotlin
+private fun resumeAllRemoteVideosOnCurrentPageExceptUserPausedVideos() {
+    remoteVideoTileStates.forEach {
+        if (remoteVideoStatesOnCurrentPage.contains(it) && !userPausedVideoTileIds.contains(it.tileId)) {
+            if (it.pauseState == VideoPauseState.PausedByUserRequest) {
+                audioVideo.resumeRemoteVideoTile(it.tileId)
+            }
+        } else {
+            if (it.pauseState != VideoPauseState.PausedByUserRequest) {
+                audioVideo.pauseRemoteVideoTile(it.tileId)
+            }
+        }
+    }
+}
+
+pauseToggleButton.setOnClickListener {
+    if (videoTileState.pauseState != VideoPauseState.PausedByUserRequest) {
+        audioVideo.pauseRemoteVideoTile(videoTileState.tileId)
+        userPausedVideoTileIds.add(videoTileState.tileId)
+    } else {
+        audioVideo.resumeRemoteVideoTile(videoTileState.tileId)
+        userPausedVideoTileIds.remove(videoTileState.tileId)
+    }
+}
+```
+
+## Implementation - Active Speaker-Based Policy
+
+The application can reorder video tiles based on the active speaker policy. To implement this, when `ActiveSpeakerPolicy` detects new active speakers, we sort `remoteVideoTileStates` accordingly so that videos from active speakers are promoted to the top of the list.
+
+```kotlin
+fun updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: Array<AttendeeInfo>) {
+    val activeSpeakerIds = activeSpeakers.map { it.attendeeId }.toHashSet()
+
+    remoteVideoTileStates.sortWith(Comparator<VideoCollectionTile> { lhs, rhs ->
+        val lhsIsActiveSpeaker = activeSpeakerIds.contains(lhs.videoTileState.attendeeId)
+        val rhsIsActiveSpeaker = activeSpeakerIds.contains(rhs.videoTileState.attendeeId)
+
+        when {
+            lhsIsActiveSpeaker && !rhsIsActiveSpeaker -> -1
+            !lhsIsActiveSpeaker && rhsIsActiveSpeaker -> 1
+            else -> 0
+        }
+    })
+}
+
+override fun onActiveSpeakerDetected(attendeeInfo: Array<AttendeeInfo>) {
+    uiScope.launch {
+        updateRemoteVideoStatesBasedOnActiveSpeakers(attendeeInfo)
+
+        updateRemoteVideoStatesOnCurrentPage()
+        videoTileAdapter.notifyDataSetChanged()
+        resumeAllRemoteVideosOnCurrentPageExceptUserPausedVideos()
+
+        refreshVideoUI()
+    }
+}
+```


### PR DESCRIPTION
### Issue #, if available:
- Chime-31805
- Chime-32300

### Description of changes:
#### New major features:
- Video pagination. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
- Video tiles ordered by the active speaker status. Video tiles of active speakers will be promoted to the top of the list automatically.

#### Bug fixes
- Fixed a demo app issue that SurfaceView was not cleared up correctly when switching between Screen tab and Video tab.
- Fixed a demo app issue that `mirror` property was not reset when `VideoHolder` is recycled.

### Testing done:

#### Adhoc test cases
> Note: these tests are done with `videoTileCountPerPage` temporarily overwritten to `2`.

- Was able to view videos when # of videos <= 2
- Was able to view videos when # of videos > 2. Was able to switch pages by clicking the "Prev page" and "Next page" buttons.
- Was able to promote the video tiles of active speakers to the first page, and properly push other video tiles to the following pages.
- Was able to pause/resume video tiles by clicking the pause/resume button on the remote video tile. The pause status from user was not impacted by the new pagination logic.
- Was able to switch to the previous page automatically when remote videos were not available anymore and the current page does not have any video tile.
- Was able to unsubscribe(pause) remote videos when user switch to other tabs, and resubscribe(resume) remote videos when user switch back to the Video tab.
- The pagination UI looks fine in both portrait mode and landscape mode.
- Unit tests passed.

#### Unit test coverage
* Class coverage: 80%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:
![image-a9963795-7528-4e15-86db-054515aabb18](https://user-images.githubusercontent.com/40373084/99698579-cd46a080-2a45-11eb-86a0-cecb5442c945.jpg)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
