### PR TITLE
Fix unnecessary binding/unbinding when video tile size changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.
 * Fixed a demo app issue that `mirror` property was not reset when `VideoHolder` is recycled.
 * Fixed rotation issue in demo app.
+
 ### Changed
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1115,7 +1115,6 @@ class MeetingFragment : Fragment(),
             TAG,
             "Video stream content size changed to ${tileState.videoStreamContentWidth}*${tileState.videoStreamContentHeight} for tileId: ${tileState.tileId}"
         )
-        videoTileAdapter.notifyDataSetChanged()
     }
 
     override fun onMetricsReceived(metrics: Map<ObservableMetric, Any>) {


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22244

### Description of changes:
We call `videoTileAdapter.notifyDataSetChanged()` in `onVideoTileSizeChanged()` handler, which doesn't do anything useful but triggers unnecessary binding/unbinding and cause video tile flickering. Confirmed with Nick that this should be a bug introduced in merge conflict resolution.

### Testing done:
- Tested with local/remote attendee rotating the devices and video tile size changed. The behavior remained the same as before.
- Confirmed that there's no bind/unbind when video tile size changed.

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
