### PR TITLE
Disable auto tab selection when start/stop local video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Changed AudioManager mode to be `MODE_IN_COMMUNICATION` only after builders call `audioVideo.start()`.
 * Update text of additional options on demo app.
 * Changes that support a speed up of video client initialization. `requestTurnCreds` callback will only be invoked as a backup for media layer logic. The signaling url is now passed into video client start. A new callback `onTurnURIsReceived` will be invoked when TURN uris are received by the client. This allows urls to be modified with urlRewriter or custom builder logic.
+* Changed the demo app behavior so that when user starts/stops local video, the app does not switch to the Video tab automatically.
 
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -860,7 +860,6 @@ class MeetingFragment : Fragment(),
             audioVideo.startLocalVideo()
         }
         buttonCamera.setImageResource(R.drawable.button_camera_on)
-        selectTab(SubTab.Video.position)
     }
 
     private fun stopLocalVideo() {
@@ -870,7 +869,6 @@ class MeetingFragment : Fragment(),
         }
         audioVideo.stopLocalVideo()
         buttonCamera.setImageResource(R.drawable.button_camera)
-        selectTab(SubTab.Video.position)
     }
 
     private fun onVideoPageUpdated() {


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22482

### Description of changes:
We made a change in PR #185 so that we call `startLocalVideo()` and `stopLocalVideo()` accordingly in `onStart()` and `onStop()` callbacks, which will be triggered when user foregrounds/backgrounds the app or when user rotates the device. As we also call `selectTab()` in `startLocalVideo()` and `stopLocalVideo()`, user will notice that they were switched to the Video tab automatically when rotating the phone.

Remove the `selectTab()` call in `startLocalVideo()` and `stopLocalVideo()` so that when user starts/stops local video, the app does not switch to the Video tab automatically.

### Testing done:

Manual testing:
1. Android client joined the meeting.
2. Enabled local video. The app did not auto switch to video tab.
3. Rotated the device. The app remained on the previous tab.

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [ ] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
