### PR TITLE
Fix front camera missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.
 * Fixed a video connection issue on network where DNS 8.8.8.8 is blocked. `ACCESS_NETWORK_STATE` permission is required to discover available DNS on the network.
+* Fixed a case when front camera is missing in the phone.
 
 ## [0.9.1] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed a case when front camera is missing in the phone.
+
 ## [0.10.0] - 2021-01-21
 
 ### Added
@@ -22,7 +27,6 @@
 ### Fixed
 * Fixed potential concurrency issue on `VideoSourceAdapter`.
 * Fixed a video connection issue on network where DNS 8.8.8.8 is blocked. `ACCESS_NETWORK_STATE` permission is required to discover available DNS on the network.
-* Fixed a case when front camera is missing in the phone.
 
 ## [0.9.1] - 2021-01-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Fixed
-* Fixed a case when front camera is missing in the phone.
+* Fixed a case when front camera is missing in the phone. (Issue #218)
 
 ## [0.10.0] - 2021-01-21
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -88,7 +88,8 @@ class DefaultCameraCaptureSource(
     }
 
     override var device: MediaDevice? = MediaDevice.listVideoDevices(cameraManager)
-        .firstOrNull { it.type == MediaDeviceType.VIDEO_FRONT_CAMERA }
+        .firstOrNull { it.type == MediaDeviceType.VIDEO_FRONT_CAMERA } ?: MediaDevice.listVideoDevices(cameraManager)
+        .firstOrNull { it.type == MediaDeviceType.VIDEO_BACK_CAMERA }
         set(value) {
             logger.info(TAG, "Setting capture device: $value")
             if (field == value) {
@@ -112,7 +113,8 @@ class DefaultCameraCaptureSource(
             MediaDeviceType.VIDEO_FRONT_CAMERA
         }
         device =
-            MediaDevice.listVideoDevices(cameraManager).firstOrNull { it.type == desiredDeviceType }
+            MediaDevice.listVideoDevices(cameraManager).firstOrNull { it.type == desiredDeviceType } ?: MediaDevice.listVideoDevices(cameraManager)
+                .firstOrNull { it.type == MediaDeviceType.VIDEO_BACK_CAMERA }
     }
 
     override var torchEnabled: Boolean = false

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSourceTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSourceTest.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert
 import org.junit.Before
 import org.junit.Ignore
 
@@ -161,6 +162,23 @@ class DefaultCameraCaptureSourceTest {
         verify { mockSurfaceTextureCaptureSource.addVideoSink(any()) }
         verify { mockCameraManager.openCamera("0", any<CameraDevice.StateCallback>(), any()) }
     }
+
+    @Ignore("Broken on build server, possible Mockk issue")
+    fun `switch should default to back if front camera is missing`() {
+        testCameraCaptureSource.start()
+        testCameraCaptureSource.switchCamera()
+        every { MediaDevice.listVideoDevices(any()) } returns listOf(
+            MediaDevice("back", MediaDeviceType.VIDEO_BACK_CAMERA, "1")
+        ) andThen listOf(
+            MediaDevice("back", MediaDeviceType.VIDEO_BACK_CAMERA, "1")
+        )
+
+        Assert.assertEquals(MediaDeviceType.VIDEO_BACK_CAMERA, testCameraCaptureSource.device?.type)
+
+        testCameraCaptureSource.switchCamera()
+
+        Assert.assertEquals(MediaDeviceType.VIDEO_BACK_CAMERA, testCameraCaptureSource.device?.type)
+}
 
     @Ignore("Broken on build server, possible Mockk issue")
     fun `stop stops and releases surface texture capture source`() {


### PR DESCRIPTION
### Issue #, if available:
#217 

### Description of changes:
It could be possible to have device without front camera. In that case, we'll default to back camera.

### Testing done:

Since we didn't have device with front camera missing, I modify the code to find null camera and it defaults to back camera.

#### Unit test coverage
* Class coverage: 80%
* Line coverage: 68%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
