### PR TITLE
Add content share APIs, default screen capture implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,26 @@
 ## Unreleased
 
+### Added
+* **Breaking** Added `ContentShareController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
+* **Breaking** Added content share metrics as new enums in `ObservableMetric`.
+* Added content share feature, read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for details.
+* Added `minFps` to `SurfaceTextureCaptureSource` as a property to help encoder improve the quality.
+* Added `createContentShareMeetingSessionConfiguration` as helper function in `MeetingSessionConfiguration` to generate content configuration based on the existing session.
+* Added screen share feature in demo app.
+* Added message for video tiles paused by poor network in demo app.
+
 ### Changed
-* Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`
+* Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`.
+* Update text of additional options on demo app.
+
+### Fixed
+* Fixed potential concurrency issue on `VideoSourceAdapter`.
 
 ## 0.9.0 - 2020-12-17
 
 ### Added
 * Added video pagination feature in the Android demo app. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
 * Added active speaker-based video tile feature in the Android demo app. Video tiles of active speakers will be promoted to the top of the list automatically.
-* Added logic to `stopRemoteVideo`/`startRemoteVideo` when application is background/foregrounded to save network bandwidth
 
 ### Fixed
 * Fixed a demo app issue that `SurfaceView` was not cleared up correctly when switching between Screen tab and Video tab.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 ## Unreleased
 
 ### Added
-* **Breaking** Added `ContentShareController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
 * **Breaking** Added content share metrics as new enums in `ObservableMetric`.
-* Added content share feature, read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for details.
+* Added content share APIs that supports a 2nd video sending stream such as screen capture, read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for details.
 * Added `minFps` to `SurfaceTextureCaptureSource` as a property to help encoder improve the quality.
 * Added `createContentShareMeetingSessionConfiguration` as helper function in `MeetingSessionConfiguration` to generate content configuration based on the existing session.
 * Added screen share feature in demo app.
 * Added message for video tiles paused by poor network in demo app.
 
 ### Changed
+* **Breaking** `AudioVideoFacade` now also implements `ContentShareController`.
+* **Breaking** Changed to take `ContentShareController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
 * Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`.
 * Update text of additional options on demo app.
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
@@ -70,6 +70,8 @@ interface AudioVideoControllerFacade {
      * transmitted. It will also stop and replace the internal capture source if [startLocalVideo]
      * was called with no arguments.
      *
+     * Read [custom video guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md) for details.
+     *
      * @param source: [VideoSource] - The source of video frames to be sent to other clients
      */
     fun startLocalVideo(source: VideoSource)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoFacade.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileControllerFacade
 import com.amazonaws.services.chime.sdk.meetings.device.DeviceController
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade
@@ -13,4 +14,6 @@ import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFaca
 interface AudioVideoFacade : AudioVideoControllerFacade,
     RealtimeControllerFacade,
     DeviceController,
-    VideoTileControllerFacade, ActiveSpeakerDetectorFacade
+    VideoTileControllerFacade,
+    ActiveSpeakerDetectorFacade,
+    ContentShareController

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -14,6 +14,9 @@ import androidx.core.content.ContextCompat
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerpolicy.ActiveSpeakerPolicy
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
@@ -32,7 +35,8 @@ class DefaultAudioVideoFacade(
     private val realtimeController: RealtimeControllerFacade,
     private val deviceController: DeviceController,
     private val videoTileController: VideoTileController,
-    private val activeSpeakerDetector: ActiveSpeakerDetectorFacade
+    private val activeSpeakerDetector: ActiveSpeakerDetectorFacade,
+    private val contentShareController: ContentShareController
 ) : AudioVideoFacade {
 
     private val permissions = arrayOf(
@@ -196,5 +200,21 @@ class DefaultAudioVideoFacade(
 
     override fun removeActiveSpeakerObserver(observer: ActiveSpeakerObserver) {
         activeSpeakerDetector.removeActiveSpeakerObserver(observer)
+    }
+
+    override fun startContentShare(source: ContentShareSource) {
+        contentShareController.startContentShare(source)
+    }
+
+    override fun stopContentShare() {
+        contentShareController.stopContentShare()
+    }
+
+    override fun addContentShareObserver(observer: ContentShareObserver) {
+        contentShareController.addContentShareObserver(observer)
+    }
+
+    override fun removeContentShareObserver(observer: ContentShareObserver) {
+        contentShareController.removeContentShareObserver(observer)
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
@@ -21,6 +21,9 @@ interface ContentShareController {
      * be invoked. If sharing fails or stops, [ContentShareObserver.onContentShareStopped]
      * will be invoked with [ContentShareStatus] as the cause.
      *
+     * This will call [VideoSource.addVideoSink] on the provided source
+     * and [VideoSource.removeVideoSink] on the previously provided source.
+     *
      * Calling this function repeatedly will replace the previous [ContentShareSource] as the one being
      * transmitted.
      *
@@ -34,7 +37,6 @@ interface ContentShareController {
      * Once the sharing stops successfully, [ContentShareObserver.onContentShareStopped]
      * will be invoked with status code [ContentShareStatusCode.OK].
      *
-     * This will call [VideoSource.removeVideoSink] on any previously provided video source.
      */
     fun stopContentShare()
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+
+/**
+ * [ContentShareController] exposes methods for starting and stopping content share with a [ContentShareSource].
+ * The content represents a media steam to be shared in the meeting, such as screen capture or
+ * media files.
+ * Read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for details.
+ */
+interface ContentShareController {
+    /**
+     * Start sharing the content of a given [ContentShareSource].
+     *
+     * Once sharing has started successfully, [ContentShareObserver.onContentShareStarted] will
+     * be invoked. If sharing fails or stops, [ContentShareObserver.onContentShareStopped]
+     * will be invoked with [ContentShareStatus] as the cause.
+     *
+     * Calling this function repeatedly will replace the previous [ContentShareSource] as the one being
+     * transmitted.
+     *
+     * @param source: [ContentShareSource] - The source of content to be shared.
+     */
+    fun startContentShare(source: ContentShareSource)
+
+    /**
+     * Stop sharing the content of a [ContentShareSource] that previously started.
+     *
+     * Once the sharing stops successfully, [ContentShareObserver.onContentShareStopped]
+     * will be invoked with status code [ContentShareStatusCode.OK].
+     *
+     * This will call [VideoSource.removeVideoSink] on any previously provided video source.
+     */
+    fun stopContentShare()
+
+    /**
+     * Subscribe the given observer to content share events (sharing started and stopped).
+     *
+     * @param observer: [ContentShareObserver] - The observer to be notified for events.
+     */
+    fun addContentShareObserver(observer: ContentShareObserver)
+
+    /**
+     * Unsubscribe the given observer from content share events.
+     *
+     * @param observer: [ContentShareObserver] - The observer to be removed for events.
+     */
+    fun removeContentShareObserver(observer: ContentShareObserver)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareObserver.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+/**
+ * [ContentShareObserver] handles all callbacks related to the content share.
+ * By implementing the callback functions and registering with [ContentShareController.addContentShareObserver],
+ * one can get notified with content share status events.
+ */
+interface ContentShareObserver {
+    /**
+     * Called when the content share has started.
+     * This callback will be on the main thread.
+     */
+    fun onContentShareStarted()
+
+    /**
+     * Called when the content is no longer shared with other attendees
+     * with the reason provided in the status.
+     *
+     * If you no longer need the source producing frames,
+     * most builders can stop the source after this callback is invoked.
+     *
+     * @param status: [ContentShareStatus] - the reason why the content share has stopped
+     */
+    fun onContentShareStopped(status: ContentShareStatus)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareSource.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+
+/**
+ * [ContentShareSource] contains the media sources to attach to the content share
+ */
+open class ContentShareSource {
+    open var videoSource: VideoSource? = null
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatus.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatus.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+/**
+ * [ContentShareStatus] indicates a status received regarding the content share.
+ *
+ * @param statusCode: [ContentShareStatusCode] - Additional details for the status
+ */
+data class ContentShareStatus(val statusCode: ContentShareStatusCode)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatusCode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatusCode.kt
@@ -16,7 +16,7 @@ enum class ContentShareStatusCode {
 
     /**
      * Content share video connection is in an unrecoverable failed state.
-     * May be recovered by restarting the content share connection.
+     * Restart content share connection when this error is encountered.
      */
     VideoServiceFailed;
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatusCode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareStatusCode.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+/**
+ * [ContentShareStatusCode] indicates the reason the content share event occurred.
+ */
+enum class ContentShareStatusCode {
+    /**
+     * No failure.
+     */
+    OK,
+
+    /**
+     * Content share video connection is in an unrecoverable failed state.
+     * May be recovered by restarting the content share connection.
+     */
+    VideoServiceFailed;
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareController.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.ContentShareVideoClientController
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+class DefaultContentShareController(
+    private val logger: Logger,
+    private val contentShareVideoClientController: ContentShareVideoClientController
+) : ContentShareController {
+
+    private val TAG = "DefaultContentShareController"
+
+    override fun startContentShare(source: ContentShareSource) {
+        source.videoSource?.let {
+            contentShareVideoClientController.startVideoShare(it)
+        }
+    }
+
+    override fun stopContentShare() {
+        contentShareVideoClientController.stopVideoShare()
+    }
+
+    override fun addContentShareObserver(observer: ContentShareObserver) {
+        contentShareVideoClientController.subscribeToVideoClientStateChange(observer)
+    }
+
+    override fun removeContentShareObserver(observer: ContentShareObserver) {
+        contentShareVideoClientController.unsubscribeFromVideoClientStateChange(observer)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/metric/ObservableMetric.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/metric/ObservableMetric.kt
@@ -9,7 +9,7 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo.metric
  * [ObservableMetric] represents filtered metrics that are intended to propagate to the
  * top level observers. All metrics are measured over the past second.
  */
-enum class ObservableMetric() {
+enum class ObservableMetric {
     /**
      * Percentage of audio packets lost from server to client
      */
@@ -59,4 +59,31 @@ enum class ObservableMetric() {
      * Percentage of video packets lost from server to client across all receive streams
      */
     videoReceivePacketLossPercent,
+
+    /* Below are metrics for content share stream */
+
+    /**
+     * Sum of total bitrate across all send streams
+     */
+    contentShareVideoSendBitrate,
+
+    /**
+     * Percentage of video packets lost from client to server across all send streams
+     */
+    contentShareVideoSendPacketLossPercent,
+
+    /**
+     * Average send FPS across all send streams
+     */
+    contentShareVideoSendFps,
+
+    /**
+     * Round trip time of packets sent from client to server
+     */
+    contentShareVideoSendRttMs;
+
+    /**
+     * Determine if the metric is for content share stream
+     */
+    fun isContentShareMetric() = this.name.startsWith("contentShare")
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -195,8 +195,8 @@ class DefaultVideoTileController(
     }
 
     private fun onAddVideoTile(tileId: Int, attendeeId: String?, pauseState: VideoPauseState, videoStreamContentWidth: Int, videoStreamContentHeight: Int) {
-        var isLocalTile: Boolean
-        var thisAttendeeId: String
+        val isLocalTile: Boolean
+        val thisAttendeeId: String
 
         if (attendeeId != null) {
             thisAttendeeId = attendeeId

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoTileState.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoTileState.kt
@@ -5,6 +5,9 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 
+import com.amazonaws.services.chime.sdk.meetings.utils.DefaultModality
+import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
+
 /**
  * Contains properties related to the current state of the [VideoTile]
  *
@@ -26,5 +29,5 @@ data class VideoTileState(
     /**
      * Whether the video tile is from screen share
      */
-    val isContent: Boolean = attendeeId.endsWith("#content")
+    val isContent: Boolean = DefaultModality(attendeeId).hasModality(ModalityType.Content)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
@@ -30,10 +30,10 @@ import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 
 /**
- * [DefaultScreenCaptureSource] uses [MediaProjection] to create a [virtualDisplay] to capture the
+ * [DefaultScreenCaptureSource] uses [MediaProjection] to create a [VirtualDisplay] to capture the
  * device screen. It will render the captured frames to a [Surface] provided by a [SurfaceTextureCaptureSourceFactory].
  *
- * Builders will need to get permission from users to obtain the [activityResultCode] and [activityData] arguments ,
+ * Builders will need to get permission from users to obtain the [activityResultCode] and [activityData] arguments,
  * required to create an internal [MediaProjection] object.
  * Read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for more information.
  */
@@ -103,7 +103,7 @@ class DefaultScreenCaptureSource(
             // Set this to no-op any future restart requests on the handler
             isRestartingForOrientationChange = false
 
-            // Notify here so restarts do not
+            // Notify here so restarts do not trigger the callback
             ObserverUtils.notifyObserverOnMainThread(observers) {
                 it.onCaptureStarted()
             }
@@ -178,7 +178,7 @@ class DefaultScreenCaptureSource(
             // Set this to no-op any future restart requests on the handler
             isRestartingForOrientationChange = false
 
-            // Notify here so restarts do not
+            // Notify here so restarts do not trigger the callback
             ObserverUtils.notifyObserverOnMainThread(observers) {
                 it.onCaptureStopped()
             }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture
+
+import android.content.Context
+import android.content.Context.MEDIA_PROJECTION_SERVICE
+import android.content.Intent
+import android.content.res.Resources
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.DisplayMetrics
+import android.view.Display
+import android.view.Surface
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoContentHint
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSink
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import kotlin.math.ceil
+import kotlinx.coroutines.android.asCoroutineDispatcher
+import kotlinx.coroutines.runBlocking
+
+/**
+ * [DefaultScreenCaptureSource] uses [MediaProjection] to create a [virtualDisplay] to capture the
+ * device screen. It will render the captured frames to a [Surface] provided by a [SurfaceTextureCaptureSourceFactory].
+ *
+ * Builders will need to get permission from users to obtain the [activityResultCode] and [activityData] arguments ,
+ * required to create an internal [MediaProjection] object.
+ * Read [content share guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for more information.
+ */
+class DefaultScreenCaptureSource(
+    private val context: Context,
+    private val logger: Logger,
+    private val surfaceTextureCaptureSourceFactory: SurfaceTextureCaptureSourceFactory,
+    private val activityResultCode: Int,
+    private val activityData: Intent,
+    private val displayManager: DisplayManager = context.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager,
+    private val mediaProjectionManager: MediaProjectionManager = context.getSystemService(MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+) : VideoCaptureSource, VideoSink {
+    private lateinit var displayMetrics: DisplayMetrics
+    private var virtualDisplay: VirtualDisplay? = null
+
+    // This source provides a surface we pass into the system APIs
+    // and then starts emitting frames once the system starts drawing to the
+    // surface. To speed up restart, since theses sources have to wait on
+    // in-flight frames to finish release, we just begin the release and
+    // create a new one
+    private var surfaceTextureSource: SurfaceTextureCaptureSource? = null
+    // See minFPS documentation in SurfaceTextureCaptureSource for motivation
+    private val MIN_FPS = 15
+
+    // Note that we intentionally choose to not reuse MediaProjection
+    // between stop and start, as there are often (likely Android) bugs
+    // resulting in cropped/glitched captures, or stalled capture
+    // when one MediaProjection is used multiple times with different surfaces
+    // or surfaces which have changed shape
+    //
+    // Since these are quick to create, we just take the result code and
+    // data from the MediaProjection activity and create it within the source
+    private var mediaProjection: MediaProjection? = null
+    private val handler: Handler
+
+    private val observers = mutableSetOf<CaptureSourceObserver>()
+    private val sinks = mutableSetOf<VideoSink>()
+
+    // This will prioritize resolution over framerate
+    override val contentHint = VideoContentHint.Text
+
+    // MediaProjection will only draw frames with the correct rotation
+    // which means if the surface is recreated, it will, for example
+    // draw a WxH frame on a HxW surface (it uses aspect fit).
+    //
+    // Therefore to avoid letterboxes we must track orientation and
+    // restart when it changes to avoid the aforementioned issue.
+    private var isOrientationInPortrait = true
+    // This is used to block frames during restart, and to avoid
+    // calling observers when we are just restarting
+    private var isRestartingForOrientationChange = false
+
+    private val TAG = "DefaultScreenCaptureSource"
+
+    init {
+        val thread = HandlerThread(TAG)
+        thread.start()
+        handler = Handler(thread.looper)
+    }
+
+    override fun start() {
+        // This function is shared with logic which restarts following orientation changes, so post it
+        // onto the handler for thread safety
+        handler.post {
+            startInternal()
+
+            // Set this to no-op any future restart requests on the handler
+            isRestartingForOrientationChange = false
+
+            // Notify here so restarts do not
+            ObserverUtils.notifyObserverOnMainThread(observers) {
+                it.onCaptureStarted()
+            }
+        }
+    }
+
+    // Separate internal function since only some logic is shared between external calls
+    // and internal restarts; must be called on handler
+    private fun startInternal() {
+        if (mediaProjection != null) {
+            logger.warn(TAG, "Screen capture has not been stopped before start request, stopping to release resources")
+            stop()
+        }
+        logger.info(TAG, "Starting screen capture source")
+
+        mediaProjection = mediaProjectionManager.getMediaProjection(activityResultCode, activityData)
+        if (mediaProjection == null) {
+            logger.error(TAG, "Was not able to retrieve media projection, may have been passed invalid result code or data")
+            return
+        }
+
+        // Note that these metrics depend on orientation
+        displayMetrics = context.resources.displayMetrics
+        val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            ?: throw RuntimeException("No display found.")
+        // Use `getRealMetrics` to properly account for menu, status bar, and rotation
+        display.getRealMetrics(displayMetrics)
+
+        val rotation = display.rotation
+        isOrientationInPortrait = rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180
+
+        // Note that in landscape, for some reason `getRealMetrics` doesn't account for the status bar correctly
+        // so we try to account for it with a manual adjustment to the surface size to avoid letterboxes
+        surfaceTextureSource =
+            surfaceTextureCaptureSourceFactory.createSurfaceTextureCaptureSource(
+                displayMetrics.widthPixels - (if (isOrientationInPortrait) 0 else getStatusBarHeight()),
+                displayMetrics.heightPixels,
+                contentHint
+            )
+        surfaceTextureSource?.minFps = MIN_FPS
+
+        surfaceTextureSource?.addVideoSink(this)
+        surfaceTextureSource?.start()
+
+        virtualDisplay = mediaProjection?.createVirtualDisplay(
+            TAG,
+            displayMetrics.widthPixels,
+            displayMetrics.heightPixels,
+            displayMetrics.densityDpi,
+            DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
+            surfaceTextureSource?.surface,
+                object : VirtualDisplay.Callback() {
+                    override fun onStopped() {
+                        // Don't trigger observer for restart
+                        if (!isRestartingForOrientationChange) {
+                            ObserverUtils.notifyObserverOnMainThread(observers) {
+                                it.onCaptureStopped()
+                            }
+                        }
+                    }
+                },
+            handler
+        )
+
+        logger.info(TAG, "Media projection adapter activity succeeded, virtual display created")
+    }
+
+    override fun stop() {
+        runBlocking(handler.asCoroutineDispatcher().immediate) {
+            stopInternal()
+
+            // Set this to no-op any future restart requests on the handler
+            isRestartingForOrientationChange = false
+
+            // Notify here so restarts do not
+            ObserverUtils.notifyObserverOnMainThread(observers) {
+                it.onCaptureStopped()
+            }
+        }
+    }
+
+    // Separate internal function since only some logic is shared between external calls
+    // and internal restarts; must be called on handler
+    private fun stopInternal() {
+        logger.info(TAG, "Stopping screen capture source")
+
+        mediaProjection?.stop()
+        mediaProjection = null
+
+        virtualDisplay?.release()
+        virtualDisplay = null
+
+        surfaceTextureSource?.removeVideoSink(this)
+        surfaceTextureSource?.stop()
+        surfaceTextureSource?.release()
+        surfaceTextureSource = null
+    }
+
+    override fun addCaptureSourceObserver(observer: CaptureSourceObserver) {
+        observers.add(observer)
+    }
+
+    override fun removeCaptureSourceObserver(observer: CaptureSourceObserver) {
+        observers.remove(observer)
+    }
+
+    override fun addVideoSink(sink: VideoSink) {
+        handler.post { sinks.add(sink) }
+    }
+
+    override fun removeVideoSink(sink: VideoSink) {
+        runBlocking(handler.asCoroutineDispatcher().immediate) {
+            sinks.remove(sink)
+        }
+    }
+
+    override fun onVideoFrameReceived(frame: VideoFrame) {
+        // Check if display rotation has changed; since this is
+        // not an activity there is otherwise no way to observe this
+        // besides checking every frame
+        val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY)
+            ?: throw RuntimeException("No display found.")
+        val rotation = display.rotation
+        val isOrientationInPortrait = rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180
+        if (this.isOrientationInPortrait != isOrientationInPortrait) {
+            isRestartingForOrientationChange = true
+            logger.info(TAG, "Orientation changed from ${if (this.isOrientationInPortrait) "portrait" else "landscape"} " +
+                "to ${if (isOrientationInPortrait) "portrait" else "landscape"}, restarting screen capture to update dimensions")
+            // Post this task to avoid deadlock with the surface texture source handler
+            handler.post {
+                // Double check that start or stop hasn't been called since this was posted
+                if (isRestartingForOrientationChange) {
+                    stopInternal()
+                    startInternal()
+                    isRestartingForOrientationChange = false
+                }
+            }
+            return
+        }
+
+        // Ignore frames while we are recreating the surface and display
+        if (isRestartingForOrientationChange) return
+        sinks.forEach { it.onVideoFrameReceived(frame) }
+    }
+
+    fun release() {
+        runBlocking(handler.asCoroutineDispatcher().immediate) {
+            logger.info(TAG, "Stopping handler looper")
+            handler.removeCallbacksAndMessages(null)
+            handler.looper.quit()
+        }
+    }
+
+    // A combination of hardcoded methods to try to obtain or estimate the status bar height
+    private fun getStatusBarHeight(): Int {
+        val resources: Resources = context.resources
+        val resourceId: Int = resources.getIdentifier("status_bar_height", "dimen", "android")
+        return if (resourceId > 0) {
+            resources.getDimensionPixelSize(resourceId)
+        } else {
+            ceil((if (VERSION.SDK_INT >= VERSION_CODES.M) 24 else 25) * resources.displayMetrics.density).toInt()
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
@@ -198,7 +198,7 @@ class DefaultSurfaceTextureCaptureSource(
         frame.release()
 
         // If we have min FPS set, check in a while if we should resend the previous frame
-        if (minFps != 0) {
+        if (minFps > 0) {
             lastAlignedTimestamp = alignedTimestamp
             val resendDelayMs = RESEND_DELAY_BUFFER_MS + (1f / minFps) * 1000
             handler.postDelayed({

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/SurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/SurfaceTextureCaptureSource.kt
@@ -25,6 +25,17 @@ interface SurfaceTextureCaptureSource : VideoCaptureSource {
     val surface: Surface
 
     /**
+     * Setting this to a non-null value will lead the source to resend previously captured frames
+     * as necessary to approximately maintain the set value.
+     *
+     * This is useful for applications like screen capture where the system does not capture when
+     * there is no motion on screen.  Continuing to send frames helps the encoder improve the quality
+     * on the receive end, and also helps mitigate possible issues with downstream frame throttling
+     * dropping frames before the end of an animation.
+     */
+    var minFps: Int
+
+    /**
      * Deallocate any state or resources held by this object. Not possible to reuse after call. Surface
      * will have been released.
      */

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/SurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/SurfaceTextureCaptureSource.kt
@@ -25,12 +25,12 @@ interface SurfaceTextureCaptureSource : VideoCaptureSource {
     val surface: Surface
 
     /**
-     * Setting this to a non-null value will lead the source to resend previously captured frames
+     * Setting this to a positive value will lead the source to resend previously captured frames
      * as necessary to approximately maintain the set value.
      *
      * This is useful for applications like screen capture where the system does not capture when
-     * there is no motion on screen.  Continuing to send frames helps the encoder improve the quality
-     * on the receive end, and also helps mitigate possible issues with downstream frame throttling
+     * there is no motion on screen. Continuing to send frames helps the encoder improve the quality
+     * on the receiving end, and also helps mitigate possible issues with downstream frame throttling
      * dropping frames before the end of an animation.
      */
     var minFps: Int

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+
+/**
+ * [ContentShareVideoClientController] uses a separate video client for content share video related
+ * functionality.
+ */
+interface ContentShareVideoClientController {
+    /**
+     * Start to share video with a provided custom [VideoSource] which can be used to provide custom
+     * [VideoFrame]s to be transmitted to remote clients. This will call [VideoSource.addVideoSink]
+     * on the provided source.
+     *
+     * Calling this function repeatedly will replace the previous [VideoSource] as the one being
+     * transmitted.
+     *
+     * @param videoSource: [VideoSource] - The source of video frames to be sent to other clients.
+     */
+    fun startVideoShare(videoSource: VideoSource)
+
+    /**
+     * Stop sending video to remote clients, this will call [VideoSource.removeVideoSink]
+     * on the previously provided source.
+     */
+    fun stopVideoShare()
+
+    /**
+     * Subscribe to video client state and connection events with an [ContentShareObserver]
+     *
+     * @param observer: [ContentShareObserver] - The observer to be notified for events.
+     */
+    fun subscribeToVideoClientStateChange(observer: ContentShareObserver)
+
+    /**
+     * Unsubscribe from video client state and connection events by removing the specified [ContentShareObserver]
+     *
+     * @param observer: [ContentShareObserver] - The observer to be removed for events.
+     */
+    fun unsubscribeFromVideoClientStateChange(observer: ContentShareObserver)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
@@ -17,7 +17,7 @@ interface ContentShareVideoClientController {
     /**
      * Start to share video with a provided custom [VideoSource] which can be used to provide custom
      * [VideoFrame]s to be transmitted to remote clients. This will call [VideoSource.addVideoSink]
-     * on the provided source.
+     * on the provided source and [VideoSource.removeVideoSink] on the previously provided source.
      *
      * Calling this function repeatedly will replace the previous [VideoSource] as the one being
      * transmitted.
@@ -27,8 +27,7 @@ interface ContentShareVideoClientController {
     fun startVideoShare(videoSource: VideoSource)
 
     /**
-     * Stop sending video to remote clients, this will call [VideoSource.removeVideoSink]
-     * on the previously provided source.
+     * Stop sending video to remote clients.
      */
     fun stopVideoShare()
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientObserver.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.xodee.client.video.VideoClientDelegate
+import com.xodee.client.video.VideoClientLogListener
+
+/**
+ * [ContentShareVideoClientObserver] handles all callbacks related to the separate video client
+ * for content share and allows higher level components to observe the lower level Video Client events.
+ */
+interface ContentShareVideoClientObserver : VideoClientDelegate, VideoClientLogListener {
+
+    /**
+     * Subscribe to video client state and connection events with an [ContentShareObserver]
+     *
+     * @param observer: [ContentShareObserver] - The observer to subscribe to events with.
+     */
+    fun subscribeToVideoClientStateChange(observer: ContentShareObserver)
+
+    /**
+     * Unsubscribe from video client state and connection events by removing the specified [ContentShareObserver]
+     *
+     * @param observer: [ContentShareObserver] - The observer to unsubscribe from events with.
+     */
+    fun unsubscribeFromVideoClientStateChange(observer: ContentShareObserver)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
+
+import android.content.Context
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
+import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientFactory
+import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoSourceAdapter
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.xodee.client.video.VideoClient
+
+class DefaultContentShareVideoClientController(
+    private val context: Context,
+    private val logger: Logger,
+    private val contentShareVideoClientObserver: ContentShareVideoClientObserver,
+    private val configuration: MeetingSessionConfiguration,
+    private val videoClientFactory: VideoClientFactory,
+    private val eglCoreFactory: EglCoreFactory
+) : ContentShareVideoClientController {
+    private val observers = mutableSetOf<ContentShareObserver>()
+    private val videoSourceAdapter = VideoSourceAdapter()
+    private var videoClient: VideoClient? = null
+    private var eglCore: EglCore? = null
+    private var isSharing = false
+
+    private val TAG = "DefaultContentShareVideoClientController"
+
+    private val VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER = 1 shl 6
+    private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 1 shl 12
+    private val VIDEO_CLIENT_FLAG_DISABLE_CAPTURER = 1 shl 20
+    private val VIDEO_CLIENT_FLAG_IS_CONTENT = 1 shl 23
+
+    override fun startVideoShare(videoSource: VideoSource) {
+        // Stop sharing the current source
+        if (isSharing) {
+            stopVideoShare()
+        }
+
+        // Start the given content share source
+        if (eglCore == null) {
+            logger.debug(TAG, "Creating EGL core")
+            eglCore = eglCoreFactory.createEglCore()
+        }
+
+        if (videoClient == null) {
+            initializeVideoClient()
+        }
+
+        if (!startVideoClient()) {
+            ObserverUtils.notifyObserverOnMainThread(observers) {
+                it.onContentShareStopped(
+                    ContentShareStatus(
+                        ContentShareStatusCode.VideoServiceFailed
+                    )
+                )
+            }
+            return
+        }
+
+        logger.debug(TAG, "Setting external video source to content share source")
+        videoSourceAdapter.source = videoSource
+        videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
+        logger.debug(TAG, "Setting sending to true")
+        videoClient?.setSending(true)
+        isSharing = true
+    }
+
+    private fun initializeVideoClient() {
+        logger.info(TAG, "Initializing content share video client")
+        AppInfoUtil.initializeVideoClientAppDetailedInfo(context)
+        // Thread safe operation, can be called multiple times
+        VideoClient.javaInitializeGlobals(context)
+        videoClient = videoClientFactory.getVideoClient(contentShareVideoClientObserver)
+        // Content share is send only
+        videoClient?.setReceiving(false)
+    }
+
+    private fun startVideoClient(): Boolean {
+        logger.info(TAG, "Starting content share video client for content share")
+        var flag = 0
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
+        flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER
+        flag = flag or VIDEO_CLIENT_FLAG_IS_CONTENT
+        val result = videoClient?.javaStartServiceV3(
+            "",
+            "",
+            configuration.meetingId,
+            configuration.credentials.joinToken,
+            false,
+            0,
+            flag,
+            eglCore?.eglContext
+        ) ?: false
+        logger.info(TAG, "Content share video client start result: $result")
+        return result
+    }
+
+    override fun stopVideoShare() {
+        logger.info(TAG, "Stopping content share video client")
+        videoClient?.javaStopService()
+        videoClient?.destroy()
+        videoClient = null
+
+        isSharing = false
+        eglCore?.release()
+        eglCore = null
+    }
+
+    override fun subscribeToVideoClientStateChange(observer: ContentShareObserver) {
+        observers.add(observer)
+        contentShareVideoClientObserver.subscribeToVideoClientStateChange(observer)
+    }
+
+    override fun unsubscribeFromVideoClientStateChange(observer: ContentShareObserver) {
+        observers.remove(observer)
+        contentShareVideoClientObserver.unsubscribeFromVideoClientStateChange(observer)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -42,30 +42,28 @@ class DefaultContentShareVideoClientController(
     private val VIDEO_CLIENT_FLAG_IS_CONTENT = 1 shl 23
 
     override fun startVideoShare(videoSource: VideoSource) {
-        // Stop sharing the current source
-        if (isSharing) {
-            stopVideoShare()
-        }
-
         // Start the given content share source
         if (eglCore == null) {
             logger.debug(TAG, "Creating EGL core")
             eglCore = eglCoreFactory.createEglCore()
         }
 
-        if (videoClient == null) {
-            initializeVideoClient()
-        }
-
-        if (!startVideoClient()) {
-            ObserverUtils.notifyObserverOnMainThread(observers) {
-                it.onContentShareStopped(
-                    ContentShareStatus(
-                        ContentShareStatusCode.VideoServiceFailed
-                    )
-                )
+        // Start video client only when not currently sharing
+        if (!isSharing) {
+            if (videoClient == null) {
+                initializeVideoClient()
             }
-            return
+
+            if (!startVideoClient()) {
+                ObserverUtils.notifyObserverOnMainThread(observers) {
+                    it.onContentShareStopped(
+                        ContentShareStatus(
+                            ContentShareStatusCode.VideoServiceFailed
+                        )
+                    )
+                }
+                return
+            }
         }
 
         logger.debug(TAG, "Setting external video source to content share source")

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
+import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.TURNRequestUtils
+import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNCredentials
+import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNRequestParams
+import com.amazonaws.services.chime.sdk.meetings.session.URLRewriter
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.video.VideoClient
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class DefaultContentShareVideoClientObserver(
+    private val logger: Logger,
+    private val turnRequestParams: TURNRequestParams,
+    private val clientMetricsCollector: ClientMetricsCollector,
+    private val urlRewriter: URLRewriter
+) : ContentShareVideoClientObserver {
+    private val TAG = "DefaultContentShareVideoClientObserver"
+
+    private val contentShareObservers = mutableSetOf<ContentShareObserver>()
+
+    private val uiScope = CoroutineScope(Dispatchers.Main)
+
+    override fun subscribeToVideoClientStateChange(observer: ContentShareObserver) {
+        contentShareObservers.add(observer)
+    }
+
+    override fun unsubscribeFromVideoClientStateChange(observer: ContentShareObserver) {
+        contentShareObservers.remove(observer)
+    }
+
+    override fun isConnecting(client: VideoClient?) {
+        logger.debug(TAG, "content share video client is connecting")
+    }
+
+    override fun didConnect(client: VideoClient?, controlStatus: Int) {
+        logger.debug(TAG, "content share video client is connected")
+        ObserverUtils.notifyObserverOnMainThread(contentShareObservers) {
+            it.onContentShareStarted()
+        }
+    }
+
+    override fun didFail(client: VideoClient?, status: Int, controlStatus: Int) {
+        logger.info(TAG, "content share video client is failed with $controlStatus")
+        resetContentShareVideoClientMetrics()
+        ObserverUtils.notifyObserverOnMainThread(contentShareObservers) {
+            it.onContentShareStopped(
+                ContentShareStatus(
+                    ContentShareStatusCode.VideoServiceFailed
+                )
+            )
+        }
+    }
+
+    override fun didStop(client: VideoClient?) {
+        logger.info(TAG, "content share video client is stopped")
+        resetContentShareVideoClientMetrics()
+        ObserverUtils.notifyObserverOnMainThread(contentShareObservers) {
+            it.onContentShareStopped(
+                ContentShareStatus(
+                    ContentShareStatusCode.OK
+                )
+            )
+        }
+    }
+
+    override fun requestTurnCreds(client: VideoClient?) {
+        logger.info(TAG, "requestTurnCreds")
+        uiScope.launch {
+            val turnResponse: TURNCredentials? = TURNRequestUtils.doTurnRequest(turnRequestParams, logger)
+            with(turnResponse) {
+                val isActive = client?.isActive ?: false
+                if (this != null && isActive) {
+                    val newUris = uris.map { url ->
+                        url?.let {
+                            urlRewriter(it)
+                        }
+                    }.toTypedArray()
+                    client?.updateTurnCredentials(
+                        username,
+                        password,
+                        ttl,
+                        newUris,
+                        turnRequestParams.signalingUrl,
+                        VideoClient.VideoClientTurnStatus.VIDEO_CLIENT_TURN_FEATURE_ON
+                    )
+                } else {
+                    client?.updateTurnCredentials(
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        VideoClient.VideoClientTurnStatus.VIDEO_CLIENT_TURN_STATUS_CCP_FAILURE
+                    )
+                }
+            }
+        }
+    }
+
+    override fun getAvailableDnsServers(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun onCameraChanged() {
+        // No implementation since we don't use default camera for content share
+    }
+
+    override fun onMetrics(metrics: IntArray?, values: DoubleArray?) {
+        if (metrics == null || values == null) return
+
+        val metricMap = mutableMapOf<Int, Double>()
+        (metrics.indices).map { i -> metricMap[metrics[i]] = values[i] }
+        clientMetricsCollector.processContentShareVideoClientMetrics(metricMap)
+    }
+
+    private fun resetContentShareVideoClientMetrics() {
+        clientMetricsCollector.processContentShareVideoClientMetrics(emptyMap())
+    }
+
+    override fun cameraSendIsAvailable(client: VideoClient?, available: Boolean) {
+        // No implementation since we don't use default camera for content share
+    }
+
+    override fun didReceiveFrame(
+        client: VideoClient?,
+        frame: Any?,
+        profileId: String?,
+        displayId: Int,
+        pauseType: Int,
+        videoId: Int
+    ) {
+        // No implementation since content share is send only and we don't use this path for local rendering
+    }
+
+    override fun pauseRemoteVideo(client: VideoClient?, display_id: Int, pause: Boolean) {
+        // No implementation since content share is send only and we don't get any remote video
+    }
+
+    override fun onLogMessage(logLevel: Int, message: String?) {
+        if (message == null) return
+        // Only print error and fatal as the Media team's request to avoid noise for application
+        // that has log level set to INFO or higher. All other cases, print as verbose
+        if (logLevel == AudioClient.L_ERROR || logLevel == AudioClient.L_FATAL) {
+            logger.error(TAG, message)
+        } else {
+            logger.verbose(TAG, message)
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/ClientMetricsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/ClientMetricsCollector.kt
@@ -29,6 +29,14 @@ interface ClientMetricsCollector {
     fun processVideoClientMetrics(metrics: Map<Int, Double>)
 
     /**
+     * Collect the raw content share video client metrics and filter observable metrics for eventual
+     * callback to the observer
+     *
+     * @param metrics: Map<Int, Double> - Map of raw content share video client metric to value
+     */
+    fun processContentShareVideoClientMetrics(metrics: Map<Int, Double>)
+
+    /**
      * Subscribe to metric events with an [MetricsObserver].
      *
      * @param observer: [MetricsObserver] - The observer to subscribe to metrics with.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollector.kt
@@ -51,6 +51,19 @@ class DefaultClientMetricsCollector :
         maybeEmitMetrics()
     }
 
+    override fun processContentShareVideoClientMetrics(metrics: Map<Int, Double>) {
+        // Currently, content share is send-only
+        cachedObservableMetrics[ObservableMetric.contentShareVideoSendBitrate] =
+            metrics[VideoClient.VIDEO_SEND_BITRATE]
+        cachedObservableMetrics[ObservableMetric.contentShareVideoSendPacketLossPercent] =
+            metrics[VideoClient.VIDEO_SEND_PACKET_LOSS_PERCENT]
+        cachedObservableMetrics[ObservableMetric.contentShareVideoSendFps] =
+            metrics[VideoClient.VIDEO_SEND_FPS]
+        cachedObservableMetrics[ObservableMetric.contentShareVideoSendRttMs] =
+            metrics[VideoClient.VIDEO_SEND_RTT]
+        maybeEmitMetrics()
+    }
+
     private fun maybeEmitMetrics() {
         val now = Calendar.getInstance().timeInMillis
         if (cachedObservableMetrics.isNotEmpty() && now - lastEmittedMetricsTime > METRICS_EMISSION_INTERVAL_MS) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import android.content.Context
+import com.amazonaws.services.chime.sdk.BuildConfig
+import com.xodee.client.video.VideoClient
+
+object AppInfoUtil {
+    fun initializeVideoClientAppDetailedInfo(context: Context) {
+        val manufacturer = android.os.Build.MANUFACTURER
+        val model = android.os.Build.MODEL
+        val osVersion = android.os.Build.VERSION.RELEASE
+        val packageName = context.packageName
+        val packageInfo = context.packageManager.getPackageInfo(packageName, 0)
+        val appVer = packageInfo.versionName
+        val appCode = packageInfo.versionCode.toString()
+        val clientSource = "amazon-chime-sdk"
+        val sdkVersion = BuildConfig.VERSION_NAME
+
+        VideoClient.AppDetailedInfo.initialize(
+            String.format("Android %s", appVer),
+            appCode,
+            model,
+            manufacturer,
+            osVersion,
+            clientSource,
+            sdkVersion
+        )
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TURNRequestUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TURNRequestUtils.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNCredentials
+import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNRequestParams
+import com.amazonaws.services.chime.sdk.meetings.utils.DefaultModality
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+object TURNRequestUtils {
+    private val TOKEN_HEADER = "X-Chime-Auth-Token"
+    private val SYSPROP_USER_AGENT = "http.agent"
+    private val USER_AGENT_HEADER = "User-Agent"
+    private val CONTENT_TYPE_HEADER = "Content-Type"
+    private val CONTENT_TYPE = "application/json"
+    private val MEETING_ID_KEY = "meetingId"
+    private val TOKEN_KEY = "_aws_wt_session"
+
+    private val TAG = "TURNRequestUtils"
+
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+
+    suspend fun doTurnRequest(turnRequestParams: TURNRequestParams, logger: Logger): TURNCredentials? {
+        return withContext(ioDispatcher) {
+            try {
+                val response = StringBuffer()
+                logger.info(TAG, "Making TURN Request")
+                with(URL(turnRequestParams.turnControlUrl).openConnection() as HttpURLConnection) {
+                    requestMethod = "POST"
+                    doInput = true
+                    doOutput = true
+                    addRequestProperty(TOKEN_HEADER, "$TOKEN_KEY=${DefaultModality(turnRequestParams.joinToken).base()}")
+                    setRequestProperty(CONTENT_TYPE_HEADER, CONTENT_TYPE)
+                    val user_agent = System.getProperty(SYSPROP_USER_AGENT)
+                    logger.info(TAG, "User Agent while doing TURN request is $user_agent")
+                    setRequestProperty(USER_AGENT_HEADER, user_agent)
+                    val out = BufferedWriter(OutputStreamWriter(outputStream))
+                    out.write(
+                        JSONObject().put(
+                            MEETING_ID_KEY,
+                            turnRequestParams.meetingId
+                        ).toString()
+                    )
+                    out.flush()
+                    out.close()
+                    BufferedReader(InputStreamReader(inputStream)).use {
+                        var inputLine = it.readLine()
+                        while (inputLine != null) {
+                            response.append(inputLine)
+                            inputLine = it.readLine()
+                        }
+                        it.close()
+                    }
+                    if (responseCode == 200) {
+                        logger.info(TAG, "TURN Request Success")
+                        var responseObject = JSONObject(response.toString())
+                        val jsonArray =
+                            responseObject.getJSONArray(TURNCredentials.TURN_CREDENTIALS_RESULT_URIS)
+                        val uris = arrayOfNulls<String>(jsonArray.length())
+                        for (i in 0 until jsonArray.length()) {
+                            uris[i] = jsonArray.getString(i)
+                        }
+                        TURNCredentials(
+                            responseObject.getString(TURNCredentials.TURN_CREDENTIALS_RESULT_USERNAME),
+                            responseObject.getString(TURNCredentials.TURN_CREDENTIALS_RESULT_PASSWORD),
+                            responseObject.getString(TURNCredentials.TURN_CREDENTIALS_RESULT_TTL),
+                            uris
+                        )
+                    } else {
+                        logger.error(
+                            TAG,
+                            "TURN Request got error with Response code: $responseCode"
+                        )
+                        null
+                    }
+                }
+            } catch (exception: Exception) {
+                logger.error(TAG, "Exception while doing TURN Request: $exception")
+                null
+            }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientFactory.kt
@@ -5,10 +5,20 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
+import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.ContentShareVideoClientObserver
 import com.xodee.client.video.VideoClient
+import com.xodee.client.video.VideoClientDataMessageListener
 
 class DefaultVideoClientFactory : VideoClientFactory {
     override fun getVideoClient(videoClientObserver: VideoClientObserver): VideoClient {
         return VideoClient(videoClientObserver, videoClientObserver, videoClientObserver)
+    }
+
+    override fun getVideoClient(contentShareVideoClientObserver: ContentShareVideoClientObserver): VideoClient {
+        return VideoClient(
+            contentShareVideoClientObserver,
+            contentShareVideoClientObserver,
+            VideoClientDataMessageListener { Unit }
+        )
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientFactory.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
+import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.ContentShareVideoClientObserver
 import com.xodee.client.video.VideoClient
 
 interface VideoClientFactory {
@@ -14,4 +15,11 @@ interface VideoClientFactory {
      * @param videoClientObserver: [VideoClientObserver] - observer for video client
      */
     fun getVideoClient(videoClientObserver: VideoClientObserver): VideoClient
+
+    /**
+     * Get a [VideoClient]
+     *
+     * @param contentShareVideoClientObserver: [ContentShareVideoClientObserver] - observer for video client
+     */
+    fun getVideoClient(contentShareVideoClientObserver: ContentShareVideoClientObserver): VideoClient
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientObserver.kt
@@ -18,6 +18,7 @@ import com.xodee.client.video.VideoClientLogListener
  */
 interface VideoClientObserver : VideoClientDelegate, VideoClientLogListener,
     VideoClientDataMessageListener {
+
     /**
      * Subscribe to audio, video, and connection events with an [AudioVideoObserver].
      *

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
@@ -15,6 +15,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFr
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
 import java.nio.ByteBuffer
 import java.security.InvalidParameterException
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * [VideoSourceAdapter] provides two classes to adapt [VideoSource] to [com.xodee.client.video.VideoSource].
@@ -72,7 +73,11 @@ class VideoSourceAdapter : VideoSink,
             source?.addVideoSink(this)
         }
 
-    private var sinks = mutableSetOf<com.xodee.client.video.VideoSink>()
+    // Concurrency modification could happen when source gets
+    // removed from media server (media thread) while sending frames (app thread).
+    // Use the CopyOnWriteArrayList as its thread-safe and suits reading more than
+    // updating scenario.
+    private var sinks = CopyOnWriteArrayList<com.xodee.client.video.VideoSink>()
 
     override fun addSink(sink: com.xodee.client.video.VideoSink) {
         sinks.add(sink)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
@@ -80,6 +80,7 @@ class VideoSourceAdapter : VideoSink,
     private var sinks = CopyOnWriteArrayList<com.xodee.client.video.VideoSink>()
 
     override fun addSink(sink: com.xodee.client.video.VideoSink) {
+        if (sinks.contains(sink)) return
         sinks.add(sink)
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
@@ -5,6 +5,9 @@
 
 package com.amazonaws.services.chime.sdk.meetings.session
 
+import com.amazonaws.services.chime.sdk.meetings.utils.DefaultModality
+import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
+
 /**
  * [MeetingSessionConfiguration] includes information needed to start the meeting session such as
  * attendee credentials and URLs for audio and video
@@ -37,4 +40,17 @@ data class MeetingSessionConfiguration(
             urlRewriter
         )
     )
+
+    fun createContentShareMeetingSessionConfiguration(): MeetingSessionConfiguration {
+        val contentModality: String = DefaultModality.MODALITY_SEPARATOR + ModalityType.Content.value
+        return MeetingSessionConfiguration(
+            meetingId,
+            MeetingSessionCredentials(
+                credentials.attendeeId + contentModality,
+                credentials.externalUserId,
+                credentials.joinToken + contentModality
+            ),
+            urls
+        )
+    }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/DefaultModality.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/DefaultModality.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.utils
+
+/**
+ * [DefaultModality] is a backwards compatible extension of the
+ * attendee id (UUID string) and session token schemas (base 64 string).
+ * It appends #<modality> to either strings, which indicates the modality
+ * of the participant.
+ *
+ * For example,
+ * attendeeId: "abcdefg"
+ * contentAttendeeId: "abcdefg#content"
+ * base(contentAttendeeId): "abcdefg"
+ * modality(contentAttendeeId): "content"
+ * hasModality(contentAttendeeId): true
+ */
+class DefaultModality(private val id: String) {
+
+    companion object {
+        const val MODALITY_SEPARATOR = "#"
+    }
+
+    /**
+     * The Id
+     */
+    fun id(): String {
+        return id
+    }
+
+    /**
+     * The base of the Id
+     */
+    fun base(): String {
+        if (id.isEmpty()) {
+            return ""
+        }
+        return id.split(MODALITY_SEPARATOR)[0]
+    }
+
+    /**
+     * The modality of the Id
+     */
+    fun modality(): ModalityType? {
+        if (id.isEmpty()) {
+            return null
+        }
+        val components = id.split(MODALITY_SEPARATOR)
+        return if (components.size == 2) ModalityType.fromValue(components[1]) else null
+    }
+
+    /**
+     * Check whether the current Id contains the input modality
+     */
+    fun hasModality(modality: ModalityType): Boolean {
+        return modality() == modality
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/ModalityType.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/utils/ModalityType.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.utils
+
+enum class ModalityType(val value: String) {
+    Content("content");
+
+    companion object {
+        fun fromValue(value: String): ModalityType? = values().find { it.value == value }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -8,6 +8,9 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo
 import android.content.Context
 import androidx.core.content.ContextCompat
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileController
 import com.amazonaws.services.chime.sdk.meetings.device.DeviceChangeObserver
@@ -21,6 +24,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import io.mockk.mockkClass
 import io.mockk.mockkStatic
 import io.mockk.verify
 import org.junit.Assert.assertEquals
@@ -57,6 +61,9 @@ class DefaultAudioVideoFacadeTest {
     private lateinit var mockMetricsObserver: MetricsObserver
 
     @MockK
+    private lateinit var mockContentShareObserver: ContentShareObserver
+
+    @MockK
     private lateinit var context: Context
 
     @MockK
@@ -73,6 +80,9 @@ class DefaultAudioVideoFacadeTest {
 
     @MockK
     private lateinit var activeSpeakerDetector: ActiveSpeakerDetectorFacade
+
+    @MockK
+    private lateinit var contentShareController: ContentShareController
 
     @InjectMockKs
     private lateinit var audioVideoFacade: DefaultAudioVideoFacade
@@ -250,5 +260,35 @@ class DefaultAudioVideoFacadeTest {
         audioVideoFacade.switchCamera()
 
         verify { deviceController.switchCamera() }
+    }
+
+    @Test
+    fun `startContentShare should call contentShareController startContentShare`() {
+        val source = mockkClass(ContentShareSource::class)
+
+        audioVideoFacade.startContentShare(source)
+
+        verify { contentShareController.startContentShare(source) }
+    }
+
+    @Test
+    fun `stopContentShare should call contentShareController stopContentShare`() {
+        audioVideoFacade.stopContentShare()
+
+        verify { contentShareController.stopContentShare() }
+    }
+
+    @Test
+    fun `addContentShareObserver should call deviceController addContentShareObserver with given observer`() {
+        audioVideoFacade.addContentShareObserver(mockContentShareObserver)
+
+        verify { contentShareController.addContentShareObserver(mockContentShareObserver) }
+    }
+
+    @Test
+    fun `removeContentShareObserver should call deviceController removeContentShareObserver with given observer`() {
+        audioVideoFacade.removeContentShareObserver(mockContentShareObserver)
+
+        verify { contentShareController.removeContentShareObserver(mockContentShareObserver) }
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareControllerTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.ContentShareVideoClientController
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class DefaultContentShareControllerTest {
+    @MockK
+    private lateinit var videoSource: VideoSource
+
+    @MockK
+    private lateinit var contentShareObserver: ContentShareObserver
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var contentShareVideoClientController: ContentShareVideoClientController
+
+    @InjectMockKs
+    private lateinit var contentShareController: DefaultContentShareController
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+    }
+
+    @Test
+    fun `startContentShare should call contentShareVideoClientController startVideoShare when video source is available`() {
+        val contentShareSource = ContentShareSource()
+        contentShareSource.videoSource = videoSource
+
+        contentShareController.startContentShare(contentShareSource)
+
+        verify(exactly = 1) { contentShareVideoClientController.startVideoShare(videoSource) }
+    }
+
+    @Test
+    fun `startContentShare should not call contentShareVideoClientController startVideoShare when video source is null`() {
+        val contentShareSource = ContentShareSource()
+
+        contentShareController.startContentShare(contentShareSource)
+
+        verify(exactly = 0) { contentShareVideoClientController.startVideoShare(any()) }
+    }
+
+    @Test
+    fun `stopContentShare should call contentShareVideoClientController stopVideoShare`() {
+        contentShareController.stopContentShare()
+
+        verify(exactly = 1) { contentShareVideoClientController.stopVideoShare() }
+    }
+
+    @Test
+    fun `addContentShareObserver should call contentShareVideoClientController subscribeToVideoClientStateChange with given observer`() {
+        contentShareController.addContentShareObserver(contentShareObserver)
+
+        verify(exactly = 1) { contentShareVideoClientController.subscribeToVideoClientStateChange(contentShareObserver) }
+    }
+
+    @Test
+    fun `removeContentShareObserver should call contentShareVideoClientController unsubscribeFromVideoClientStateChange with given observer`() {
+        contentShareController.removeContentShareObserver(contentShareObserver)
+
+        verify(exactly = 1) { contentShareVideoClientController.unsubscribeFromVideoClientStateChange(contentShareObserver) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/metric/ObservableMetricTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/metric/ObservableMetricTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.metric
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ObservableMetricTest {
+    @Test
+    fun `isContentShareMetric should return expected values`() {
+        assertTrue(ObservableMetric.contentShareVideoSendBitrate.isContentShareMetric())
+        assertFalse(ObservableMetric.videoSendBitrate.isContentShareMetric())
+        assertTrue(ObservableMetric.contentShareVideoSendFps.isContentShareMetric())
+        assertFalse(ObservableMetric.videoSendFps.isContentShareMetric())
+        assertTrue(ObservableMetric.contentShareVideoSendPacketLossPercent.isContentShareMetric())
+        assertFalse(ObservableMetric.videoSendPacketLossPercent.isContentShareMetric())
+        assertTrue(ObservableMetric.contentShareVideoSendRttMs.isContentShareMetric())
+        assertFalse(ObservableMetric.videoSendRttMs.isContentShareMetric())
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSourceTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSourceTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture
+
+import android.content.Context
+import android.content.Intent
+import android.hardware.display.DisplayManager
+import android.hardware.display.VirtualDisplay
+import android.media.projection.MediaProjection
+import android.media.projection.MediaProjectionManager
+import android.os.Handler
+import android.os.HandlerThread
+import android.os.Looper
+import android.view.Display
+import android.view.Surface
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSink
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class DefaultScreenCaptureSourceTest {
+
+    @MockK(relaxed = true)
+    private lateinit var mockContext: Context
+
+    @MockK
+    private lateinit var mockLogger: Logger
+
+    @MockK
+    private lateinit var mockSurfaceTextureCaptureSourceFactory: SurfaceTextureCaptureSourceFactory
+
+    @MockK(relaxed = true)
+    private lateinit var mockDisplayManager: DisplayManager
+
+    @MockK
+    private lateinit var mockMediaProjectionManager: MediaProjectionManager
+
+    private var activityResult = 1
+
+    @MockK
+    private lateinit var mockActivityData: Intent
+
+    @InjectMockKs
+    private lateinit var testScreenCaptureSource: DefaultScreenCaptureSource
+
+    private lateinit var mockLooper: Looper
+
+    @MockK(relaxed = true)
+    private lateinit var mockSurfaceTextureCaptureSource: SurfaceTextureCaptureSource
+
+    @MockK
+    private lateinit var mockVideoSink: VideoSink
+
+    @MockK
+    private lateinit var mockMediaProjection: MediaProjection
+
+    @MockK
+    private lateinit var mockVirtualDisplay: VirtualDisplay
+
+    @MockK
+    private lateinit var mockCaptureSourceObserver: CaptureSourceObserver
+
+    @MockK
+    private lateinit var mockFrame: VideoFrame
+
+    @MockK
+    private lateinit var mockDisplay: Display
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setUp() {
+        mockLooper = mockk()
+        mockkConstructor(HandlerThread::class)
+        every { anyConstructed<HandlerThread>().looper } returns mockLooper
+        mockkConstructor(Handler::class)
+        every { anyConstructed<Handler>().looper } returns mockLooper
+        val slot = slot<Runnable>()
+        every { anyConstructed<Handler>().post(capture(slot)) } answers {
+            slot.captured.run()
+            true
+        }
+        mockkStatic(Looper::class)
+        every { Looper.myLooper() } returns mockLooper
+
+        Dispatchers.setMain(testDispatcher)
+
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every { mockSurfaceTextureCaptureSourceFactory.createSurfaceTextureCaptureSource(any(), any(), any()) } returns mockSurfaceTextureCaptureSource
+        every { mockContext.getSystemService(Context.DISPLAY_SERVICE) } returns mockDisplayManager
+        every { mockContext.getSystemService(Context.MEDIA_PROJECTION_SERVICE) } returns mockMediaProjectionManager
+        every { mockMediaProjectionManager.getMediaProjection(1, mockActivityData) } returns mockMediaProjection
+        every { mockMediaProjection.createVirtualDisplay(any(), any(), any(), any(), any(), any(), any(), any()) } returns mockVirtualDisplay
+        every { mockDisplayManager.getDisplay(Display.DEFAULT_DISPLAY) } returns mockDisplay
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `start will notify subscribed observers of onCaptureStarted event`() {
+        every { mockDisplay.rotation } returns Surface.ROTATION_0
+        testScreenCaptureSource.addCaptureSourceObserver(mockCaptureSourceObserver)
+
+        testScreenCaptureSource.start()
+
+        verify(exactly = 1) { mockCaptureSourceObserver.onCaptureStarted() }
+    }
+
+    @Test
+    fun `stop will notify subscribed observers of onCaptureStopped event`() {
+        testScreenCaptureSource.addCaptureSourceObserver(mockCaptureSourceObserver)
+
+        testScreenCaptureSource.stop()
+
+        verify(exactly = 1) { mockCaptureSourceObserver.onCaptureStopped() }
+    }
+
+    @Test
+    fun `restarting for rotation will not notify subscribed observers of events`() {
+        every { mockDisplay.rotation } returns Surface.ROTATION_90
+
+        testScreenCaptureSource.onVideoFrameReceived(mockFrame)
+
+        verify(exactly = 1) { mockMediaProjection.stop() }
+        verify(exactly = 1) { mockMediaProjectionManager.getMediaProjection(1, mockActivityData) }
+        verify(exactly = 0) { mockCaptureSourceObserver.onCaptureStopped() }
+        verify(exactly = 0) { mockCaptureSourceObserver.onCaptureStarted() }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
@@ -106,14 +106,13 @@ class DefaultContentShareVideoClientControllerTest {
     }
 
     @Test
-    fun `startVideoShare should call VideoClientStateController stopService first when is sharing`() {
+    fun `startVideoShare should not call VideoClientStateController startService again when is sharing`() {
         every { mockVideoClient.start(any()) } returns true
         testContentShareVideoClientController.startVideoShare(mockVideoSource)
 
         testContentShareVideoClientController.startVideoShare(mockVideoSource)
 
-        verify(exactly = 2) { mockVideoClient.start(any()) }
-        verify(exactly = 1) { mockVideoClient.javaStopService() }
+        verify(exactly = 1) { mockVideoClient.start(any()) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
+
+import android.content.Context
+import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
+import com.amazonaws.services.chime.sdk.meetings.internal.video.DefaultVideoClientFactory
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.xodee.client.video.VideoClient
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class DefaultContentShareVideoClientControllerTest {
+
+    @MockK
+    private lateinit var mockContext: Context
+
+    @MockK
+    private lateinit var mockLogger: Logger
+
+    @MockK
+    private lateinit var mockContentShareVideoClientObserver: DefaultContentShareVideoClientObserver
+
+    @MockK(relaxed = true)
+    private lateinit var mockConfiguration: MeetingSessionConfiguration
+
+    @MockK
+    private lateinit var mockVideoClient: VideoClient
+
+    @MockK
+    private lateinit var mockVideoClientFactory: DefaultVideoClientFactory
+
+    @MockK
+    private lateinit var mockEglCoreFactory: EglCoreFactory
+
+    @MockK(relaxed = true)
+    private lateinit var mockEglCore: EglCore
+
+    @InjectMockKs
+    private lateinit var testContentShareVideoClientController: DefaultContentShareVideoClientController
+
+    @MockK
+    private lateinit var mockVideoSource: VideoSource
+
+    @MockK
+    private lateinit var mockContentShareObserver: ContentShareObserver
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    @Before
+    fun setUp() {
+        mockkStatic(System::class, Log::class, VideoClient::class)
+        every { Log.d(any(), any()) } returns 0
+        every { System.loadLibrary(any()) } just runs
+        every { VideoClient.javaInitializeGlobals(any()) } returns true
+        mockkObject(AppInfoUtil)
+        every { AppInfoUtil.initializeVideoClientAppDetailedInfo(any()) } just runs
+        Dispatchers.setMain(testDispatcher)
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { mockVideoClientFactory.getVideoClient(mockContentShareVideoClientObserver) } returns mockVideoClient
+        every { mockEglCoreFactory.createEglCore() } returns mockEglCore
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `startVideoShare should call VideoClientStateController setExternalVideoSource`() {
+        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+        testContentShareVideoClientController.startVideoShare(mockVideoSource)
+
+        verify(exactly = 1) { mockVideoClient.setExternalVideoSource(any(), any()) }
+    }
+
+    @Test
+    fun `stopVideoShare should call VideoClientStateController stopService`() {
+        testContentShareVideoClientController.stopVideoShare()
+
+        verify(exactly = 1) { mockVideoClient.javaStopService() }
+    }
+
+    @Test
+    fun `startVideoShare should call VideoClientStateController stopService first when is sharing`() {
+        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+        testContentShareVideoClientController.startVideoShare(mockVideoSource)
+
+        testContentShareVideoClientController.startVideoShare(mockVideoSource)
+
+        verify(exactly = 2) { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 1) { mockVideoClient.javaStopService() }
+    }
+
+    @Test
+    fun `startVideoShare should notify subscribed observer of onContentShareStopped event when failed`() {
+        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns false
+        testContentShareVideoClientController.subscribeToVideoClientStateChange(mockContentShareObserver)
+
+        testContentShareVideoClientController.startVideoShare(mockVideoSource)
+
+        verify(exactly = 1) { mockContentShareObserver.onContentShareStopped(any()) }
+    }
+
+    @Test
+    fun `subscribeToVideoClientStateChange should call contentShareVideoClientObserver subscribeToVideoClientStateChange with given observer`() {
+        testContentShareVideoClientController.subscribeToVideoClientStateChange(mockContentShareObserver)
+
+        verify(exactly = 1) { mockContentShareVideoClientObserver.subscribeToVideoClientStateChange(mockContentShareObserver) }
+    }
+
+    @Test
+    fun `unsubscribeFromVideoClientStateChange should call contentShareVideoClientObserver unsubscribeFromVideoClientStateChange with given observer`() {
+        testContentShareVideoClientController.unsubscribeFromVideoClientStateChange(mockContentShareObserver)
+
+        verify(exactly = 1) { mockContentShareVideoClientObserver.unsubscribeFromVideoClientStateChange(mockContentShareObserver) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollectorTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollectorTest.kt
@@ -89,6 +89,18 @@ class DefaultClientMetricsCollectorTest {
     }
 
     @Test
+    fun `onMetrics for content share should call observer after interval has passed and observer should not receive any null metrics`() {
+        clientMetricsCollector.subscribeToMetrics(mockMetricsObserver)
+        val rawMetrics = mutableMapOf(VideoClient.VIDEO_SEND_FPS to 10.0)
+        val observableMetrics =
+            mutableMapOf(ObservableMetric.contentShareVideoSendFps to 10.0)
+
+        clientMetricsCollector.processContentShareVideoClientMetrics(rawMetrics)
+
+        verify(exactly = 1) { mockMetricsObserver.onMetricsReceived(observableMetrics) }
+    }
+
+    @Test
     fun `onMetrics should not emit non-observable metrics`() {
         clientMetricsCollector.subscribeToMetrics(mockMetricsObserver)
         val rawMetrics =

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.video
+
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
+import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.DefaultContentShareVideoClientObserver
+import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.session.URLRewriter
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.xodee.client.video.VideoClient
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class DefaultContentShareVideoClientObserverTest {
+    @MockK
+    private lateinit var mockLogger: Logger
+
+    @MockK
+    private lateinit var mockTurnRequestParams: TURNRequestParams
+
+    @MockK
+    private lateinit var mockClientMetricsCollector: ClientMetricsCollector
+
+    @MockK
+    private lateinit var mockURLRewriter: URLRewriter
+
+    @InjectMockKs
+    private lateinit var testContentShareVideoClientObserver: DefaultContentShareVideoClientObserver
+
+    @MockK
+    private lateinit var mockContentShareObserver: ContentShareObserver
+
+    @MockK
+    private lateinit var mockVideoClient: VideoClient
+
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private val videoClientStatus = 0
+
+    @Before
+    fun setUp() {
+        mockkStatic(System::class)
+        every { System.loadLibrary(any()) } just runs
+        Dispatchers.setMain(testDispatcher)
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        testContentShareVideoClientObserver.subscribeToVideoClientStateChange(
+            mockContentShareObserver
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+
+    @Test
+    fun `didFail should notify observer of onContentShareStopped event with VideoServiceFailed status`() {
+        testContentShareVideoClientObserver.didFail(
+            mockVideoClient,
+            videoClientStatus,
+            VideoClient.VIDEO_CLIENT_STATUS_CALL_AT_CAPACITY
+        )
+
+        verify(exactly = 1) {
+            mockContentShareObserver.onContentShareStopped(
+                ContentShareStatus(
+                    ContentShareStatusCode.VideoServiceFailed
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `didFail should call clientMetricsCollector to clean metrics`() {
+        testContentShareVideoClientObserver.didFail(
+            mockVideoClient,
+            videoClientStatus,
+            VideoClient.VIDEO_CLIENT_STATUS_CALL_AT_CAPACITY
+        )
+
+        verify { mockClientMetricsCollector.processContentShareVideoClientMetrics(emptyMap()) }
+    }
+
+    @Test
+    fun `didStop should notify observer of onContentShareStopped event with OK status`() {
+        testContentShareVideoClientObserver.didStop(mockVideoClient)
+
+        verify(exactly = 1) {
+            mockContentShareObserver.onContentShareStopped(
+                ContentShareStatus(
+                    ContentShareStatusCode.OK
+                )
+            )
+        }
+    }
+
+    @Test
+    fun `didStop should call clientMetricsCollector to clean metrics`() {
+        testContentShareVideoClientObserver.didStop(mockVideoClient)
+
+        verify { mockClientMetricsCollector.processContentShareVideoClientMetrics(emptyMap()) }
+    }
+
+    @Test
+    fun `onMetrics should call clientMetricsCollector to process video metrics`() {
+        testContentShareVideoClientObserver.onMetrics(intArrayOf(1), doubleArrayOf(1.0))
+
+        verify { mockClientMetricsCollector.processContentShareVideoClientMetrics(any()) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
@@ -34,16 +34,19 @@ import org.junit.Test
 
 class DefaultMeetingSessionTest {
     @MockK
-    lateinit var configuration: MeetingSessionConfiguration
+    private lateinit var configuration: MeetingSessionConfiguration
 
     @MockK
-    lateinit var logger: Logger
+    private lateinit var contentConfiguration: MeetingSessionConfiguration
 
     @MockK
-    lateinit var context: Context
+    private lateinit var logger: Logger
 
     @MockK
-    lateinit var mockAudioClient: AudioClient
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var mockAudioClient: AudioClient
 
     @MockK
     private lateinit var assetManager: AssetManager
@@ -54,7 +57,7 @@ class DefaultMeetingSessionTest {
     @MockK
     private lateinit var mockLooper: Looper
 
-    lateinit var meetingSession: DefaultMeetingSession
+    private lateinit var meetingSession: DefaultMeetingSession
 
     @Before
     fun setup() {
@@ -62,7 +65,7 @@ class DefaultMeetingSessionTest {
         mockkStatic(System::class, Log::class)
         every { System.loadLibrary(any()) } just runs
         every { Log.d(any(), any()) } returns 0
-        MockKAnnotations.init(this)
+        MockKAnnotations.init(this, relaxed = true)
         every { context.assets } returns assetManager
         every { context.registerReceiver(any(), any()) } returns mockkClass(Intent::class)
         val audioManager = mockkClass(AudioManager::class)
@@ -80,13 +83,8 @@ class DefaultMeetingSessionTest {
         every { context.getSystemService(Context.CAMERA_SERVICE) } returns cameraManager
         mockkObject(AudioClientFactory.Companion)
         every { AudioClientFactory.getAudioClient(any(), any()) } returns mockAudioClient
-        every { configuration.meetingId } returns "meetingId"
-        every { configuration.urls.signalingURL } returns "signalingUrl"
-        every { configuration.urls.turnControlURL } returns "turnControlUrl"
-        every { configuration.credentials.joinToken } returns "joinToken"
-        every { configuration.credentials.attendeeId } returns "attendeeId"
-        every { configuration.urls.urlRewriter } returns ::defaultUrlRewriter
         every { logger.info(any(), any()) } just runs
+        every { configuration.createContentShareMeetingSessionConfiguration() } returns contentConfiguration
 
         mockkConstructor(HandlerThread::class)
         every { anyConstructed<HandlerThread>().looper } returns mockLooper

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/utils/DefaultModalityTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/utils/DefaultModalityTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DefaultModalityTest {
+    private val id = "abc"
+    private val modalityType = ModalityType.Content
+    private val idWithModality = "abc#" + modalityType.value
+    private val idWithOnlySeparator = DefaultModality.MODALITY_SEPARATOR
+
+    @Test
+    fun `id should return expected value`() {
+        assertEquals(id, DefaultModality(id).id())
+        assertEquals(idWithModality, DefaultModality(idWithModality).id())
+        assertEquals(idWithOnlySeparator, DefaultModality(idWithOnlySeparator).id())
+        assertEquals("", DefaultModality("").id())
+    }
+
+    @Test
+    fun `base should return expected value`() {
+        assertEquals(id, DefaultModality(id).base())
+        assertEquals(id, DefaultModality(idWithModality).base())
+        assertEquals("", DefaultModality(idWithOnlySeparator).base())
+        assertEquals("", DefaultModality("").base())
+    }
+
+    @Test
+    fun `modality should return expected value`() {
+        assertNull(DefaultModality(id).modality())
+        assertEquals(modalityType, DefaultModality(idWithModality).modality())
+        assertNull(DefaultModality(idWithOnlySeparator).modality())
+        assertNull(DefaultModality("").modality())
+    }
+
+    @Test
+    fun `hasModality should return expected value`() {
+        assertFalse(DefaultModality(id).hasModality(modalityType))
+        assertTrue(DefaultModality(idWithModality).hasModality(modalityType))
+        assertFalse(DefaultModality(idWithOnlySeparator).hasModality(modalityType))
+        assertFalse(DefaultModality("").hasModality(modalityType))
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <application
         android:allowBackup="true"
@@ -17,7 +18,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.amazonaws.services.chime.sdkdemo.activity.SplashActivity">
+
+        <activity android:name=".activity.SplashActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -26,6 +28,13 @@
         </activity>
         <activity android:name=".activity.HomeActivity" />
         <activity android:name=".activity.MeetingActivity" />
+
+        <service
+            android:name=".service.ScreenCaptureService"
+            android:enabled="true"
+            android:foregroundServiceType="mediaProjection"
+            android:stopWithTask="true"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -23,6 +23,7 @@ import com.amazonaws.services.chime.sdkdemo.utils.inflate
 import com.amazonaws.services.chime.sdkdemo.utils.isLandscapeMode
 import kotlinx.android.synthetic.main.item_video.view.attendee_name
 import kotlinx.android.synthetic.main.item_video.view.on_tile_button
+import kotlinx.android.synthetic.main.item_video.view.poor_connection_message
 import kotlinx.android.synthetic.main.item_video.view.video_surface
 
 class VideoAdapter(
@@ -52,7 +53,7 @@ class VideoAdapter(
         context?.let {
             if (!videoCollectionTile.videoTileState.isContent) {
                 val viewportWidth = tabContentLayout.width
-                if (isLandscapeMode(context) == true) {
+                if (isLandscapeMode(context)) {
                     holder.tileContainer.layoutParams.width = viewportWidth / 2
                 } else {
                     holder.tileContainer.layoutParams.height = (VIDEO_ASPECT_RATIO_16_9 * viewportWidth).toInt()
@@ -84,6 +85,7 @@ class VideoHolder(
         // Save the bound VideoRenderView in order to explicitly control the visibility of SurfaceView.
         // This is to bypass the issue where we cannot hide a SurfaceView that overlaps with another one.
         videoCollectionTile.videoRenderView = view.video_surface
+        videoCollectionTile.pauseMessageView = view.poor_connection_message
 
         if (videoCollectionTile.videoTileState.isContent) {
             view.video_surface.contentDescription = "ScreenTile"
@@ -112,10 +114,13 @@ class VideoHolder(
             view.attendee_name.text = videoCollectionTile.attendeeName
             view.attendee_name.visibility = View.VISIBLE
             view.on_tile_button.visibility = View.VISIBLE
-            if (videoCollectionTile.videoTileState.pauseState == VideoPauseState.Unpaused) {
-                view.on_tile_button.setImageResource(R.drawable.ic_pause_video)
-            } else {
-                view.on_tile_button.setImageResource(R.drawable.ic_resume_video)
+            when (videoCollectionTile.videoTileState.pauseState) {
+                VideoPauseState.Unpaused ->
+                    view.on_tile_button.setImageResource(R.drawable.ic_pause_video)
+                VideoPauseState.PausedByUserRequest ->
+                    view.on_tile_button.setImageResource(R.drawable.ic_resume_video)
+                VideoPauseState.PausedForPoorConnection ->
+                    view.poor_connection_message.visibility = View.VISIBLE
             }
 
             view.on_tile_button.setOnClickListener {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/data/VideoCollectionTile.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/data/VideoCollectionTile.kt
@@ -4,11 +4,22 @@
  */
 package com.amazonaws.services.chime.sdkdemo.data
 
+import androidx.constraintlayout.widget.ConstraintLayout
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileState
 
 data class VideoCollectionTile(
     val attendeeName: String,
-    val videoTileState: VideoTileState,
-    var videoRenderView: DefaultVideoRenderView?
-)
+    val videoTileState: VideoTileState
+) {
+    var videoRenderView: DefaultVideoRenderView? = null
+    var pauseMessageView: ConstraintLayout? = null
+
+    fun setRenderViewVisibility(visibility: Int) {
+        videoRenderView?.visibility = visibility
+    }
+
+    fun setPauseMessageVisibility(visibility: Int) {
+        pauseMessageView?.visibility = visibility
+    }
+}

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdkdemo.device
+
+import android.content.Context
+import android.content.Intent
+import android.media.projection.MediaProjection
+import android.os.Build
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.CaptureSourceObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.DefaultScreenCaptureSource
+import com.amazonaws.services.chime.sdkdemo.service.ScreenCaptureService
+
+/**
+ * [ScreenShareManager] is a wrapper of [ContentShareSource]. It manages
+ * [DefaultScreenCaptureSource] and foreground service which required for [MediaProjection]
+ * starting [Build.VERSION_CODES.Q].
+ */
+class ScreenShareManager(
+    private val screenCaptureSource: DefaultScreenCaptureSource,
+    private val context: Context
+) : ContentShareSource() {
+    override var videoSource: VideoSource? = screenCaptureSource
+
+    fun start() = screenCaptureSource.start()
+
+    fun stop() {
+        context.stopService(Intent(context, ScreenCaptureService::class.java))
+        screenCaptureSource.stop()
+    }
+
+    fun release() = screenCaptureSource.release()
+
+    fun addObserver(observer: CaptureSourceObserver) = screenCaptureSource.addCaptureSourceObserver(observer)
+
+    fun removeObserver(observer: CaptureSourceObserver) = screenCaptureSource.removeCaptureSourceObserver(observer)
+}

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -150,7 +150,7 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
         view.findViewById<DefaultVideoRenderView>(R.id.videoPreview)?.let {
             val displayMetrics = context.resources.displayMetrics
             val width =
-                    if (isLandscapeMode(context) == true) displayMetrics.widthPixels / 2 else displayMetrics.widthPixels
+                    if (isLandscapeMode(context)) displayMetrics.widthPixels / 2 else displayMetrics.widthPixels
             val height = (width * VIDEO_ASPECT_RATIO_16_9).toInt()
             it.layoutParams.width = width
             it.layoutParams.height = height

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -35,6 +35,7 @@ class MeetingModel : ViewModel() {
     var isCameraOn = false
     var isDeviceListDialogOn = false
     var isAdditionalOptionsDialogOn = false
+    var isSharingContent = false
     var lastReceivedMessageTimestamp = 0L
     var tabIndex = 0
     var isUsingCameraCaptureSource = true

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
@@ -12,6 +12,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.DefaultEglC
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSession
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
+import com.amazonaws.services.chime.sdkdemo.device.ScreenShareManager
 import com.amazonaws.services.chime.sdkdemo.utils.CpuVideoProcessor
 import com.amazonaws.services.chime.sdkdemo.utils.GpuVideoProcessor
 
@@ -33,4 +34,6 @@ class MeetingSessionModel : ViewModel() {
     lateinit var cameraCaptureSource: CameraCaptureSource
     lateinit var gpuVideoProcessor: GpuVideoProcessor
     lateinit var cpuVideoProcessor: CpuVideoProcessor
+    // Source for screen capture and share, will be set only if created in call
+    var screenShareManager: ScreenShareManager? = null
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/service/ScreenCaptureService.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/service/ScreenCaptureService.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdkdemo.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.amazonaws.services.chime.sdkdemo.R
+
+class ScreenCaptureService : Service() {
+    private lateinit var notificationManager: NotificationManager
+
+    private val CHANNEL_ID = "ScreenCaptureServiceChannelID"
+    private val CHANNEL_NAME = "Screen Share"
+    private val SERVICE_ID = 1
+
+    override fun onCreate() {
+        super.onCreate()
+
+        notificationManager =
+            applicationContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                CHANNEL_NAME,
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        startForeground(
+            SERVICE_ID,
+            NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle(getString(R.string.screen_capture_notification_tile))
+                .setContentText(getText(R.string.screen_capture_notification_text))
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .build()
+        )
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+}

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/Extensions.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/Extensions.kt
@@ -21,6 +21,6 @@ fun encodeURLParam(string: String?): String {
     return URLEncoder.encode(string, "utf-8")
 }
 
-fun isLandscapeMode(context: Context?): Boolean? {
-    return context?.let { it.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE }
+fun isLandscapeMode(context: Context?): Boolean {
+    return context?.let { it.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE } ?: false
 }

--- a/app/src/main/res/drawable/ic_connection_problem.xml
+++ b/app/src/main/res/drawable/ic_connection_problem.xml
@@ -1,0 +1,15 @@
+<!--
+  ~ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  ~ SPDX-License-Identifier: Apache-2.0
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6.113,13.03h3.5c0.496,0 0.898,0.403 0.898,0.898v4.91l6.398,-7.808h-3.5c-0.495,0 -0.898,-0.402 -0.898,-0.897L12.511,5.19l-6.398,7.84zM10.408,20.025c-0.108,0 -0.215,-0.02 -0.32,-0.06 -0.35,-0.133 -0.577,-0.462 -0.577,-0.837L9.511,14.03L5.9,14.03c-0.358,0 -0.673,-0.204 -0.82,-0.532 -0.147,-0.327 -0.09,-0.698 0.149,-0.966l6.7,-8.213c0.265,-0.296 0.65,-0.395 1.004,-0.258 0.35,0.133 0.577,0.462 0.577,0.837v5.132h3.604c0.36,0 0.676,0.205 0.823,0.533 0.148,0.328 0.09,0.7 -0.148,0.969l-6.7,8.176c-0.184,0.208 -0.43,0.317 -0.682,0.317z"
+      android:fillColor="#FFFFFF"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/item_video.xml
+++ b/app/src/main/res/layout/item_video.xml
@@ -18,6 +18,41 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/poor_connection_message"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/colorTranslucentBackground"
+        android:visibility="invisible"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" >
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_connection_problem"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/poor_connection_text" />
+
+        <TextView
+            android:id="@+id/poor_connection_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:paddingHorizontal="20dp"
+            android:text="@string/poor_connection_message"
+            android:textAlignment="center"
+            android:textColor="@color/colorWhite"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
     <ImageButton
         android:id="@+id/on_tile_button"
         android:layout_width="48dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -15,4 +15,5 @@
 
     <!-- For roster view -->
     <color name="colorBackground">#E9E9E9</color>
+    <color name="colorTranslucentBackground">#64000000</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,17 +15,17 @@
     <string name="test_url"></string>
     <string name="volume_indicator">Volume Indicator</string>
     <string name="active_speaker_indicator">Active Speaker Indicator</string>
-    <string name="switch_camera">Switch Camera</string>
-    <string name="speaker_button">Toggle Speaker</string>
     <string name="screen_share_view">Screen Share</string>
     <string name="version_prefix">amazon-chime-sdk-android@</string>
+    
+    <!-- video -->
     <string name="video_view">Video Collection</string>
     <string name="no_screen_share_available">No screen share available</string>
     <string name="no_videos_available">No videos available</string>
-    <string name="enable_voice_focus">Turn on Voice Focus</string>
-    <string name="disable_voice_focus">Turn off Voice Focus</string>
     <string name="next_video_page">Next Page &gt;&gt;</string>
     <string name="prev_video_page">&lt;&lt; Prev Page</string>
+    <string name="switch_camera">Switch Camera</string>
+    <string name="poor_connection_message">Poor local connection. \nVideo will resume \nwhen your connection improves.</string>
 
     <!-- device selection -->
     <string name="device_management_title">Select devices</string>
@@ -42,23 +42,37 @@
     <string name="preview_meeting_info">Ready to join meeting %1$s as %2$s.</string>
 
     <!-- toggle tab -->
+    <string name="speaker_button">Toggle Speaker</string>
     <string name="toggle_camera">Toggle Camera</string>
     <string name="toggle_additional_options_menu">Toggle Additional Options Menu</string>
-    <string name="toggle_flashlight">Toggle flashlight on current camera</string>
-    <string name="toggle_cpu_filter">Toggle demo filter (CPU)</string>
-    <string name="toggle_gpu_filter">Toggle demo filter (GPU)</string>
-    <string name="toggle_custom_capture_source">Toggle using custom capture source</string>
     <string name="toggle_mute">Toggle Mute</string>
+    <string name="enable_screen_capture_source">Share screen</string>
+    <string name="disable_screen_capture_source">Stop sharing screen</string>
+    <string name="enable_voice_focus">Turn on Voice Focus (noise suppression)</string>
+    <string name="disable_voice_focus">Turn off Voice Focus (noise suppression)</string>
+    <string name="enable_flashlight">Turn on flashlight</string>
+    <string name="disable_flashlight">Turn off flashlight</string>
+    <string name="enable_cpu_filter">Turn on demo filter (CPU)</string>
+    <string name="disable_cpu_filter">Turn off demo filter (CPU)</string>
+    <string name="enable_gpu_filter">Turn on demo filter (GPU)</string>
+    <string name="disable_gpu_filter">Turn off demo filter (GPU)</string>
+    <string name="enable_custom_capture_source">Turn on custom capture source</string>
+    <string name="disable_custom_capture_source">Turn off custom capture source</string>
 
     <!-- Alert -->
     <string name="cancel">Cancel</string>
     <string name="alert_title_choose_audio">Choose a device</string>
     <string name="alert_title_additional_options">Additional Options</string>
 
+    <!-- Service -->
+    <string name="screen_capture_notification_tile">Screen Sharing</string>
+    <string name="screen_capture_notification_text">Your screen is being shared.</string>
+
     <!-- Notify users for errors -->
     <string name="user_notification_meeting_id_invalid">Meeting ID is invalid</string>
     <string name="user_notification_attendee_name_invalid">Attendee name is invalid</string>
     <string name="user_notification_permission_error">WebRTC cannot work without permissions</string>
+    <string name="user_notification_screen_share_permission_error">Screen share cannot work without permissions</string>
     <string name="user_notification_flashlight_unavailable_error">Flashlight not available on current device</string>
     <string name="user_notification_flashlight_custom_source_error">Cannot toggle flashlight without using custom camera capture source</string>
     <string name="user_notification_filter_custom_source_error">Cannot toggle filters without using custom camera capture source</string>

--- a/guides/api_overview.md
+++ b/guides/api_overview.md
@@ -318,3 +318,35 @@ Note that if you want to share music or background sounds with others in the cal
 ## 12. Using a custom video source, sink or processing step (optional)
 
 Builders using the Amazon Chime SDK for video can produce, modify, and consume raw video frames transmitted or received during the call. You can allow the facade to manage its own camera capture source, provide your own custom source, or use a provided SDK capture source as the first step in a video processing pipeline which modifies frames before transmission. See the [Custom Video Sources, Processors, and Sinks](custom_video.md) guide for more information.
+
+## 13. Share screen and other content (optional)
+
+Builders using the Amazon Chime SDK for Android can share a second video stream such as screen capture in a meeting without disrupting their applications existing audio/video stream. When a content share is started, another attendee with the attendee ID `<attendee-id>#content` joins the meeting. You can subscribe its presence event to show it in the roster and bind its video tile to a video render view the same as you would for a regular attendee.
+
+Each attendee can share one content share in addition to their main video. Each meeting may have two simultaneous content shares. Content share does not count towards the max video tile limit.
+
+### 13a. Start and stop the content share
+
+To start the content share, call meetingSession.audioVideo.[startContentShare(source)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-controller/start-content-share.html).
+
+To stop the content share, call meetingSession.audioVideo.[stopContentShare()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-controller/stop-content-share.html).
+
+### 13b. Register a content share observer
+
+You can receive events about the content share by implementing a [ContentShareObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-observer/index.html).
+
+To add a ContentShareObserver, call meetingSession.audioVideo.[addContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-controller/add-content-share-observer.html).
+
+To remove a ContentShareObserver, call meetingSession.audioVideo.[removeContentShareObserver(observer)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-controller/remove-content-share-observer.html).
+
+You can implement the following callbacks:
+
+* [onContentShareStarted](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-observer/on-content-share-started.html): called when the content share has started
+
+* [onContentShareStopped(status)](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-observer/on-content-share-stopped.html): called when the content is no longer shared with other attendees with the reason provided in the status
+
+### 13c. Collect content share metrics
+
+You will receive content share metrics if you registered a metric observer by [9.Receiving metrics (optional)](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/api_overview.md#9-receiving-metrics-optional).
+
+Content share metrics will be prefixed by `contentShare`. Or you can use the [isContentShareMetric()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.metric/-observable-metric/is-content-share-metric.html) to help identify a content share metric.

--- a/guides/content_share.md
+++ b/guides/content_share.md
@@ -1,0 +1,127 @@
+# Content Share
+
+Builders using the Amazon Chime SDK for Android can share a second video stream such as screen capture in a meeting without disrupting their applications existing audio/video stream.
+
+## Prerequisites
+
+* You have read the [API overview](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/api_overview.md) and have a basic understanding of the components covered in that document.
+* You have completed [Getting Started](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/getting_started.md) and have running application which uses the Amazon Chime SDK.
+* You have read the [Custom Video Sources, Processors, and Sinks](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md) and have a basic understanding of APIs such as [VideoSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-source/index.html).
+
+## Sharing content with remote participants
+
+Content share APIs are accessible from [AudioVideoFacade](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-audio-video-facade.html). Builders will need to create a [ContentShareSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-source/index.html) which currently contains just the [VideoSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-source/index.html) desired to share in the meeting. A bundled screen capture source using [MediaProjection](https://developer.android.com/reference/android/media/projection/MediaProjection) is provided in [DefaultScreenCaptureSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture/-default-screen-capture-source/index.html), but developers can also share any video source which implements [VideoSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-source/index.html).
+
+### Constructing the provided screen capture source implementation
+
+In [DefaultScreenCaptureSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture/-default-screen-capture-source/index.html), the video frames are provided via the [MediaProjection](https://developer.android.com/reference/android/media/projection/MediaProjection) APIs, so an application will need to complete the following prerequisites before the implementation is ready for use:
+
+1. *(Android Q and above only)* Starting in Android Q, a foreground service is required before acquiring a `MediaProjection` through [MediaProjectionManger.getMediaProjection](https://developer.android.com/reference/android/media/projection/MediaProjectionManager). Applications will need to create a Service, defined in your `AndroidManifest.xml` and start it as foreground before starting the screen capture source.  This will look like the following:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+<application>
+    <service
+        android:name=".ScreenCaptureService"
+        android:foregroundServiceType="mediaProjection" />
+</application>
+```
+
+2. To construct a [DefaultScreenCaptureSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture/-default-screen-capture-source/index.html), request screen capture permissions from the user and use the result in the constructor parameters:
+
+```kotlin
+// Call this function when screen capture is desired
+fun requestScreenCapturePermission() {
+    mediaProjectionManager = getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+
+    // Show prompt for screen capture permission
+    startActivityForResult(
+        mediaProjectionManager.createScreenCaptureIntent(),
+        SCREEN_CAPTURE_REQUEST_CODE
+    )
+}
+
+// Handle the result of permission prompt activity started
+// in requestScreenCapturePermission
+override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    // ...
+    if (SCREEN_CAPTURE_REQUEST_CODE == requestCode && resultCode == Activity.RESULT_OK && data != null) {
+        // (Android Q and above) Start the service created in step 1
+        startService(Intent(this, ScreenCaptureService::class.java))
+ 
+        // Initialize a DefaultScreenCaptureSource instance using given result
+        val screenCaptureSource = DefaultScreenCaptureSource(
+            this,
+            logger,
+            // Use the same EglCoreFactory instance as passed into DefaultMeetingSession
+            DefaultSurfaceTextureCaptureSourceFactory(
+                logger,
+                eglCoreFactory),
+            resultCode,
+            data
+        )
+        screenCaptureSource.start()
+    }
+    // ... Complete any other initialization
+}
+```
+
+See [Custom Video Sources, Processors, and Sinks](http://custom%20video%20sources%2C%20processors%2C%20and%20sinks/) for more information on the usage of [EglCoreFactory](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl/-egl-core-factory/index.html). The capture source will not work if the factory is not shared between the capture and the meeting session due to use of GPU based video frames.
+
+### Using a custom video source
+
+Refer to the [Implementing a custom video source and transmitting](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md#implementing-a-custom-video-source-and-transmitting) section of the custom video guide to build a video source to share.  Content share supports sharing any source which implements [VideoSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-source/index.html).
+
+### Passing a video source into the facade
+Once the video source is ready, wrap it with [ContentShareSource](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-source/index.html) to share the video.
+
+```kotlin
+// Construct the content share source
+val contentShareSource = ContentShareSource()
+contentShareSource.videoSource = screenCaptureSource // Or a custom source
+
+// Start sharing the content share source to remote participants
+audioVideo.startContentShare(contentShareSource)
+
+// ...
+
+// Stop sharing the source
+audioVideo.stopContentShare()
+```
+
+Note that the content share APIs do not manage the source and only provide a sink to transmit captured frames to remote participants, builders will be responsible to take care of its lifecycle including stopping and releasing the capture sources internal resources.
+
+### Receiving content share events
+
+Applications can receive content share events by implementing methods from [ContentShareObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-observer/index.html) and subscribe with [addContentShareObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare/-content-share-controller/add-content-share-observer.html).
+
+
+## Viewing the content
+
+Content shares are treated as regular audio-video attendees. The attendee ID of a content share is the same as the original attendee, but with a suffix of **#content**. Applications using the Amazon Chime SDK receive real-time attendee presence and video tile updates callbacks for content attendee using the exact same mechanisms as normal video.
+
+To view the content share:
+1. Create an observer of [VideoTileObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-observer/index.html) that implements [onVideoTileAdded](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-observer/on-video-tile-added.html) to receive callbacks when the video tile is added.
+1. Subscribe the observer with [addVideoTileObserver](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-controller-facade/add-video-tile-observer.html) via audio video facade.
+1. In the `onVideoTileAdded`, bind the video tile to a [VideoRenderView](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-render-view.html).
+
+```kotlin
+override fun onVideoTileAdded(tileState: VideoTileState) {
+    // ...
+    if (tileState.isContent) {
+         audioVideo.bindVideoView(view.video_surface, tileState.tileId)
+    }
+}
+```
+
+Builders can use the [VideoTileState.isContent](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo.video/-video-tile-state/is-content.html) to check if the video tile is a content share, and any add special logic you need to handle the content share.
+
+You can also use the [DefaultModality](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.utils/-default-modality/index.html) class to determine that an attendee ID is a content share:
+
+```kotlin
+if (DefaultModality(attendeeId).hasModality(ModalityType.Content)) {
+  // ...special handling for content share...
+}
+
+```


### PR DESCRIPTION
### Issue #, if available:
Chime-29187

### Description of changes:
- APIs
- Default screen capture implementation
- Demo
- Document
- Unit tests

### Testing done:
#### Unit test coverage
* Class coverage: 79%
* Line coverage:  67%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:
![image-8ed71b16-376b-4086-be0d-c7031664ef9a](https://user-images.githubusercontent.com/55719628/103322016-47792600-49f1-11eb-86b3-05d7bba6cc0e.jpg)
![image-ace58fd7-0d38-402d-88b3-39219d6e368a](https://user-images.githubusercontent.com/55719628/103322018-49db8000-49f1-11eb-9794-0f0714c22890.jpg)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
