### PR TITLE
Fix camera capture start when there are no ranges at or below desired max

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -366,12 +366,17 @@ class DefaultCameraCaptureSource(
                     .filter { it.upper <= this.format.maxFps }
                     .minBy { this.format.maxFps - it.upper }
                     ?: run {
-                        logger.error(TAG, "No FPS ranges below set max FPS")
+                        logger.warn(TAG, "No FPS ranges below set max FPS")
+                        // Just fall back to the closest
+                        return@run fpsRanges.minBy { abs(this.format.maxFps - it.upper) }
+                    } ?: run {
+                        logger.error(TAG, "No valid FPS ranges")
                         ObserverUtils.notifyObserverOnMainThread(observers) {
                             it.onCaptureFailed(CaptureSourceError.ConfigurationFailure)
                         }
                         return
                     }
+
             logger.info(TAG, "Setting target FPS range to $bestFpsRange")
             captureRequestBuilder.set(
                 CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE,


### PR DESCRIPTION
### Description of changes: 

Before we incorrectly assumed that all device captures would support a range at 15 FPS or below which was incorrect.

### Testing done: 
I do not have a device with the issue, but i can reproduce by setting the max desired FPS to 1 which causes capture to fail.  The included change resolves that issue.

#### Unit test coverage
Class coverage: 80%
Line coverage: 67%

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
