### PR TITLE
Implement TURN URIs received callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@
 * Added screen share feature in demo app.
 * Added message for video tiles paused by poor network in demo app.
 * Added logic to `stopRemoteVideo`/`startRemoteVideo` when application is background/foregrounded to save network bandwidth in demo app.
+* Added TURN uris received callback.
 
 ### Changed
 * **Breaking** `AudioVideoFacade` now also implements `ContentShareController`.
 * **Breaking** Changed to take `ContentShareController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
 * Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`.
 * Update text of additional options on demo app.
+* Changes that support a speed up of video client initialization. `requestTurnCreds` callback will only be invoked as a backup for media layer logic. The signaling url is now passed into video client start. A new callback `onTurnURIsReceived` will be invoked when TURN uris are received by the client. This allows urls to be modified with urlRewriter or custom builder logic.
 
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -42,6 +42,7 @@ class DefaultContentShareVideoClientController(
     private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 1 shl 12
     private val VIDEO_CLIENT_FLAG_DISABLE_CAPTURER = 1 shl 20
     private val VIDEO_CLIENT_FLAG_IS_CONTENT = 1 shl 23
+    private val VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS = 1 shl 26
 
     override fun startVideoShare(videoSource: VideoSource) {
         // Start the given content share source
@@ -93,6 +94,7 @@ class DefaultContentShareVideoClientController(
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER
         flag = flag or VIDEO_CLIENT_FLAG_IS_CONTENT
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS
 
         val videoClientConfig: VideoClientConfig = VideoClientConfigBuilder()
             .setMeetingId(configuration.meetingId)
@@ -100,6 +102,7 @@ class DefaultContentShareVideoClientController(
             .setAudioHostUrl(configuration.urls.audioHostURL)
             .setFlags(flag)
             .setSharedEglContext(eglCore?.eglContext)
+            .setSignalingUrl(configuration.urls.signalingURL)
             .createVideoClientConfig()
         val result = videoClient?.start(videoClientConfig) ?: false
         logger.info(TAG, "Content share video client start result: $result")

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
@@ -159,4 +159,8 @@ class DefaultContentShareVideoClientObserver(
             logger.verbose(TAG, message)
         }
     }
+
+    override fun onTurnURIsReceived(uris: List<String>): List<String> {
+        return uris.map(urlRewriter)
+    }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -44,6 +44,7 @@ class DefaultVideoClientController(
     private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 1 shl 12
     private val VIDEO_CLIENT_FLAG_DISABLE_CAPTURER = 1 shl 20
     private val VIDEO_CLIENT_FLAG_EXCLUDE_SELF_CONTENT_IN_INDEX = 1 shl 24
+    private val VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS = 1 shl 26
 
     private val gson = Gson()
 
@@ -197,11 +198,13 @@ class DefaultVideoClientController(
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER
         flag = flag or VIDEO_CLIENT_FLAG_EXCLUDE_SELF_CONTENT_IN_INDEX
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS
         val videoClientConfig: VideoClientConfig = VideoClientConfigBuilder()
                 .setMeetingId(configuration.meetingId)
                 .setToken(configuration.credentials.joinToken)
                 .setFlags(flag)
                 .setSharedEglContext(eglCore?.eglContext)
+                .setSignalingUrl(configuration.urls.signalingURL)
                 .createVideoClientConfig()
         videoClient?.start(videoClientConfig)
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -241,6 +241,10 @@ class DefaultVideoClientObserver(
         }
     }
 
+    override fun onTurnURIsReceived(uris: List<String>): List<String> {
+        return uris.map(urlRewriter)
+    }
+
     override fun subscribeToVideoClientStateChange(observer: AudioVideoObserver) {
         videoClientStateObservers.add(observer)
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
@@ -126,4 +126,19 @@ class DefaultContentShareVideoClientObserverTest {
 
         verify { mockClientMetricsCollector.processContentShareVideoClientMetrics(any()) }
     }
+
+    @Test
+    fun `onTurnURIsReceived should call urlRewriter for each uri passed in`() {
+        val uri1 = "one"
+        val uri2 = "two"
+        val uri3 = "three"
+        every { mockURLRewriter(uri1) } returns uri1
+        every { mockURLRewriter(uri2) } returns uri2
+        every { mockURLRewriter(uri3) } returns uri3
+        val turnUris = listOf<String>(uri1, uri2, uri3)
+        val outUris = testContentShareVideoClientObserver.onTurnURIsReceived(turnUris)
+
+        verify(exactly = 3) { mockURLRewriter(any()) }
+        assert(outUris.equals(turnUris))
+    }
 }


### PR DESCRIPTION
Issue #, if available:
Description of changes:
Implement callback that allows modification of TURN uris by builder.
Pass signaling url into video client start since requestTurnCreds will only be called as a backup.

Testing done:
Joined a meeting with 2 participants and ensured video was sent and received.

Unit test coverage
Class coverage: 80%
Line coverage: 67%
Manual test cases (add more as needed):
[ x] Join meeting
[ x] Leave meeting
 Rejoin meeting
[x ] Send audio
[x ] Receive audio
[x ] See active speaker indicator when speaking
[ x] Mute/Unmute self
[x ] See local mute indicator when muted
[x ] See remote mute indicator when other is muted
 See audio video events
 See signal strength changes
 See media metrics received
[ x] See roster updates when remote attendees join / leave the meeting
[ x] Enable local video
[x ] See local video tile
[x ] See remote video tile
 Switch camera
 See remote screen sharing content with attendee name
[x ] Pause remote video tile
[x ] Resume remote video tile
[x ] First time audio permissions
[x ] First time video permissions
Screenshots, if available:
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.