### PR TITLE
Stop internal capture source when stopping video client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fix a bug that internal capture source was not stopped properly when the video client was being stopped.
+
 ## 0.9.0 - 2020-12-17
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -97,10 +97,7 @@ class DefaultVideoClientController(
     override fun startLocalVideo(source: VideoSource) {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
-        if (isUsingInternalCaptureSource) {
-            cameraCaptureSource.stop()
-            isUsingInternalCaptureSource = false
-        }
+        stopInternalCaptureSourceIfRunning()
 
         videoSourceAdapter.source = source
         logger.info(TAG, "Setting external video source in media client to custom source")
@@ -113,10 +110,7 @@ class DefaultVideoClientController(
 
         logger.info(TAG, "Stopping local video")
         videoClient?.setSending(false)
-        if (isUsingInternalCaptureSource) {
-            cameraCaptureSource.stop()
-            isUsingInternalCaptureSource = false
-        }
+        stopInternalCaptureSourceIfRunning()
     }
 
     override fun startRemoteVideo() {
@@ -210,6 +204,8 @@ class DefaultVideoClientController(
     override fun stopVideoClient() {
         logger.info(TAG, "Stopping video client")
         videoClient?.stopService()
+        // SDK owns the lifecycle of the internal capture source
+        stopInternalCaptureSourceIfRunning()
     }
 
     override fun destroyVideoClient() {
@@ -239,5 +235,12 @@ class DefaultVideoClientController(
             clientSource,
             sdkVersion
         )
+    }
+
+    private fun stopInternalCaptureSourceIfRunning() {
+        if (isUsingInternalCaptureSource) {
+            cameraCaptureSource.stop()
+            isUsingInternalCaptureSource = false
+        }
     }
 }


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-ios/issues/200

### Description of changes:
When builder calls `startLocalVideo()` (the one without parameter), we start an internal capture source. This internal capture source need to be stopped when we destroy video client. Otherwise, after builder calls `audioVideo.stop()`, the local video will still be on.

### Testing done:
Tested by commenting out [`stopLocalVideo()` when leave meeting](https://github.com/aws/amazon-chime-sdk-android/blob/master/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt#L115) and changing [`isUsingCameraCaptureSource`](https://github.com/aws/amazon-chime-sdk-android/blob/master/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt#L40) to `false`. Was still able to see the `DefaultCameraCaptureSource` being stopped properly.

#### Unit test coverage
* Class coverage: 80%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [ ] See audio video events
* [x] See signal strength changes
* [ ] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
