### PR TITLE
Fix Video Connection issue when certain DNS is blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.
-* Fixed a video connection issue on network where DNS 8.8.8.8 is blocked.
+* Fixed a video connection issue on network where DNS 8.8.8.8 is blocked. `ACCESS_NETWORK_STATE` permission is required to discover available DNS on the network.
 
 ## [0.9.1] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@
 
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.
+* Fixed a video connection issue on network where DNS 8.8.8.8 is blocked.
 
-## [0.13.1] - 2021-01-08
+## [0.9.1] - 2021-01-08
 
 ### Fixed
 * Fix a bug that internal capture source was not stopped properly when the video client was being stopped.
 * Fix camera capture start failure on certain Android devices when there are no FPS ranges at or below desired FPS max.
 
-## 0.9.0 - 2020-12-17
+## [0.9.0] - 2020-12-17
 
 ### Added
 * Added video pagination feature in the Android demo app. Remote videos will be paginated into several pages. Each page contains at most 4 videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.

--- a/amazon-chime-sdk/src/main/AndroidManifest.xml
+++ b/amazon-chime-sdk/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amazonaws.services.chime.sdk">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
@@ -5,10 +5,12 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
 
+import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.DNSServerUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.TURNRequestUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNCredentials
@@ -22,6 +24,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class DefaultContentShareVideoClientObserver(
+    private val context: Context,
     private val logger: Logger,
     private val turnRequestParams: TURNRequestParams,
     private val clientMetricsCollector: ClientMetricsCollector,
@@ -111,7 +114,7 @@ class DefaultContentShareVideoClientObserver(
     }
 
     override fun getAvailableDnsServers(): Array<String> {
-        return emptyArray()
+        return DNSServerUtils.getAvailableDnsServers(context, logger)
     }
 
     override fun onCameraChanged() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DNSServerUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DNSServerUtils.kt
@@ -1,0 +1,49 @@
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import android.os.Build
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.lang.reflect.Method
+import java.net.InetAddress
+
+object DNSServerUtils {
+    private val TAG = "DNSServerUtils"
+
+    fun getAvailableDnsServers(context: Context, logger: Logger): Array<String> {
+        val dnsHosts: MutableList<String> = ArrayList()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            try {
+                val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+                val linkProperties = connectivityManager.getLinkProperties(connectivityManager.activeNetwork)
+                if (linkProperties != null) {
+                    val addresses: List<InetAddress> = linkProperties.dnsServers
+                    for (i in addresses.indices) {
+                        if (addresses[i].hostAddress.isNotEmpty()) {
+                            dnsHosts.add(addresses[i].hostAddress)
+                        }
+                    }
+                    logger.info(TAG, "Get " + dnsHosts.size + " DNS addresses.")
+                }
+            } catch (e: Exception) {
+                logger.error(TAG, "Failed to get active DNS address.")
+            }
+        } else {
+            try {
+                @SuppressLint("PrivateApi") val SystemProperties = Class.forName("android.os.SystemProperties")
+                val method: Method = SystemProperties.getMethod("get", String::class.java)
+                for (name in arrayOf("net.dns1", "net.dns2")) {
+                    val value = method.invoke(null, name) as String
+                    if (value.isNotEmpty()) {
+                        dnsHosts.add(value)
+                    }
+                }
+                logger.info(TAG, "Get " + dnsHosts.size + " DNS addresses,")
+            } catch (e: Exception) {
+                logger.error(TAG, "Failed to get active DNS address.")
+            }
+        }
+        return dnsHosts.toTypedArray()
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
+import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
@@ -14,6 +15,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFr
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameI420Buffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.DNSServerUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.TURNRequestUtils
 import com.amazonaws.services.chime.sdk.meetings.realtime.datamessage.DataMessage
@@ -34,6 +36,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 class DefaultVideoClientObserver(
+    private val context: Context,
     private val logger: Logger,
     private val turnRequestParams: TURNRequestParams,
     private val clientMetricsCollector: ClientMetricsCollector,
@@ -216,7 +219,7 @@ class DefaultVideoClientObserver(
     }
 
     override fun getAvailableDnsServers(): Array<String> {
-        return emptyArray()
+        return DNSServerUtils.getAvailableDnsServers(context, logger)
     }
 
     override fun onDataMessageReceived(dataMessages: Array<mediaDataMessage>?) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSession.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSession.kt
@@ -76,6 +76,7 @@ class DefaultMeetingSession(
             )
         val videoClientObserver =
             DefaultVideoClientObserver(
+                context,
                 logger,
                 turnRequestParams,
                 metricsCollector,
@@ -147,6 +148,7 @@ class DefaultMeetingSession(
 
         val contentShareObserver =
             DefaultContentShareVideoClientObserver(
+                context,
                 logger,
                 contentShareTurnRequestParams,
                 metricsCollector,

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultContentShareVideoClientObserverTest.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
+import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
@@ -30,6 +31,9 @@ import org.junit.Before
 import org.junit.Test
 
 class DefaultContentShareVideoClientObserverTest {
+    @MockK
+    private lateinit var mockContext: Context
+
     @MockK
     private lateinit var mockLogger: Logger
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserverTest.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
+import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRotation
@@ -50,6 +51,9 @@ class DefaultVideoClientObserverTest {
 
     @MockK
     private lateinit var mockAnotherDataMessageObserver: DataMessageObserver
+
+    @MockK
+    private lateinit var mockContext: Context
 
     @MockK
     private lateinit var mockLogger: Logger
@@ -130,6 +134,7 @@ class DefaultVideoClientObserverTest {
         MockKAnnotations.init(this, relaxUnitFun = true)
         testVideoClientObserver =
             DefaultVideoClientObserver(
+                mockContext,
                 mockLogger,
                 turnRequestParams,
                 mockMetricsCollector,


### PR DESCRIPTION
### Issue #, if available:
Chime-34758

### Description of changes:
When DNS 8.8.8.8 is blocked, Video connection will be blocked.
This change is to implement the `getAvailableDnsServers` on VideoClientObserver to send available DNS addresses to Media layer

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [X] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
