### PR TITLE
Add thread-safe set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [Unreleased]
 ### Added
-* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client
+* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client.
+
+### Fixed
+* Fixed `DefaultCameraCaptureSource`, `DefaultSurfaceTextureCaptureSource` concurrency issue (Issue #221).
 
 ## [0.11.0] - 2021-02-04
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -81,9 +81,8 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
 
     private val observers = mutableSetOf<CaptureSourceObserver>()
 
-    // Concurrency modification could happen when source gets
-    // removed from media server (media thread) while sending frames (app thread).
-    // Use the ConcurrentSet
+    // Concurrency modification could happen when sink gets
+    // added/removed from another thread while sending frames
     private val sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     override val contentHint = VideoContentHint.Motion
@@ -265,13 +264,11 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
     }
 
     override fun addVideoSink(sink: VideoSink) {
-        handler.post { sinks.add(sink) }
+        sinks.add(sink)
     }
 
     override fun removeVideoSink(sink: VideoSink) {
-        runBlocking(handler.asCoroutineDispatcher().immediate) {
-            sinks.remove(sink)
-        }
+        sinks.remove(sink)
     }
 
     override fun addCaptureSourceObserver(observer: CaptureSourceObserver) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -37,6 +37,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFr
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import kotlin.math.abs
@@ -79,7 +80,11 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
     private var surfaceTextureSource: SurfaceTextureCaptureSource? = null
 
     private val observers = mutableSetOf<CaptureSourceObserver>()
-    private val sinks = mutableSetOf<VideoSink>()
+
+    // Concurrency modification could happen when source gets
+    // removed from media server (media thread) while sending frames (app thread).
+    // Use the ConcurrentSet
+    private val sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     override val contentHint = VideoContentHint.Motion
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
@@ -72,9 +72,8 @@ class DefaultScreenCaptureSource(
 
     private val observers = mutableSetOf<CaptureSourceObserver>()
 
-    // Concurrency modification could happen when source gets
-    // removed from media server (media thread) while sending frames (app thread).
-    // Use the ConcurrentSet
+    // Concurrency modification could happen when sink gets
+    // added/removed from another thread while sending frames
     private val sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     // This will prioritize resolution over framerate
@@ -224,13 +223,11 @@ class DefaultScreenCaptureSource(
     }
 
     override fun addVideoSink(sink: VideoSink) {
-        handler.post { sinks.add(sink) }
+        sinks.add(sink)
     }
 
     override fun removeVideoSink(sink: VideoSink) {
-        runBlocking(handler.asCoroutineDispatcher().immediate) {
-            sinks.remove(sink)
-        }
+        sinks.remove(sink)
     }
 
     override fun onVideoFrameReceived(frame: VideoFrame) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
@@ -23,6 +23,7 @@ import android.view.Surface
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoContentHint
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSink
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import kotlin.math.ceil
@@ -70,7 +71,11 @@ class DefaultScreenCaptureSource(
     private val handler: Handler
 
     private val observers = mutableSetOf<CaptureSourceObserver>()
-    private val sinks = mutableSetOf<VideoSink>()
+
+    // Concurrency modification could happen when source gets
+    // removed from media server (media thread) while sending frames (app thread).
+    // Use the ConcurrentSet
+    private val sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     // This will prioritize resolution over framerate
     override val contentHint = VideoContentHint.Text

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
@@ -19,6 +19,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSink
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.video.gl.GlUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.video.TimestampAligner
@@ -79,7 +80,10 @@ class DefaultSurfaceTextureCaptureSource(
     // enough sent a new frame
     private var lastAlignedTimestamp: Long? = null
 
-    private var sinks = mutableSetOf<VideoSink>()
+    // Concurrency modification could happen when source gets
+    // removed from media server (media thread) while sending frames (app thread).
+    // Use the ConcurrentSet
+    private var sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     private val TAG = "SurfaceTextureCaptureSource"
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
@@ -80,9 +80,8 @@ class DefaultSurfaceTextureCaptureSource(
     // enough sent a new frame
     private var lastAlignedTimestamp: Long? = null
 
-    // Concurrency modification could happen when source gets
-    // removed from media server (media thread) while sending frames (app thread).
-    // Use the ConcurrentSet
+    // Concurrency modification could happen when sink gets
+    // added/removed from another thread while sending frames
     private var sinks = ConcurrentSet.createConcurrentSet<VideoSink>()
 
     private val TAG = "SurfaceTextureCaptureSource"
@@ -147,13 +146,11 @@ class DefaultSurfaceTextureCaptureSource(
     override fun removeCaptureSourceObserver(observer: CaptureSourceObserver) {}
 
     override fun addVideoSink(sink: VideoSink) {
-        handler.post { sinks.add(sink) }
+        sinks.add(sink)
     }
 
     override fun removeVideoSink(sink: VideoSink) {
-        runBlocking(handler.asCoroutineDispatcher().immediate) {
-            sinks.remove(sink)
-        }
+        sinks.remove(sink)
     }
 
     override fun release() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/ConcurrentSet.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/ConcurrentSet.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import java.util.Collections
+import java.util.concurrent.ConcurrentHashMap
+
+class ConcurrentSet {
+    companion object {
+        fun <T> createConcurrentSet(): MutableSet<T> {
+            return Collections.newSetFromMap(ConcurrentHashMap<T, Boolean>())
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
@@ -13,9 +13,9 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameI420Buffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameRGBABuffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import java.nio.ByteBuffer
 import java.security.InvalidParameterException
-import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * [VideoSourceAdapter] provides two classes to adapt [VideoSource] to [com.xodee.client.video.VideoSource].
@@ -75,9 +75,7 @@ class VideoSourceAdapter : VideoSink,
 
     // Concurrency modification could happen when source gets
     // removed from media server (media thread) while sending frames (app thread).
-    // Use the CopyOnWriteArrayList as its thread-safe and suits reading more than
-    // updating scenario.
-    private var sinks = CopyOnWriteArrayList<com.xodee.client.video.VideoSink>()
+    private var sinks = ConcurrentSet.createConcurrentSet<com.xodee.client.video.VideoSink>()
 
     override fun addSink(sink: com.xodee.client.video.VideoSink) {
         if (sinks.contains(sink)) return

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoSourceAdapter.kt
@@ -78,7 +78,6 @@ class VideoSourceAdapter : VideoSink,
     private var sinks = ConcurrentSet.createConcurrentSet<com.xodee.client.video.VideoSink>()
 
     override fun addSink(sink: com.xodee.client.video.VideoSink) {
-        if (sinks.contains(sink)) return
         sinks.add(sink)
     }
 


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/221
### Description of changes:
This is to add thread-safe set to `DefaultSurfaceTextureCaptureSource` and related APIs


### Testing done:
Testing code
```
GlobalScope.launch {
                    for (i in 1..1000) {
                        cameraCaptureSource.removeVideoSink(videoPreview)
                        cameraCaptureSource.addVideoSink(videoPreview2)
                        delay(500)
                        cameraCaptureSource.addVideoSink(videoPreview)
                        cameraCaptureSource.removeVideoSink(videoPreview2)
                    }
                }
```

This crashed our application, but after this change, unable to crash.
#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [x] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [X] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
