### PR TITLE
Remove the video tile mapping entry when video is removed instead of when video is unbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Changed
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
+* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `onVideoTileAdded(tileState)` callback and removed in `onVideoTileRemoved(tileState)` callback.
 
 ## [0.8.1] - 2020-11-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 ### Changed
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
-* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `onVideoTileAdded(tileState)` callback and removed in `onVideoTileRemoved(tileState)` callback.
+* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is *removed*, instead of when video is *unbound*. This fixes [`onVideoTileAdded(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId)` if they did not call `bindVideoView(videoView, tileId)`.
 
 ## [0.8.1] - 2020-11-20
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -168,7 +168,7 @@ class DefaultVideoTileController(
     }
 
     private fun removeVideoViewFromMap(tileId: Int) {
-        boundVideoViewMap.filterValues { it.state.tileId == tileId }.entries.forEach {
+        boundVideoViewMap.entries.firstOrNull { it.value.state.tileId == tileId }?.let {
             val renderView = it.key
             val videoTile = it.value
             videoTile.unbind()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -20,7 +20,7 @@ class DefaultVideoTileController(
     // A map of tile id to VideoTile to determine if VideoTileController is adding, removing, pausing, or rendering
     private val videoTileMap = mutableMapOf<Int, VideoTile>()
     // A map of VideoRenderView to VideoTile to determine if users are adding same video render view
-    private val boundVideoViewMap = mutableMapOf<VideoRenderView, VideoTile>()
+    private val renderViewToBoundVideoTileMap = mutableMapOf<VideoRenderView, VideoTile>()
     private val TAG = "DefaultVideoTileController"
 
     private var videoTileObservers = mutableSetOf<VideoTileObserver>()
@@ -148,7 +148,7 @@ class DefaultVideoTileController(
     override fun bindVideoView(videoView: VideoRenderView, tileId: Int) {
         logger.info(TAG, "Binding VideoView to Tile with tileId = $tileId")
 
-        boundVideoViewMap[videoView]?.let {
+        renderViewToBoundVideoTileMap[videoView]?.let {
             logger.warn(TAG, "Override the binding from ${it.state.tileId} to $tileId")
             removeVideoViewFromMap(it.state.tileId)
         }
@@ -163,12 +163,12 @@ class DefaultVideoTileController(
                 videoView.init(eglCoreFactory)
             }
             it.bind(videoView)
-            boundVideoViewMap[videoView] = it
+            renderViewToBoundVideoTileMap[videoView] = it
         }
     }
 
     private fun removeVideoViewFromMap(tileId: Int) {
-        boundVideoViewMap.entries.firstOrNull { it.value.state.tileId == tileId }?.let {
+        renderViewToBoundVideoTileMap.entries.firstOrNull { it.value.state.tileId == tileId }?.let {
             val renderView = it.key
             val videoTile = it.value
             videoTile.unbind()
@@ -176,7 +176,7 @@ class DefaultVideoTileController(
                 logger.info(TAG, "Releasing EGL state on EGL render view")
                 renderView.release()
             }
-            boundVideoViewMap.remove(renderView)
+            renderViewToBoundVideoTileMap.remove(renderView)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -150,13 +150,13 @@ class DefaultVideoTileController(
 
         renderViewToBoundVideoTileMap[videoView]?.let {
             logger.warn(TAG, "Override the binding from ${it.state.tileId} to $tileId")
-            removeVideoViewFromMap(it.state.tileId)
+            removeRenderViewFromBoundVideoTileMap(it.state.tileId)
         }
 
         videoTileMap[tileId]?.let {
             it.videoRenderView?.let {
                 logger.info(TAG, "tileId = $tileId already had a different video view. Unbinding the old one and associating the new one")
-                removeVideoViewFromMap(tileId)
+                removeRenderViewFromBoundVideoTileMap(tileId)
             }
             if (videoView is EglVideoRenderView) {
                 logger.info(TAG, "Initializing EGL state on EGL render view")
@@ -167,7 +167,7 @@ class DefaultVideoTileController(
         }
     }
 
-    private fun removeVideoViewFromMap(tileId: Int) {
+    private fun removeRenderViewFromBoundVideoTileMap(tileId: Int) {
         renderViewToBoundVideoTileMap.entries.firstOrNull { it.value.state.tileId == tileId }?.let {
             val renderView = it.key
             val videoTile = it.value
@@ -182,7 +182,7 @@ class DefaultVideoTileController(
 
     override fun unbindVideoView(tileId: Int) {
         logger.info(TAG, "Unbinding Tile with tileId = $tileId")
-        removeVideoViewFromMap(tileId)
+        removeRenderViewFromBoundVideoTileMap(tileId)
     }
 
     private fun onRemoveVideoTile(tileId: Int) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -19,8 +19,8 @@ class DefaultVideoTileController(
 ) : VideoTileController {
     // A map of tile id to VideoTile to determine if VideoTileController is adding, removing, pausing, or rendering
     private val videoTileMap = mutableMapOf<Int, VideoTile>()
-    // A map of VideoRenderView to tile id to determine if users are adding same video render view
-    private val boundVideoViewMap = mutableMapOf<VideoRenderView, Int>()
+    // A map of VideoRenderView to VideoTile to determine if users are adding same video render view
+    private val boundVideoViewMap = mutableMapOf<VideoRenderView, VideoTile>()
     private val TAG = "DefaultVideoTileController"
 
     private var videoTileObservers = mutableSetOf<VideoTileObserver>()
@@ -149,8 +149,8 @@ class DefaultVideoTileController(
         logger.info(TAG, "Binding VideoView to Tile with tileId = $tileId")
 
         boundVideoViewMap[videoView]?.let {
-            logger.warn(TAG, "Override the binding from $it to $tileId")
-            removeVideoViewFromMap(it)
+            logger.warn(TAG, "Override the binding from ${it.state.tileId} to $tileId")
+            removeVideoViewFromMap(it.state.tileId)
         }
 
         videoTileMap[tileId]?.let {
@@ -163,19 +163,19 @@ class DefaultVideoTileController(
                 videoView.init(eglCoreFactory)
             }
             it.bind(videoView)
-            boundVideoViewMap[videoView] = tileId
+            boundVideoViewMap[videoView] = it
         }
     }
 
     private fun removeVideoViewFromMap(tileId: Int) {
-        videoTileMap[tileId]?.let {
-            val renderView = it.videoRenderView
-            it.unbind()
+        boundVideoViewMap.filterValues { it.state.tileId == tileId }.entries.forEach {
+            val renderView = it.key
+            val videoTile = it.value
+            videoTile.unbind()
             if (renderView is EglVideoRenderView) {
                 logger.info(TAG, "Releasing EGL state on EGL render view")
                 renderView.release()
             }
-
             boundVideoViewMap.remove(renderView)
         }
     }
@@ -183,12 +183,12 @@ class DefaultVideoTileController(
     override fun unbindVideoView(tileId: Int) {
         logger.info(TAG, "Unbinding Tile with tileId = $tileId")
         removeVideoViewFromMap(tileId)
-        videoTileMap.remove(tileId)
     }
 
     private fun onRemoveVideoTile(tileId: Int) {
         videoTileMap[tileId]?.let {
             forEachObserver { observer -> observer.onVideoTileRemoved(it.state) }
+            videoTileMap.remove(tileId)
         }
     }
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
@@ -556,7 +556,7 @@ class DefaultVideoTileControllerTest {
         videoTileController.bindVideoView(mockVideoRenderView, tileId)
         videoTileController.bindVideoView(mockVideoRenderView2, tileId2)
 
-        verify(exactly = 1) { mockVideoTile.unbind() }
+        verify(exactly = 0) { mockVideoTile.unbind() }
         verify(exactly = 0) { mockVideoTile2.unbind() }
         verify(exactly = 1) { mockVideoTile.bind(any()) }
         verify(exactly = 1) { mockVideoTile2.bind(any()) }
@@ -683,6 +683,56 @@ class DefaultVideoTileControllerTest {
                     testHeight,
                     VideoPauseState.Unpaused,
                     localTile
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `Video tile mapping entry should be removed when unbound video is removed`() {
+        val mockObserver = spyk(tileObserver)
+
+        videoTileController.addVideoTileObserver(mockObserver)
+        runBlockingTest {
+            // Add video but do not bind it
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+            // Remove video
+            videoTileController.onReceiveFrame(null, tileId, attendeeId, VideoPauseState.Unpaused)
+            // Add video again
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+        }
+
+        verify(exactly = 1) {
+            mockObserver.onVideoTileRemoved(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
+                )
+            )
+        }
+        verify(exactly = 2) {
+            mockObserver.onVideoTileAdded(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
                 )
             )
         }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
@@ -689,7 +689,7 @@ class DefaultVideoTileControllerTest {
     }
 
     @Test
-    fun `Video tile mapping entry should be removed when unbound video is removed`() {
+    fun `onReceiveFrame should notify observer about video tile add when the video is unbound and previously removed`() {
         val mockObserver = spyk(tileObserver)
 
         videoTileController.addVideoTileObserver(mockObserver)
@@ -704,6 +704,121 @@ class DefaultVideoTileControllerTest {
             // Remove video
             videoTileController.onReceiveFrame(null, tileId, attendeeId, VideoPauseState.Unpaused)
             // Add video again
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+        }
+
+        verify(exactly = 1) {
+            mockObserver.onVideoTileRemoved(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
+                )
+            )
+        }
+        verify(exactly = 2) {
+            mockObserver.onVideoTileAdded(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `onReceiveFrame should notify observer about video tile add when the video is bound and previously removed`() {
+        val mockObserver = spyk(tileObserver)
+
+        videoTileController.addVideoTileObserver(mockObserver)
+        runBlockingTest {
+            // Add video and bind it
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+            videoTileController.bindVideoView(mockVideoRenderView, tileId)
+            // Remove video
+            videoTileController.onReceiveFrame(null, tileId, attendeeId, VideoPauseState.Unpaused)
+            // Add video again
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+        }
+
+        verify(exactly = 1) {
+            mockObserver.onVideoTileRemoved(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
+                )
+            )
+        }
+        verify(exactly = 2) {
+            mockObserver.onVideoTileAdded(
+                VideoTileState(
+                    tileId,
+                    attendeeId,
+                    testWidth,
+                    testHeight,
+                    VideoPauseState.Unpaused,
+                    remoteTile
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `onReceiveFrame should notify observer about video tile add when the paused video was previously removed then added and resumed`() {
+        val mockObserver = spyk(tileObserver)
+
+        videoTileController.addVideoTileObserver(mockObserver)
+        runBlockingTest {
+            // Add video but do not bind it
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+            // Pause video
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.PausedByUserRequest
+            )
+            // Remove video
+            videoTileController.onReceiveFrame(null, tileId, attendeeId, VideoPauseState.Unpaused)
+            // Add video again
+            videoTileController.onReceiveFrame(
+                null,
+                tileId,
+                attendeeId,
+                VideoPauseState.PausedByUserRequest
+            )
+            // Resume video
             videoTileController.onReceiveFrame(
                 mockVideoFrame,
                 tileId,


### PR DESCRIPTION
### Issue #, if available:
#186

### Description of changes:
Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `onVideoTileAdded(tileState)` callback and removed in `onVideoTileRemoved(tileState)` callback.

### Testing done:
Tested by modifying the demo app so that it does not bind remote video in `onVideoTileAdded(tileState)` and it does not unbind remote video in `onVideoTileRemoved(tileState)`. Test steps:
1. UserA joined Web client and enabled video.
2. UserB joined mobile client. Verified in the log that onVideoTileAdded was called for UserA's video, but the view was not bound (so video was not showing on the screen).
3. UserA disabled video. Verified in the log that onVideoTileRemoved was called for UserA's video.
4. UserA enabled video again. Verified in the log that onVideoTileAdded was called again for UserA's video.

#### Unit test coverage
Unit test coverage was not available currently, but all test cases passed.

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
