### PR TITLE
Fix audio manager change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@
 * Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.
 * Fixed a demo app issue that `mirror` property was not reset when `VideoHolder` is recycled.
 * Fixed rotation issue in demo app.
-
 ### Changed
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
 * **Breaking** Remove the internal video tile mapping entry not only when the video is *unbound*, but also when the video is *removed*. This fixes [`onVideoTileAdded(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId)` if they did not call `bindVideoView(videoView, tileId)`.
   * After this fix, the internal video tile mapping entry will be removed before `onVideoTileRemoved(tileState)` callback is called. Please check your `VideoTileObserver`s and make sure your `onVideoTileRemoved(tileState)` handlers do not call any SDK APIs that depend on the existance of video tiles (e.g. `bindVideoView(videoView, tileId)`).
+* Change AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
 
 ## [0.8.2] - 2020-12-11
 ## [0.8.1] - 2020-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+### Changed
+* Change AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
 ## 0.9.0 - 2020-12-17
 
 ### Added
@@ -13,7 +17,7 @@
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
 * **Breaking** Remove the internal video tile mapping entry not only when the video is *unbound*, but also when the video is *removed*. This fixes [`onVideoTileAdded(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId)` if they did not call `bindVideoView(videoView, tileId)`.
   * After this fix, the internal video tile mapping entry will be removed before `onVideoTileRemoved(tileState)` callback is called. Please check your `VideoTileObserver`s and make sure your `onVideoTileRemoved(tileState)` handlers do not call any SDK APIs that depend on the existance of video tiles (e.g. `bindVideoView(videoView, tileId)`).
-* Change AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
+
 
 ## [0.8.2] - 2020-12-11
 ## [0.8.1] - 2020-11-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Changed
-* Changed AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
+* Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`
 
 ## 0.9.0 - 2020-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 ### Changed
-* Change AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
+* Changed AudioManager mode in `DefaultAudioClientController` so that it doesn't change when builder didn't start the meeting.
+
 ## 0.9.0 - 2020-12-17
 
 ### Added
@@ -13,13 +14,14 @@
 * Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.
 * Fixed a demo app issue that `mirror` property was not reset when `VideoHolder` is recycled.
 * Fixed rotation issue in demo app.
+
 ### Changed
 * Refactored video view to resemble iOS UI so that video doesn't get cropped.
 * **Breaking** Remove the internal video tile mapping entry not only when the video is *unbound*, but also when the video is *removed*. This fixes [`onVideoTileAdded(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId)` if they did not call `bindVideoView(videoView, tileId)`.
   * After this fix, the internal video tile mapping entry will be removed before `onVideoTileRemoved(tileState)` callback is called. Please check your `VideoTileObserver`s and make sure your `onVideoTileRemoved(tileState)` handlers do not call any SDK APIs that depend on the existance of video tiles (e.g. `bindVideoView(videoView, tileId)`).
 
-
 ## [0.8.2] - 2020-12-11
+
 ## [0.8.1] - 2020-11-20
 
 ## [0.8.0] - 2020-11-17

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -49,7 +49,6 @@ class DefaultDeviceController(
                 }
 
                 override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
-                    audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
                     notifyAudioDeviceChange()
                 }
             }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -70,7 +70,6 @@ class DefaultDeviceController(
                 receiver, IntentFilter(BluetoothDevice.ACTION_ACL_DISCONNECTED)
             )
         }
-        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
     }
 
     override fun listAudioDevices(): List<MediaDevice> {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -127,7 +127,7 @@ class DefaultAudioClientController(
                 false
             )
         }
-        initAudioManager()
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
         uiScope.launch {
             val res = audioClient.startSession(
                 AudioClient.XTL_DEFAULT_TRANSPORT,
@@ -179,10 +179,6 @@ class DefaultAudioClientController(
                 }
             }
         }
-    }
-
-    private fun initAudioManager() {
-        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
     }
 
     private fun resetAudioManager() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -121,14 +121,13 @@ class DefaultAudioClientController(
             )
             DEFAULT_PORT
         }
-
         setUpAudioConfiguration()
         audioClientObserver.notifyAudioClientObserver { observer ->
             observer.onAudioSessionStartedConnecting(
                 false
             )
         }
-
+        initAudioManager()
         uiScope.launch {
             val res = audioClient.startSession(
                 AudioClient.XTL_DEFAULT_TRANSPORT,
@@ -180,6 +179,10 @@ class DefaultAudioClientController(
                 }
             }
         }
+    }
+
+    private fun initAudioManager() {
+        audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
     }
 
     private fun resetAudioManager() {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -287,6 +287,23 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
+    fun `start should call AudioManger setMode`() {
+        setupStartTests()
+
+        audioClientController.start(
+                testAudioFallbackUrl,
+                testAudioHostUrl,
+                testMeetingId,
+                testAttendeeId,
+                testJoinToken
+        )
+
+        verify {
+            audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+        }
+    }
+
+    @Test
     fun `start should notify audioClientObserver about audio client connection events`() {
         setupStartTests()
 


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/189
### Description of changes:
Instead of init audio manager mode in the DefaultDeviceController init, we'll set it in `DefaultAudioClientController` to handle cases like not meeting hasn't started.
### Testing done:
2020-12-16 15:32:48.277 14959-14959/com.amazonaws.services.chime.sdkdemo I/DeviceManagementFragment: onAttach 0
2020-12-16 15:32:48.322 14959-14959/com.amazonaws.services.chime.sdkdemo I/InMeetingActivity: onStart 0
2020-12-16 15:33:25.872 14959-14959/com.amazonaws.services.chime.sdkdemo I/MeetingFragment: onAudioSessionStarted 3
2020-12-16 15:33:37.001 14959-14959/com.amazonaws.services.chime.sdkdemo I/InMeetingActivity: onStop 0
#### Unit test coverage
* Class coverage:  80%
* Line coverage: 69%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
