### PR TITLE
Stop screen share when screen is locked

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -12,6 +12,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.media.projection.MediaProjectionManager
 import android.os.Bundle
+import android.os.PowerManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -99,6 +100,7 @@ class MeetingFragment : Fragment(),
     private var screenShareManager: ScreenShareManager? = null
 
     private lateinit var mediaProjectionManager: MediaProjectionManager
+    private lateinit var powerManager: PowerManager
     private lateinit var credentials: MeetingSessionCredentials
     private lateinit var audioVideo: AudioVideoFacade
     private lateinit var cameraCaptureSource: CameraCaptureSource
@@ -193,6 +195,7 @@ class MeetingFragment : Fragment(),
         audioDeviceManager = AudioDeviceManager(audioVideo)
 
         mediaProjectionManager = activity.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        powerManager = activity.getSystemService(Context.POWER_SERVICE) as PowerManager
 
         view.findViewById<TextView>(R.id.textViewMeetingId)?.text = arguments?.getString(
             HomeActivity.MEETING_ID_KEY
@@ -1366,5 +1369,11 @@ class MeetingFragment : Fragment(),
             stopLocalVideo()
         }
         audioVideo.stopRemoteVideo()
+
+        // Turn off screen share when screen locked
+        if (meetingModel.isSharingContent && !powerManager.isInteractive) {
+            audioVideo.stopContentShare()
+            screenShareManager?.stop()
+        }
     }
 }


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22241

### Description of changes:
- Stop screen share when screen is locked.

### Testing done:
- Tested with OnePlus 6, the screen share is stopped once screen is locked.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
