### PR TITLE
Add start/stop remote video logic when app is backgrounded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 * Added video pagination feature in the Android demo app. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
 * Added active speaker-based video tile feature in the Android demo app. Video tiles of active speakers will be promoted to the top of the list automatically.
+* Added logic to `stopRemoteVideo`/`startRemoteVideo` when application is background/foregrounded to save network bandwidth
 
 ### Fixed
 * Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1235,4 +1235,21 @@ class MeetingFragment : Fragment(),
         deviceDialog?.dismiss()
         unsubscribeFromAttendeeChangeHandlers()
     }
+
+    // Handle backgrounded app
+    override fun onStart() {
+        super.onStart()
+        if (meetingModel.isLocalVideoStarted) {
+            audioVideo.startLocalVideo()
+        }
+        audioVideo.startRemoteVideo()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (meetingModel.isLocalVideoStarted) {
+            audioVideo.stopLocalVideo()
+        }
+        audioVideo.stopRemoteVideo()
+    }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1115,7 +1115,6 @@ class MeetingFragment : Fragment(),
             TAG,
             "Video stream content size changed to ${tileState.videoStreamContentWidth}*${tileState.videoStreamContentHeight} for tileId: ${tileState.tileId}"
         )
-        videoTileAdapter.notifyDataSetChanged()
     }
 
     override fun onMetricsReceived(metrics: Map<ObservableMetric, Any>) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1239,16 +1239,17 @@ class MeetingFragment : Fragment(),
     // Handle backgrounded app
     override fun onStart() {
         super.onStart()
-        if (meetingModel.isLocalVideoStarted) {
-            audioVideo.startLocalVideo()
+        if (meetingModel.wasLocalVideoStarted) {
+            startLocalVideo()
         }
         audioVideo.startRemoteVideo()
     }
 
     override fun onStop() {
         super.onStop()
-        if (meetingModel.isLocalVideoStarted) {
-            audioVideo.stopLocalVideo()
+        meetingModel.wasLocalVideoStarted = meetingModel.isLocalVideoStarted
+        if (meetingModel.wasLocalVideoStarted) {
+            stopLocalVideo()
         }
         audioVideo.stopRemoteVideo()
     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1115,6 +1115,7 @@ class MeetingFragment : Fragment(),
             TAG,
             "Video stream content size changed to ${tileState.videoStreamContentWidth}*${tileState.videoStreamContentHeight} for tileId: ${tileState.tileId}"
         )
+        videoTileAdapter.notifyDataSetChanged()
     }
 
     override fun onMetricsReceived(metrics: Map<ObservableMetric, Any>) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -39,6 +39,7 @@ class MeetingModel : ViewModel() {
     var tabIndex = 0
     var isUsingCameraCaptureSource = true
     var isLocalVideoStarted = false
+    var wasLocalVideoStarted = false
     var isUsingGpuVideoProcessor = false
     var isUsingCpuVideoProcessor = false
 


### PR DESCRIPTION
### Issue #, if available:
Chime-33481
### Description of changes:
Save some network bandwidth by calling stopLocalVideo and stopRemoteVideo when backgrounded. Note that this will be called when device is rotated.

### Testing done:
1. Rotate with two videos on.
2. background and foreground with two videos on.
3. Background and add/remove video tile. When foregrounded, those are reflected
4. Pause and background the tile. When foregrounded, it is still in paused state.
#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [X] Pause remote video tile
* [X] Resume remote video tile
* [X] First time audio permissions
* [X] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
