### PR TITLE
Refactor UI to be similar to iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Fixed
+* Fixed rotation issue in demo app.
+
+### Changed
+* Refactored video view to resemble iOS UI so that video doesn't get cropped.
+
 ## [0.8.1] - 2020-11-20
 
 ## [0.8.0] - 2020-11-17

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -91,6 +91,7 @@ class VideoHolder(
             view.video_surface.contentDescription = "${videoCollectionTile.attendeeName} VideoTile"
         }
         if (videoCollectionTile.videoTileState.isLocalTile) {
+            view.on_tile_button.setImageResource(R.drawable.ic_switch_camera)
             view.attendee_name.visibility = View.GONE
             view.on_tile_button.visibility = View.VISIBLE
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -11,7 +11,6 @@ import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.CameraCaptureSource
@@ -37,7 +36,7 @@ class VideoAdapter(
     private val VIDEO_ASPECT_RATIO_16_9 = 0.5625
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoHolder {
-        tabContentLayout = (context as MeetingActivity).findViewById<ConstraintLayout>(R.id.constraintLayout)
+        tabContentLayout = (context as MeetingActivity).findViewById(R.id.constraintLayout)
         val inflatedView = parent.inflate(R.layout.item_video, false)
         return VideoHolder(inflatedView, audioVideoFacade, logger, cameraCaptureSource)
     }
@@ -50,18 +49,15 @@ class VideoAdapter(
         val videoCollectionTile = videoCollectionTiles.elementAt(position)
         holder.bindVideoTile(videoCollectionTile)
         context?.let {
-            val videoRenderView = holder.tileContainer.getViewById(R.id.video_surface) as DefaultVideoRenderView
             if (!videoCollectionTile.videoTileState.isContent) {
                 val viewportWidth = tabContentLayout.width
                 if (isLandscapeMode(context) == true) {
-                    val containerWidth = viewportWidth / 2
-                    holder.tileContainer.layoutParams.width = containerWidth
+                    holder.tileContainer.layoutParams.width = viewportWidth / 2
                 } else {
-                    val containerHeight = (VIDEO_ASPECT_RATIO_16_9 * viewportWidth).toInt()
-                    holder.tileContainer.layoutParams.height = containerHeight
+                    holder.tileContainer.layoutParams.height = (VIDEO_ASPECT_RATIO_16_9 * viewportWidth).toInt()
                 }
             }
-
+            val videoRenderView = holder.itemView.video_surface
             videoRenderView.scalingType = VideoScalingType.AspectFit
             videoRenderView.hardwareScaling = false
         }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -8,14 +8,17 @@ package com.amazonaws.services.chime.sdkdemo.adapter
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import android.widget.RelativeLayout
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoScalingType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.CameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.amazonaws.services.chime.sdkdemo.R
+import com.amazonaws.services.chime.sdkdemo.activity.MeetingActivity
 import com.amazonaws.services.chime.sdkdemo.data.VideoCollectionTile
 import com.amazonaws.services.chime.sdkdemo.utils.inflate
 import com.amazonaws.services.chime.sdkdemo.utils.isLandscapeMode
@@ -30,9 +33,11 @@ class VideoAdapter(
     private val context: Context?,
     private val logger: Logger
 ) : RecyclerView.Adapter<VideoHolder>() {
+    private lateinit var tabContentLayout: ConstraintLayout
     private val VIDEO_ASPECT_RATIO_16_9 = 0.5625
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoHolder {
+        tabContentLayout = (context as MeetingActivity).findViewById<ConstraintLayout>(R.id.constraintLayout)
         val inflatedView = parent.inflate(R.layout.item_video, false)
         return VideoHolder(inflatedView, audioVideoFacade, logger, cameraCaptureSource)
     }
@@ -45,12 +50,20 @@ class VideoAdapter(
         val videoCollectionTile = videoCollectionTiles.elementAt(position)
         holder.bindVideoTile(videoCollectionTile)
         context?.let {
-            val displayMetrics = context.resources.displayMetrics
-            val width =
-                if (isLandscapeMode(context) == true) displayMetrics.widthPixels / 2 else displayMetrics.widthPixels
-            val height = (width * VIDEO_ASPECT_RATIO_16_9).toInt()
-            holder.tileContainer.layoutParams.height = height
-            holder.tileContainer.layoutParams.width = width
+            val videoRenderView = holder.tileContainer.getViewById(R.id.video_surface) as DefaultVideoRenderView
+            if (!videoCollectionTile.videoTileState.isContent) {
+                val viewportWidth = tabContentLayout.width
+                if (isLandscapeMode(context) == true) {
+                    val containerWidth = viewportWidth / 2
+                    holder.tileContainer.layoutParams.width = containerWidth
+                } else {
+                    val containerHeight = (VIDEO_ASPECT_RATIO_16_9 * viewportWidth).toInt()
+                    holder.tileContainer.layoutParams.height = containerHeight
+                }
+            }
+
+            videoRenderView.scalingType = VideoScalingType.AspectFit
+            videoRenderView.hardwareScaling = false
         }
     }
 }
@@ -62,7 +75,7 @@ class VideoHolder(
     private val cameraCaptureSource: CameraCaptureSource?
 ) : RecyclerView.ViewHolder(view) {
 
-    val tileContainer: RelativeLayout = view.findViewById(R.id.tile_container)
+    val tileContainer: ConstraintLayout = view.findViewById(R.id.tile_container)
 
     init {
         view.video_surface.logger = logger

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -18,6 +18,7 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -131,6 +132,7 @@ class MeetingFragment : Fragment(),
     private lateinit var messageAdapter: MessageAdapter
     private lateinit var tabLayout: TabLayout
     private lateinit var audioDeviceManager: AudioDeviceManager
+    private lateinit var tabContentLayout: ConstraintLayout
 
     companion object {
         fun newInstance(meetingId: String): MeetingFragment {
@@ -219,6 +221,7 @@ class MeetingFragment : Fragment(),
         recyclerViewRoster.visibility = View.VISIBLE
 
         // Video (camera & content)
+        tabContentLayout = view.findViewById(R.id.constraintLayout)
         recyclerViewVideoCollection =
             view.findViewById(R.id.recyclerViewVideoCollection)
         recyclerViewVideoCollection.layoutManager = createLinearLayoutManagerForOrientation()
@@ -1027,6 +1030,7 @@ class MeetingFragment : Fragment(),
             TAG,
             "Video stream content size changed to ${tileState.videoStreamContentWidth}*${tileState.videoStreamContentHeight} for tileId: ${tileState.tileId}"
         )
+        videoTileAdapter.notifyDataSetChanged()
     }
 
     override fun onMetricsReceived(metrics: Map<ObservableMetric, Any>) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -18,7 +18,6 @@ import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -132,7 +131,6 @@ class MeetingFragment : Fragment(),
     private lateinit var messageAdapter: MessageAdapter
     private lateinit var tabLayout: TabLayout
     private lateinit var audioDeviceManager: AudioDeviceManager
-    private lateinit var tabContentLayout: ConstraintLayout
 
     companion object {
         fun newInstance(meetingId: String): MeetingFragment {
@@ -221,7 +219,6 @@ class MeetingFragment : Fragment(),
         recyclerViewRoster.visibility = View.VISIBLE
 
         // Video (camera & content)
-        tabContentLayout = view.findViewById(R.id.constraintLayout)
         recyclerViewVideoCollection =
             view.findViewById(R.id.recyclerViewVideoCollection)
         recyclerViewVideoCollection.layoutManager = createLinearLayoutManagerForOrientation()

--- a/app/src/main/res/layout/item_video.xml
+++ b/app/src/main/res/layout/item_video.xml
@@ -42,7 +42,7 @@
         android:layout_alignParentBottom="true"
         android:maxLines="1"
         android:ellipsize="end"
-        android:textColor="@color/colorAttendeeName"
+        android:textColor="@color/colorWhite"
         android:textSize="12sp"
         android:visibility="invisible"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/item_video.xml
+++ b/app/src/main/res/layout/item_video.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/tile_container"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:gravity="center_horizontal"
-    android:padding="8dp">
+    android:layout_height="match_parent"
+    android:background="@color/colorBlack"
+    android:gravity="center_horizontal">
 
     <com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
         android:id="@+id/video_surface"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center" />
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <ImageButton
         android:id="@+id/on_tile_button"
@@ -19,9 +24,12 @@
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
         android:background="@null"
+        android:tint="@color/colorWhite"
         android:contentDescription="@string/switch_camera"
         android:src="@drawable/button_switch_camera"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <TextView
         android:id="@+id/attendee_name"
@@ -34,6 +42,8 @@
         android:ellipsize="end"
         android:textColor="@color/colorAttendeeName"
         android:textSize="12sp"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
-</RelativeLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_video.xml
+++ b/app/src/main/res/layout/item_video.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tile_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -19,17 +20,18 @@
 
     <ImageButton
         android:id="@+id/on_tile_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_alignParentEnd="true"
         android:layout_alignParentBottom="true"
         android:background="@null"
-        android:tint="@color/colorWhite"
         android:contentDescription="@string/switch_camera"
         android:src="@drawable/button_switch_camera"
+        android:tint="@color/colorWhite"
         android:visibility="invisible"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        android:scaleType="fitCenter"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
 
     <TextView
         android:id="@+id/attendee_name"

--- a/app/src/main/res/layout/row_message.xml
+++ b/app/src/main/res/layout/row_message.xml
@@ -33,7 +33,7 @@
         android:layout_height="wrap_content"
         android:padding="8dp"
         android:textSize="18sp"
-        android:textColor="@color/colorMessageText"
+        android:textColor="@color/colorBlack"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/senderName" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,6 +11,8 @@
     <color name="colorAccent">#D81B60</color>
     <color name="colorText">#3f4149</color>
     <color name="colorMessageText">#000000</color>
+    <color name="colorWhite">#FFFFFF</color>
+    <color name="colorBlack">#000000</color>
 
     <!-- For roster view -->
     <color name="colorBackground">#E9E9E9</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,11 +10,9 @@
     <color name="colorPrimaryDark">#00574B</color>
     <color name="colorAccent">#D81B60</color>
     <color name="colorText">#3f4149</color>
-    <color name="colorMessageText">#000000</color>
     <color name="colorWhite">#FFFFFF</color>
     <color name="colorBlack">#000000</color>
 
     <!-- For roster view -->
     <color name="colorBackground">#E9E9E9</color>
-    <color name="colorAttendeeName">#FFFFFFFF</color>
 </resources>


### PR DESCRIPTION
### Issue #, if available:
Chime-33151
### Description of changes:
Add more usage of API to demo app.
### Testing done:
![image-42adab46-7c89-4a9b-b2a6-215df5a362c1](https://user-images.githubusercontent.com/57926812/99839853-49adb200-2b20-11eb-8c01-6cc0924f0635.jpg)
![image-4660bdd3-2bdb-4449-8d0a-7261900d1102](https://user-images.githubusercontent.com/57926812/99839856-4c100c00-2b20-11eb-895a-b78cc44e5b8f.jpg)
![image-4cb1691a-1e2a-4f07-a336-1564003cc784](https://user-images.githubusercontent.com/57926812/99839861-4dd9cf80-2b20-11eb-9597-9ad3d9527ee9.jpg)
![image-10d74f6b-773d-40ce-948b-293919350111](https://user-images.githubusercontent.com/57926812/99839873-503c2980-2b20-11eb-8be3-f9b305a6be1a.jpg)

#### Unit test coverage
* Class coverage: same as before
* Line coverage: same as before

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [ ] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [X] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
