### PR TITLE
Add audio host URL, use VideoClientConfig (merge to content share branch)

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -19,6 +19,8 @@ import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoSourceAdapt
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.video.VideoClient
+import com.xodee.client.video.VideoClientConfig
+import com.xodee.client.video.VideoClientConfigBuilder
 
 class DefaultContentShareVideoClientController(
     private val context: Context,
@@ -93,16 +95,15 @@ class DefaultContentShareVideoClientController(
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER
         flag = flag or VIDEO_CLIENT_FLAG_IS_CONTENT
-        val result = videoClient?.javaStartServiceV3(
-            "",
-            "",
-            configuration.meetingId,
-            configuration.credentials.joinToken,
-            false,
-            0,
-            flag,
-            eglCore?.eglContext
-        ) ?: false
+
+        val videoClientConfig: VideoClientConfig = VideoClientConfigBuilder()
+            .setMeetingId(configuration.meetingId)
+            .setToken(configuration.credentials.joinToken)
+            .setAudioHostUrl(configuration.urls.audioHostURL)
+            .setFlags(flag)
+            .setSharedEglContext(eglCore?.eglContext)
+            .createVideoClientConfig()
+        val result = videoClient?.start(videoClientConfig) as Boolean
         logger.info(TAG, "Content share video client start result: $result")
         return result
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -103,7 +103,7 @@ class DefaultContentShareVideoClientController(
             .setFlags(flag)
             .setSharedEglContext(eglCore?.eglContext)
             .createVideoClientConfig()
-        val result = videoClient?.start(videoClientConfig) as Boolean
+        val result = videoClient?.start(videoClientConfig) ?: false
         logger.info(TAG, "Content share video client start result: $result")
         return result
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -19,6 +19,8 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.google.gson.Gson
 import com.xodee.client.video.VideoClient
 import com.xodee.client.video.VideoClientCapturer
+import com.xodee.client.video.VideoClientConfig
+import com.xodee.client.video.VideoClientConfigBuilder
 import java.security.InvalidParameterException
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -195,16 +197,13 @@ class DefaultVideoClientController(
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER
         flag = flag or VIDEO_CLIENT_FLAG_EXCLUDE_SELF_CONTENT_IN_INDEX
-        videoClient?.javaStartServiceV3(
-            "",
-            "",
-            configuration.meetingId,
-            configuration.credentials.joinToken,
-            false,
-            0,
-            flag,
-            eglCore?.eglContext
-        )
+        val videoClientConfig: VideoClientConfig = VideoClientConfigBuilder()
+                .setMeetingId(configuration.meetingId)
+                .setToken(configuration.credentials.joinToken)
+                .setFlags(flag)
+                .setSharedEglContext(eglCore?.eglContext)
+                .createVideoClientConfig()
+        videoClient?.start(videoClientConfig)
 
         videoSourceAdapter.let { videoClient?.setExternalVideoSource(it, eglCore?.eglContext) }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientControllerTest.kt
@@ -92,7 +92,7 @@ class DefaultContentShareVideoClientControllerTest {
 
     @Test
     fun `startVideoShare should call VideoClientStateController setExternalVideoSource`() {
-        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+        every { mockVideoClient.start(any()) } returns true
         testContentShareVideoClientController.startVideoShare(mockVideoSource)
 
         verify(exactly = 1) { mockVideoClient.setExternalVideoSource(any(), any()) }
@@ -107,18 +107,18 @@ class DefaultContentShareVideoClientControllerTest {
 
     @Test
     fun `startVideoShare should call VideoClientStateController stopService first when is sharing`() {
-        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns true
+        every { mockVideoClient.start(any()) } returns true
         testContentShareVideoClientController.startVideoShare(mockVideoSource)
 
         testContentShareVideoClientController.startVideoShare(mockVideoSource)
 
-        verify(exactly = 2) { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) }
+        verify(exactly = 2) { mockVideoClient.start(any()) }
         verify(exactly = 1) { mockVideoClient.javaStopService() }
     }
 
     @Test
     fun `startVideoShare should notify subscribed observer of onContentShareStopped event when failed`() {
-        every { mockVideoClient.javaStartServiceV3(any(), any(), any(), any(), any(), any(), any(), any()) } returns false
+        every { mockVideoClient.start(any()) } returns false
         testContentShareVideoClientController.subscribeToVideoClientStateChange(mockContentShareObserver)
 
         testContentShareVideoClientController.startVideoShare(mockVideoSource)


### PR DESCRIPTION
### Description of changes:
Pass down audio host URL and use new config builder.

### Testing done:
Smoke tested android demo

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
