### PR TITLE
Implement TURN URIs received callback

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -201,7 +201,8 @@ class DefaultVideoClientController(
             false,
             0,
             flag,
-            eglCore?.eglContext
+            eglCore?.eglContext,
+            configuration.urls.signalingURL
         )
 
         videoSourceAdapter?.let { videoClient?.setExternalVideoSource(it, eglCore?.eglContext) }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -318,6 +318,16 @@ class DefaultVideoClientObserver(
         }
     }
 
+    override fun onTurnURIsReceived(uris: MutableList<String>?): MutableList<String>? {
+        if (uris == null) return null
+
+        var newUris: MutableList<String> = mutableListOf()
+        for (uri in uris) {
+            newUris.add(uri)
+        }
+        return newUris
+    }
+
     override fun subscribeToVideoClientStateChange(observer: AudioVideoObserver) {
         videoClientStateObservers.add(observer)
     }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Implement callback that allows modification of TURN uris by builder.
Pass signaling url into video client start since requestTurnCreds will only be called as a backup.
### Testing done:
Joined a meeting with 2 participants and ensured video was sent and received.
#### Unit test coverage
* Class coverage: 80%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [ x] Join meeting
* [ x] Leave meeting
* [ ] Rejoin meeting
* [x ] Send audio
* [x ] Receive audio
* [x ] See active speaker indicator when speaking
* [ x] Mute/Unmute self
* [x ] See local mute indicator when muted
* [x ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ x] See roster updates when remote attendees join / leave the meeting
* [ x] Enable local video
* [x ] See local video tile
* [x ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [x ] Pause remote video tile
* [x ] Resume remote video tile
* [x ] First time audio permissions
* [x ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
