### PR TITLE
Add analytics API and documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Changed
 * Analytics
   * **Breaking** Changed to take `EventAnalyticsController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
-  * Changed to take `EventAnalyticsController` as an additional parameter of  `DefaultAudioClientObserver`, `DefaultAudioClientController` constructor.
+  * Changed to take `EventAnalyticsController` as an additional parameter of `DefaultAudioClientObserver`, `DefaultAudioClientController` constructor.
 
 ### Fixed
 * Fixed a case when front camera is missing in the phone. (Issue #218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 * Added Analytics
     * `EventAnalyticsController`, `EventAnalyticsFacade`, `EventAnalyticsObserver` to handle analytics.
     * Added `EventAttributes`, `EventName`, `MeetingHistoryEventName` for meeting event information.
-    * **Breaking** Added `EventAnalyticsController` to parameters of `DefaultAudioVideoFacade`, `DefaultCameraCaptureSource`, `DefaultAudioClientObserver`, `DefaultAudioClientController`.
+    * **Breaking** Added `EventAnalyticsController` to property of `DefaultAudioVideoFacade`, `DefaultCameraCaptureSource`, `DefaultAudioClientObserver`, `DefaultAudioClientController`.
     * Added `externalMeetingId` to property of `MeetingSessionConfiguration`.
     * Added `PermissionError` to `CaptureSourceError`
-    * Added `eventAnalyticsController` property to `AudioVideoFacade`
+    * **Breaking** Added `eventAnalyticsController` property to `AudioVideoFacade`
     * [Demo] Added `PostLogger` to demo application to showcase sending events
     * [Documentation] Added analytics API usage documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ### Changed
 * Analytics
-  * **Breaking** Changed to take `EventAnalyticsController` as an additional parameter of `DefaultAudioVideoFacade`.
-  * Changed to take `EventAnalyticsController` as an additional parameter of  `DefaultAudioClientObserver`, `DefaultAudioClientController`
+  * **Breaking** Changed to take `EventAnalyticsController` as an additional parameter of `DefaultAudioVideoFacade` constructor.
+  * Changed to take `EventAnalyticsController` as an additional parameter of  `DefaultAudioClientObserver`, `DefaultAudioClientController` constructor.
 
 ### Fixed
 * Fixed a case when front camera is missing in the phone. (Issue #218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Unreleased
 
+### Added
+* Added Analytics
+    * `EventAnalyticsController`, `EventAnalyticsFacade`, `EventAnalyticsObserver` to handle analytics.
+    * Added `EventAttributes`, `EventName`, `MeetingHistoryEventName` for meeting event information.
+    * **Breaking** Added `EventAnalyticsController` to parameters of `DefaultAudioVideoFacade`, `DefaultCameraCaptureSource`, `DefaultAudioClientObserver`, `DefaultAudioClientController`.
+    * Added `externalMeetingId` to property of `MeetingSessionConfiguration`.
+    * Added `PermissionError` to `CaptureSourceError`
+    * Added `eventAnalyticsController` property to `AudioVideoFacade`
+    * [Demo] Added `PostLogger` to demo application to showcase sending events
+    * [Documentation] Added analytics API usage documentation
+
 ### Fixed
 * Fixed a case when front camera is missing in the phone. (Issue #218)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 * Added Analytics
     * `EventAnalyticsController`, `EventAnalyticsFacade`, `EventAnalyticsObserver` to handle analytics.
     * Added `EventAttributes`, `EventName`, `MeetingHistoryEventName` for meeting event information.
-    * **Breaking** Added `EventAnalyticsController` to property of `DefaultAudioVideoFacade`, `DefaultCameraCaptureSource`, `DefaultAudioClientObserver`, `DefaultAudioClientController`.
     * Added `externalMeetingId` to property of `MeetingSessionConfiguration`.
-    * Added `PermissionError` to `CaptureSourceError`
-    * **Breaking** Added `eventAnalyticsController` property to `AudioVideoFacade`
-    * [Demo] Added `PostLogger` to demo application to showcase sending events
-    * [Documentation] Added analytics API usage documentation
+    * Added `PermissionError` to `CaptureSourceError`.
+    * **Breaking** Added `eventAnalyticsController` to property of `AudioVideoFacade`.
+    * [Demo] Added `PostLogger` to demo application to showcase sending events to backend.
+    * [Documentation] Added analytics API usage documentation.
+
+### Changed
+* Analytics
+  * **Breaking** Changed to take `EventAnalyticsController` as an additional parameter of `DefaultAudioVideoFacade`.
+  * Changed to take `EventAnalyticsController` as an additional parameter of  `DefaultAudioClientObserver`, `DefaultAudioClientController`
 
 ### Fixed
 * Fixed a case when front camera is missing in the phone. (Issue #218)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ And review the following guides:
 * [Custom Video Sources, Processors, and Sinks](guides/custom_video.md)
 * [Video Pagination with Active Speaker-Based Policy](guides/video_pagination.md)
 * [Content Share](guides/content_share.md)
+* [Meeting Events](guides/meeting_events.md)
 
 ## Setup
 

--- a/THIRD-PARTY.txt
+++ b/THIRD-PARTY.txt
@@ -142,7 +142,7 @@ The Amazon Chime SDK for Android includes the following third-party software/lic
 https://github.com/Kotlin/kotlinx.coroutines
 ** Material Components; version 1.1.0 --
 https://github.com/material-components/material-components-android
-** MockK; version 1.9.3 -- https://mockk.io/
+** MockK; version 1.10.0 -- https://mockk.io/
 ** shadow; version 4.0.2 -- https://github.com/johnrengelman/shadow
 ** shadow; version 4.0.2 -- https://github.com/johnrengelman/shadow
 

--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -85,5 +85,5 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3'
     testImplementation 'junit:junit:4.12'
-    testImplementation "io.mockk:mockk:1.9.3"
+    testImplementation "io.mockk:mockk:1.10.0"
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.DeviceUtils
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.util.Calendar
+
+class DefaultEventAnalyticsController(
+    private val logger: Logger,
+    private val meetingSessionConfiguration: MeetingSessionConfiguration,
+    private val meetingStatsCollector: MeetingStatsCollector
+) : EventAnalyticsController {
+    private var eventAnalyticsObservers: MutableSet<EventAnalyticsObserver> = mutableSetOf()
+
+    override fun publishEvent(name: EventName, attributes: EventAttributes?) {
+        val now = Calendar.getInstance().timeInMillis
+
+        // Also pushes to the history
+        meetingStatsCollector.addMeetingHistoryEvent(
+            MeetingHistoryEventName.fromMeetingEvent(name),
+            now
+        )
+
+        // Create event to publish
+        val eventAttributes = attributes ?: mutableMapOf()
+        eventAttributes[EventAttributeName.timestampMs] = now
+
+        // Add meeting stats for meeting cycle related events
+        when (name) {
+            EventName.meetingStartSucceeded, EventName.meetingStartFailed,
+            EventName.meetingEnded, EventName.meetingFailed ->
+                eventAttributes.putAll(meetingStatsCollector.getMeetingStatsEventAttributes())
+            else -> Unit
+        }
+
+        ObserverUtils.notifyObserverOnMainThread(eventAnalyticsObservers) {
+            it.onEventReceived(name, eventAttributes)
+        }
+    }
+
+    override fun pushHistory(historyEventName: MeetingHistoryEventName) {
+        meetingStatsCollector.addMeetingHistoryEvent(historyEventName, Calendar.getInstance().timeInMillis)
+    }
+
+    override fun getMeetingHistory(): List<MeetingHistoryEvent> {
+        return meetingStatsCollector.getMeetingHistory()
+    }
+
+    override fun getCommonEventAttributes(): EventAttributes {
+        return mutableMapOf(
+            EventAttributeName.deviceName to DeviceUtils.deviceName,
+            EventAttributeName.deviceManufacturer to DeviceUtils.deviceManufacturer,
+            EventAttributeName.deviceModel to DeviceUtils.deviceModel,
+            EventAttributeName.mediaSdkVersion to DeviceUtils.mediaSDKVersion,
+            EventAttributeName.osName to DeviceUtils.osName,
+            EventAttributeName.osVersion to DeviceUtils.osVersion,
+            EventAttributeName.sdkName to DeviceUtils.sdkName,
+            EventAttributeName.sdkVersion to DeviceUtils.sdkVersion,
+            EventAttributeName.meetingId to meetingSessionConfiguration.meetingId,
+            EventAttributeName.externalMeetingId to
+                    meetingSessionConfiguration.externalMeetingId,
+            EventAttributeName.attendeeId to
+                    meetingSessionConfiguration.credentials.attendeeId,
+            EventAttributeName.externalUserId to
+                    meetingSessionConfiguration.credentials.externalUserId
+        )
+    }
+
+    override fun addEventAnalyticsObserver(observer: EventAnalyticsObserver) {
+        this.eventAnalyticsObservers.add(observer)
+    }
+
+    override fun removeEventAnalyticsObserver(observer: EventAnalyticsObserver) {
+        this.eventAnalyticsObservers.remove(observer)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.DeviceUtils

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.util.Calendar
+
+class DefaultMeetingStatsCollector(
+    private val logger: Logger
+) : MeetingStatsCollector {
+    // The time meeting has started
+    private var meetingStartTimeMs: Long = 0L
+    // The number of attempts to reconnect to the meeting
+    private var retryCount: Int = 0
+    // The number of poor connection occurrences
+    private var poorConnectionCount: Int = 0
+    // The max count of video tile during the meeting
+    private var maxVideoTileCount: Int = 0
+
+    private val historyEvents = mutableListOf<MeetingHistoryEvent>()
+
+    override fun incrementRetryCount() {
+        retryCount++
+    }
+
+    override fun incrementPoorConnectionCount() {
+        poorConnectionCount++
+    }
+
+    override fun updateMaxVideoTile(videoTileCount: Int) {
+        maxVideoTileCount = videoTileCount.coerceAtLeast(maxVideoTileCount)
+    }
+
+    override fun updateMeetingStartTimeMs() {
+        meetingStartTimeMs = Calendar.getInstance().timeInMillis
+    }
+
+    override fun resetMeetingStats() {
+        meetingStartTimeMs = 0L
+        retryCount = 0
+        poorConnectionCount = 0
+        maxVideoTileCount = 0
+    }
+
+    override fun getMeetingStatsEventAttributes(): EventAttributes {
+        return mutableMapOf(
+            EventAttributeName.maxVideoTileCount to maxVideoTileCount,
+            EventAttributeName.retryCount to retryCount,
+            EventAttributeName.poorConnectionCount to poorConnectionCount,
+            EventAttributeName.meetingDurationMs to if (meetingStartTimeMs == 0L) 0L else Calendar.getInstance().timeInMillis - meetingStartTimeMs
+        )
+    }
+
+    override fun addMeetingHistoryEvent(historyEventName: MeetingHistoryEventName, timestampMs: Long) {
+        historyEvents.add(MeetingHistoryEvent(historyEventName, timestampMs))
+    }
+
+    override fun getMeetingHistory(): List<MeetingHistoryEvent> = historyEvents
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
@@ -2,7 +2,6 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
@@ -13,7 +13,7 @@ interface EventAnalyticsController {
      * Publish an event with updated [EventAttributes].
      *
      * @param name: [EventName] - Name of event to publish
-     * @param attributes: [EventAttributes] - Attributes of event to pass to builders. It will always add default attributes
+     * @param attributes: [EventAttributes] - Attributes of event to pass to builders.
      */
     fun publishEvent(name: EventName, attributes: EventAttributes? = null)
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsController.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+/**
+ * [EventAnalyticsController] keeps track of events and notifies [EventAnalyticsObserver].
+ * An event describes the success and failure conditions for the meeting session.
+ */
+interface EventAnalyticsController {
+    /**
+     * Publish an event with updated [EventAttributes].
+     *
+     * @param name: [EventName] - Name of event to publish
+     * @param attributes: [EventAttributes] - Attributes of event to pass to builders. It will always add default attributes
+     */
+    fun publishEvent(name: EventName, attributes: EventAttributes? = null)
+
+    /**
+     * Push [MeetingHistoryEventName] to internal [MeetingStatsCollector].
+     *
+     * @param historyEventName: MeetingHistoryEventName - History event name to add.
+     */
+    fun pushHistory(historyEventName: MeetingHistoryEventName)
+
+    /**
+     * Retrieve meeting history.
+     */
+    fun getMeetingHistory(): List<MeetingHistoryEvent>
+
+    /**
+     * Retrieve common attributes, including deviceName, osName, and more.
+     */
+    fun getCommonEventAttributes(): EventAttributes
+
+    /**
+     * Add specified [EventAnalyticsObserver].
+     *
+     * @param observer: [EventAnalyticsObserver] - The observer to subscribe to events with.
+     */
+    fun addEventAnalyticsObserver(observer: EventAnalyticsObserver)
+
+    /**
+     * Remove specified [EventAnalyticsObserver].
+     *
+     * @param observer: [EventAnalyticsObserver] - The observer to unsubscribe from events with.
+     */
+    fun removeEventAnalyticsObserver(observer: EventAnalyticsObserver)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsFacade.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+/**
+ * [EventAnalyticsFacade] allows builders to listen to meeting analytics events
+ * through adding/removing [EventAnalyticsObserver].
+ *
+ * For instance, if meeting start succeeded, you'll receive data
+ * [EventAnalyticsObserver.onEventReceived] with name as [EventName] and attributes as [EventAttributes],
+ * which is just [Map]. [EventAttributes] should include information about the device (model, OS),
+ * meeting (meeting ID), attendee (attendee ID, external attendee ID).
+ *
+ * For more information about the attributes, please refer to [EventAttributeName].
+ *
+ * It can have additional attributes based on the event.
+ */
+interface EventAnalyticsFacade {
+    /**
+     * Subscribe to meeting event related data with an observer.
+     *
+     * @param observer: [EventAnalyticsObserver] - An observer to add to start receiving meeting events
+     */
+    fun addEventAnalyticsObserver(observer: EventAnalyticsObserver)
+
+    /**
+     * Unsubscribe from meeting event by removing the specified observer.
+     *
+     * @param observer: [EventAnalyticsObserver] - An observer to remove to stop receiving meeting events
+     */
+    fun removeEventAnalyticsObserver(observer: EventAnalyticsObserver)
+
+    /**
+     * Retrieve meeting history.
+     */
+    fun getMeetingHistory(): List<MeetingHistoryEvent>
+
+    /**
+     * Retrieve common attributes, including deviceName, osName, and more.
+     */
+    fun getCommonEventAttributes(): EventAttributes
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsFacade.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**
@@ -10,8 +11,7 @@ package com.amazonaws.services.chime.sdk.meetings.analytics
  *
  * For instance, if meeting start succeeded, you'll receive data
  * [EventAnalyticsObserver.onEventReceived] with name as [EventName] and attributes as [EventAttributes],
- * which is just [Map]. [EventAttributes] should include information about the device (model, OS),
- * meeting (meeting ID), attendee (attendee ID, external attendee ID).
+ * which is just [Map]. This will include attributes specific to the event.
  *
  * For more information about the attributes, please refer to [EventAttributeName].
  *

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsObserver.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAnalyticsObserver.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+/**
+ * [EventAnalyticsObserver] handles events regarding to analytics.
+ */
+interface EventAnalyticsObserver {
+    /**
+     * Called when specific events occur during the meeting. Each event includes attributes of the event.
+     *
+     * For more information about the attributes, please refer to [EventAttributeName].
+     *
+     * One example could be [EventName] as [EventName.meetingStartSucceeded] and
+     * attributes would be [MutableMap] of [EventAttributeName] and it's value.
+     *
+     * @param name: [EventName] - name of meeting event
+     * @param attributes: [EventAttributes] - attributes of meeting event
+     *
+     * NOTE: all callbacks will be called on main thread.
+     */
+    fun onEventReceived(name: EventName, attributes: EventAttributes)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+enum class EventAttributeName {
+    /**
+     * Name of device = Manufacturer of Device + Device Model
+     */
+    deviceName,
+
+    /**
+     * Manufacturer of Device
+     */
+    deviceManufacturer,
+
+    /**
+     * Model of Device
+     */
+    deviceModel,
+
+    /**
+     * Version of media SDK
+     */
+    mediaSdkVersion,
+
+    /**
+     * Operating system name
+     */
+    osName,
+
+    /**
+     * Operating system version
+     */
+    osVersion,
+
+    /**
+     * Name of SDK
+     */
+    sdkName,
+
+    /**
+     * Version of SDK
+     */
+    sdkVersion,
+
+    /**
+     * Timestamp of event occurrence
+     */
+    timestampMs,
+
+    /**
+     * AttendeeId
+     */
+    attendeeId,
+
+    /**
+     * External Meeting Id
+     */
+    externalMeetingId,
+
+    /**
+     * External Attendee Id
+     */
+    externalUserId,
+
+    /**
+     * Meeting Id
+     */
+    meetingId,
+
+    /**
+     * History of the meeting events in chronological order
+     */
+    meetingHistory,
+
+    // Meeting Stats Event Attributes
+
+    /**
+     * Maximum number video tile shared during the meeting, including self video tile
+     */
+    maxVideoTileCount,
+
+    /**
+     * Duration of the meeting
+     */
+    meetingDurationMs,
+
+    /**
+     * Error message of the meeting
+     */
+    meetingErrorMessage,
+
+    /**
+     * Meeting Status [MeetingSessionStatus]
+     */
+    meetingStatus,
+
+    /**
+     * The number of poor connection count during the meeting from start to end
+     */
+    poorConnectionCount,
+
+    /**
+     * The number of meeting retry connection count during the meeting from start to end
+     */
+    retryCount,
+
+    // Device Event Attributes - videoInputFailed
+
+    /**
+     * The error of video input selection such as starting camera
+     */
+    videoInputError;
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributes.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributes.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.JsonUtils
+
+/**
+ * [EventAttributes] describes meeting event.
+ */
+typealias EventAttributes = MutableMap<EventAttributeName, Any>
+
+/**
+ * Convert event attributes into JSON string.
+ *
+ * @return string
+ */
+fun EventAttributes.toJsonString(): String {
+    return JsonUtils.marshal(this)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributes.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributes.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.JsonUtils

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+/**
+ * [EventName] represent some major event that could help builders to analyze the data.
+ */
+enum class EventName {
+    /**
+     * The camera selection failed.
+     */
+    videoInputFailed,
+
+    /**
+     * The meeting will start.
+     */
+    meetingStartRequested,
+
+    /**
+     * The meeting started.
+     */
+    meetingStartSucceeded,
+
+    /**
+     * The meeting failed to start.
+     */
+    meetingStartFailed,
+
+    /**
+     * The meeting ended.
+     */
+    meetingEnded,
+
+    /**
+     * The meeting ended with failure.
+     */
+    meetingFailed;
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEvent.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEvent.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+data class MeetingHistoryEvent(val meetingHistoryEventName: MeetingHistoryEventName, val timestamp: Long)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEventName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEventName.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+/**
+ * [MeetingHistoryEventName] is a notable event (such as MeetingStartSucceeded) that occur during meeting.
+ * Thus, this also includes events in [EventName].
+ */
+enum class MeetingHistoryEventName {
+    /**
+     * The microphone was selected.
+     */
+    audioInputSelected,
+
+    /**
+     * The camera selection failed.
+     */
+    videoInputFailed,
+
+    /**
+     * The camera was selected.
+     */
+    videoInputSelected,
+
+    /**
+     * The meeting failed to start.
+     */
+    meetingStartFailed,
+
+    /**
+     * The meeting will start.
+     */
+    meetingStartRequested,
+
+    /**
+     * The meeting started.
+     */
+    meetingStartSucceeded,
+
+    /**
+     * The meeting ended.
+     */
+    meetingEnded,
+
+    /**
+     * The meeting failed.
+     */
+    meetingFailed,
+
+    /**
+     * The meeting reconnected.
+     */
+    meetingReconnected;
+
+    companion object {
+        fun fromMeetingEvent(name: EventName): MeetingHistoryEventName {
+            return when (name) {
+                EventName.meetingStartSucceeded -> meetingStartSucceeded
+                EventName.videoInputFailed -> videoInputFailed
+                EventName.meetingStartRequested -> meetingStartRequested
+                EventName.meetingStartFailed -> meetingStartFailed
+                EventName.meetingEnded -> meetingEnded
+                EventName.meetingFailed -> meetingFailed
+            }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEventName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingHistoryEventName.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingStatsCollector.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+interface MeetingStatsCollector {
+    /**
+     * Increment meeting session retry count.
+     */
+    fun incrementRetryCount()
+
+    /**
+     * Increment poor connection count during the session.
+     */
+    fun incrementPoorConnectionCount()
+
+    /**
+     * Update max video tile count during the meeting.
+     *
+     * @param videoTileCount: Int - Current video tile count.
+     */
+    fun updateMaxVideoTile(videoTileCount: Int)
+
+    /**
+     * Update meeting start time.
+     */
+    fun updateMeetingStartTimeMs()
+
+    /**
+     * Clear meeting stats.
+     */
+    fun resetMeetingStats()
+
+    /**
+     * Get the meeting stats attributes.
+     *
+     * @return [EventAttributes] - Event attributes of meeting stats.
+     */
+    fun getMeetingStatsEventAttributes(): EventAttributes
+
+    /**
+     * Get a list of meeting history events.
+     *
+     * @return [List<MeetingHistoryEvent>] - The list of meeting history events.
+     */
+    fun getMeetingHistory(): List<MeetingHistoryEvent>
+
+    /**
+     * Add a history meeting event.
+     *
+     * @param historyEventName: MeetingHistoryEventName - History event name to add.
+     * @param timestampMs: Long - Timestamp of the event in millisecond.
+     */
+    fun addMeetingHistoryEvent(historyEventName: MeetingHistoryEventName, timestampMs: Long)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoFacade.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileControllerFacade
@@ -16,4 +17,5 @@ interface AudioVideoFacade : AudioVideoControllerFacade,
     DeviceController,
     VideoTileControllerFacade,
     ActiveSpeakerDetectorFacade,
-    ContentShareController
+    ContentShareController,
+    EventAnalyticsFacade

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -22,7 +22,6 @@ class DefaultAudioVideoController(
     private val videoClientController: VideoClientController,
     private val videoClientObserver: VideoClientObserver
 ) : AudioVideoControllerFacade {
-
     override fun start() {
         audioClientController.start(
             configuration.urls.audioFallbackURL,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -11,6 +11,10 @@ import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsObserver
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEvent
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerpolicy.ActiveSpeakerPolicy
@@ -36,7 +40,8 @@ class DefaultAudioVideoFacade(
     private val deviceController: DeviceController,
     private val videoTileController: VideoTileController,
     private val activeSpeakerDetector: ActiveSpeakerDetectorFacade,
-    private val contentShareController: ContentShareController
+    private val contentShareController: ContentShareController,
+    private val eventAnalyticsController: EventAnalyticsController
 ) : AudioVideoFacade {
 
     private val permissions = arrayOf(
@@ -216,5 +221,21 @@ class DefaultAudioVideoFacade(
 
     override fun removeContentShareObserver(observer: ContentShareObserver) {
         contentShareController.removeContentShareObserver(observer)
+    }
+
+    override fun addEventAnalyticsObserver(observer: EventAnalyticsObserver) {
+        eventAnalyticsController.addEventAnalyticsObserver(observer)
+    }
+
+    override fun removeEventAnalyticsObserver(observer: EventAnalyticsObserver) {
+        eventAnalyticsController.removeEventAnalyticsObserver(observer)
+    }
+
+    override fun getMeetingHistory(): List<MeetingHistoryEvent> {
+        return eventAnalyticsController.getMeetingHistory()
+    }
+
+    override fun getCommonEventAttributes(): EventAttributes {
+        return eventAnalyticsController.getCommonEventAttributes()
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 
+import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglVideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
@@ -15,7 +16,8 @@ class DefaultVideoTileController(
     private val logger: Logger,
     private val videoClientController: VideoClientController,
     private val videoTileFactory: VideoTileFactory,
-    private val eglCoreFactory: EglCoreFactory
+    private val eglCoreFactory: EglCoreFactory,
+    private val meetingStatsCollector: MeetingStatsCollector
 ) : VideoTileController {
     // A map of tile id to VideoTile to determine if VideoTileController is adding, removing, pausing, or rendering
     private val videoTileMap = mutableMapOf<Int, VideoTile>()
@@ -207,6 +209,7 @@ class DefaultVideoTileController(
         }
         val tile = videoTileFactory.makeTile(tileId, thisAttendeeId, videoStreamContentWidth, videoStreamContentHeight, isLocalTile)
         videoTileMap[tileId] = tile
+        meetingStatsCollector.updateMaxVideoTile(videoTileMap.size)
         tile.setPauseState(pauseState)
         forEachObserver { observer -> observer.onVideoTileAdded(tile.state) }
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CaptureSourceError.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CaptureSourceError.kt
@@ -16,6 +16,11 @@ enum class CaptureSourceError {
     Unknown,
 
     /**
+     * A failure to obtain necessary permission to start video
+     */
+    PermissionError,
+
+    /**
      * A failure observed from a system API used for capturing
      * e.g. In response to a `CameraDevice.StateCallback().onError` call
      */

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -17,6 +17,8 @@ import android.media.AudioManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
+import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEventName
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientState
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.DefaultAudioClientController
@@ -28,6 +30,7 @@ class DefaultDeviceController(
     private val context: Context,
     private val audioClientController: AudioClientController,
     private val videoClientController: VideoClientController,
+    private val eventAnalyticsController: EventAnalyticsController,
     private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
     private val buildVersion: Int = Build.VERSION.SDK_INT
 ) : DeviceController {
@@ -157,7 +160,11 @@ class DefaultDeviceController(
             MediaDeviceType.AUDIO_WIRED_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
             else -> AudioClient.SPK_STREAM_ROUTE_RECEIVER
         }
-        audioClientController.setRoute(route)
+
+        val selected = audioClientController.setRoute(route)
+        if (selected) {
+            eventAnalyticsController.pushHistory(MeetingHistoryEventName.audioInputSelected)
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.N)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
@@ -6,20 +6,19 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import android.content.Context
-import com.amazonaws.services.chime.sdk.BuildConfig
 import com.xodee.client.video.VideoClient
 
 object AppInfoUtil {
     fun initializeVideoClientAppDetailedInfo(context: Context) {
-        val manufacturer = android.os.Build.MANUFACTURER
-        val model = android.os.Build.MODEL
-        val osVersion = android.os.Build.VERSION.RELEASE
+        val manufacturer = DeviceUtils.deviceManufacturer
+        val model = DeviceUtils.deviceModel
+        val osVersion = DeviceUtils.osVersion
         val packageName = context.packageName
         val packageInfo = context.packageManager.getPackageInfo(packageName, 0)
         val appVer = packageInfo.versionName
         val appCode = packageInfo.versionCode.toString()
         val clientSource = "amazon-chime-sdk"
-        val sdkVersion = BuildConfig.VERSION_NAME
+        val sdkVersion = DeviceUtils.sdkVersion
 
         VideoClient.AppDetailedInfo.initialize(
             String.format("Android %s", appVer),

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.amazonaws.services.chime.sdk.meetings.utils.Versioning
+import com.biba.android.MediaClient.BuildConfig
+
+/**
+ * [DeviceUtils] stores general device/SDK information
+ */
+class DeviceUtils {
+    companion object {
+        val sdkName: String by lazy {
+            "amazon-chime-sdk-android"
+        }
+        val sdkVersion: String by lazy {
+            Versioning.sdkVersion()
+        }
+
+        val deviceModel: String by lazy {
+            android.os.Build.MODEL
+        }
+
+        val deviceManufacturer: String by lazy {
+            android.os.Build.MANUFACTURER
+        }
+
+        val deviceName: String by lazy {
+            "${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}"
+        }
+
+        val osName: String by lazy {
+            "Android"
+        }
+        val osVersion: String by lazy {
+            android.os.Build.VERSION.RELEASE
+        }
+
+        val mediaSDKVersion: String by lazy {
+            BuildConfig.VERSION_NAME
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtils.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import com.amazonaws.services.chime.sdk.meetings.utils.Versioning

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/JsonUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/JsonUtils.kt
@@ -1,0 +1,13 @@
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.google.gson.Gson
+
+class JsonUtils {
+    companion object {
+        private val gson = Gson()
+
+        fun marshal(data: Any): String {
+            return gson.toJson(data)
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSession.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSession.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.session
 
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 
@@ -16,4 +17,5 @@ interface MeetingSession {
     val configuration: MeetingSessionConfiguration
     val logger: Logger
     val audioVideo: AudioVideoFacade
+    val eventAnalyticsController: EventAnalyticsController
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
@@ -18,6 +18,7 @@ import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
  */
 data class MeetingSessionConfiguration(
     val meetingId: String,
+    val externalMeetingId: String,
     val credentials: MeetingSessionCredentials,
     val urls: MeetingSessionURLs
 ) {
@@ -27,6 +28,7 @@ data class MeetingSessionConfiguration(
         urlRewriter: URLRewriter = ::defaultUrlRewriter
     ) : this(
         createMeetingResponse.Meeting.MeetingId,
+        createMeetingResponse.Meeting.ExternalMeetingId,
         MeetingSessionCredentials(
             createAttendeeResponse.Attendee.AttendeeId,
             createAttendeeResponse.Attendee.ExternalUserId,
@@ -45,6 +47,7 @@ data class MeetingSessionConfiguration(
         val contentModality: String = DefaultModality.MODALITY_SEPARATOR + ModalityType.Content.value
         return MeetingSessionConfiguration(
             meetingId,
+            externalMeetingId,
             MeetingSessionCredentials(
                 credentials.attendeeId + contentModality,
                 credentials.externalUserId,

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.DeviceUtils
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkObject
+import io.mockk.verify
+import java.util.Calendar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class DefaultEventAnalyticsControllerTest {
+    private val testDispatcher = TestCoroutineDispatcher()
+
+    private lateinit var testEventAnalyticsController: EventAnalyticsController
+
+    @MockK
+    private lateinit var mockLogger: Logger
+
+    @MockK
+    private lateinit var mockMeetingSessionConfiguration: MeetingSessionConfiguration
+
+    @MockK
+    private lateinit var mockMeetingStatsCollector: MeetingStatsCollector
+
+    private val meetingDurationAttribute: EventAttributes =
+        mutableMapOf(EventAttributeName.meetingDurationMs to 1000L)
+
+    @Before
+    fun setup() {
+        mockkStatic(Calendar::class)
+
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        testEventAnalyticsController =
+            DefaultEventAnalyticsController(
+                mockLogger,
+                mockMeetingSessionConfiguration,
+                mockMeetingStatsCollector
+            )
+        every { mockMeetingStatsCollector.getMeetingStatsEventAttributes() } returns meetingDurationAttribute
+        every { mockMeetingStatsCollector.getMeetingHistory() } returns emptyList()
+        every { mockMeetingSessionConfiguration.credentials } returns MeetingSessionCredentials(
+            "attendeeId",
+            "externalUserId",
+            "joinToken"
+        )
+        every { mockMeetingSessionConfiguration.externalMeetingId } returns "externalMeetingId"
+        every { mockMeetingSessionConfiguration.meetingId } returns "meetingId"
+        mockkObject(DeviceUtils)
+        every { DeviceUtils.deviceManufacturer } returns "deviceManufacturer"
+        every { DeviceUtils.deviceModel } returns "deviceModel"
+        every { DeviceUtils.deviceName } returns "deviceName"
+        every { DeviceUtils.sdkVersion } returns "sdkVersion"
+        every { DeviceUtils.sdkName } returns "sdkName"
+        every { DeviceUtils.osName } returns "osName"
+        every { DeviceUtils.osVersion } returns "osVersion"
+
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+        unmockkObject(DeviceUtils)
+    }
+
+    @Test
+    fun `onEventReceived should be invoked when publishEvent is called`() {
+        val observer = spyk<EventAnalyticsObserver>()
+        testEventAnalyticsController.addEventAnalyticsObserver(observer)
+        runBlockingTest {
+            testEventAnalyticsController.publishEvent(EventName.meetingFailed)
+        }
+
+        verify(exactly = 1) { observer.onEventReceived(withArg {
+            assertEquals(EventName.meetingFailed, it)
+        }, any()) }
+    }
+
+    @Test
+    fun `onEventReceived should not be invoked when publishEvent is called when no observer is available `() {
+        val observer = spyk<EventAnalyticsObserver>()
+        testEventAnalyticsController.addEventAnalyticsObserver(observer)
+        testEventAnalyticsController.removeEventAnalyticsObserver(observer)
+
+        runBlockingTest {
+            testEventAnalyticsController.publishEvent(EventName.meetingFailed)
+        }
+
+        verify(exactly = 0) { observer.onEventReceived(any(), any()) }
+    }
+
+    @Test
+    fun `onEventReceived should add event when publishEvent is called when no observer is available `() {
+        val observer = spyk<EventAnalyticsObserver>()
+        testEventAnalyticsController.addEventAnalyticsObserver(observer)
+        testEventAnalyticsController.removeEventAnalyticsObserver(observer)
+
+        runBlockingTest {
+            testEventAnalyticsController.publishEvent(EventName.meetingFailed)
+        }
+
+        verify(exactly = 0) { observer.onEventReceived(any(), any()) }
+    }
+
+    @Test
+    fun `onEventReceived should be invoked with meeting stats when event is meeting life cycle related`() {
+        val observer = spyk<EventAnalyticsObserver>()
+        testEventAnalyticsController.addEventAnalyticsObserver(observer)
+
+        runBlockingTest {
+            testEventAnalyticsController.publishEvent(EventName.meetingFailed)
+        }
+
+        verify(exactly = 1) {
+            observer.onEventReceived(
+                EventName.meetingFailed,
+                withArg { assertTrue(it.containsKey(EventAttributeName.meetingDurationMs)) })
+        }
+    }
+
+    @Test
+    fun `onEventReceived should be invoked without meeting stats when event is not meeting life cycle related`() {
+        val observer = spyk<EventAnalyticsObserver>()
+        testEventAnalyticsController.addEventAnalyticsObserver(observer)
+
+        runBlockingTest {
+            testEventAnalyticsController.publishEvent(EventName.videoInputFailed)
+        }
+
+        verify(exactly = 1) { observer.onEventReceived(
+            EventName.videoInputFailed,
+            withArg { assertFalse(it.containsKey(EventAttributeName.meetingDurationMs)) })
+        }
+    }
+
+    @Test
+    fun `getCommonEventAttributes should return common attributes`() {
+        val attributes = testEventAnalyticsController.getCommonEventAttributes()
+
+        assertTrue(attributes.containsKey(EventAttributeName.attendeeId))
+        assertTrue(attributes.containsKey(EventAttributeName.deviceName))
+        assertTrue(attributes.containsKey(EventAttributeName.deviceManufacturer))
+        assertTrue(attributes.containsKey(EventAttributeName.deviceModel))
+        assertTrue(attributes.containsKey(EventAttributeName.sdkVersion))
+        assertTrue(attributes.containsKey(EventAttributeName.mediaSdkVersion))
+        assertTrue(attributes.containsKey(EventAttributeName.meetingId))
+    }
+
+    @Test
+    fun `getMeetingHistory should call meetingStatsCollector to get history events`() {
+        testEventAnalyticsController.getMeetingHistory()
+
+        verify { mockMeetingStatsCollector.getMeetingHistory() }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.DeviceUtils

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollectorTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollectorTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class DefaultMeetingStatsCollectorTest {
+    @MockK
+    private lateinit var mockLogger: Logger
+
+    @InjectMockKs
+    private lateinit var testMeetingStatsCollector: DefaultMeetingStatsCollector
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+    }
+
+    @Test
+    fun `maxVideoTileCount should take the higher value between the current maxVideoTileCount and the value passed in`() {
+        testMeetingStatsCollector.updateMaxVideoTile(5)
+
+        val maxVideoTileCount = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.maxVideoTileCount]
+        assertEquals(5, maxVideoTileCount)
+
+        testMeetingStatsCollector.updateMaxVideoTile(6)
+        val maxVideoTileCountAfter = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.maxVideoTileCount]
+        assertEquals(6, maxVideoTileCountAfter)
+
+        testMeetingStatsCollector.updateMaxVideoTile(5)
+        val maxVideoTileCountLast = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.maxVideoTileCount]
+        assertEquals(6, maxVideoTileCountLast)
+    }
+
+    @Test
+    fun `resetMeetingStats should reset meeting stats`() {
+        testMeetingStatsCollector.updateMeetingStartTimeMs()
+        testMeetingStatsCollector.incrementPoorConnectionCount()
+        testMeetingStatsCollector.incrementRetryCount()
+        testMeetingStatsCollector.updateMaxVideoTile(5)
+
+        testMeetingStatsCollector.resetMeetingStats()
+
+        val meetingDurationMs = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.meetingDurationMs]
+        val retryCount = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.retryCount]
+        val poorConnectionCount = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.poorConnectionCount]
+        val maxVideoTileCount = testMeetingStatsCollector.getMeetingStatsEventAttributes()[EventAttributeName.maxVideoTileCount]
+        assertEquals(0L, meetingDurationMs)
+        assertEquals(0, retryCount)
+        assertEquals(0, poorConnectionCount)
+        assertEquals(0, maxVideoTileCount)
+    }
+
+    @Test
+    fun `getMeetingHistory should return current meeting history`() {
+        assertEquals(0, testMeetingStatsCollector.getMeetingHistory().size)
+
+        testMeetingStatsCollector.addMeetingHistoryEvent(MeetingHistoryEventName.meetingStartSucceeded, 100)
+
+        assertEquals(1, testMeetingStatsCollector.getMeetingHistory().size)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributesTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributesTest.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.analytics
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.JsonUtils
+import org.junit.Assert
+import org.junit.Test
+
+class EventAttributesTest {
+    @Test
+    fun `toJsonString should call JSONUtils marshal function`() {
+        val attributes = mutableMapOf<EventAttributeName, Any>()
+        val text = attributes.toJsonString()
+
+        Assert.assertEquals(JsonUtils.marshal(attributes), text)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -28,6 +28,7 @@ class DefaultAudioVideoControllerTest {
     private lateinit var metricsObserver: MetricsObserver
 
     private val meetingId = "meetingId"
+    private val externalMeetingId = "externalMeetingId"
     private val attendeeId = "attendeeId"
     private val externalUserId = "externalUserId"
     private val joinToken = "joinToken"
@@ -38,6 +39,7 @@ class DefaultAudioVideoControllerTest {
 
     private val meetingSessionConfiguration = MeetingSessionConfiguration(
         meetingId,
+        externalMeetingId,
         MeetingSessionCredentials(attendeeId, externalUserId, joinToken),
         MeetingSessionURLs(audioFallbackURL, audioHostURL, turnControlURL, signalingURL, ::defaultUrlRewriter)
     )

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -7,6 +7,8 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import android.content.Context
 import androidx.core.content.ContextCompat
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
@@ -52,6 +54,9 @@ class DefaultAudioVideoFacadeTest {
     private lateinit var mockRealtimeObserver: RealtimeObserver
 
     @MockK
+    private lateinit var mockEventAnalyticsObserver: EventAnalyticsObserver
+
+    @MockK
     private lateinit var mockDataMessageObserver: DataMessageObserver
 
     @MockK
@@ -68,6 +73,9 @@ class DefaultAudioVideoFacadeTest {
 
     @MockK
     private lateinit var audioVideoController: AudioVideoControllerFacade
+
+    @MockK
+    private lateinit var eventAnalyticsController: EventAnalyticsController
 
     @MockK
     private lateinit var realtimeController: RealtimeControllerFacade
@@ -98,6 +106,13 @@ class DefaultAudioVideoFacadeTest {
     }
 
     @Test
+    fun `addEventAnalyticsObserver should call EvenController addEventAnalyticsObserver with given observer`() {
+        audioVideoFacade.addEventAnalyticsObserver(mockEventAnalyticsObserver)
+
+        verify { eventAnalyticsController.addEventAnalyticsObserver(mockEventAnalyticsObserver) }
+    }
+
+    @Test
     fun `addAudioVideoObserver should call audioVideoController addObserver with given observer`() {
         audioVideoFacade.addAudioVideoObserver(mockAudioVideoObserver)
         verify { audioVideoController.addAudioVideoObserver(mockAudioVideoObserver) }
@@ -113,6 +128,13 @@ class DefaultAudioVideoFacadeTest {
     fun `addMetricsObserver should call audioVideoController addMetricsObserver with given observer`() {
         audioVideoFacade.addMetricsObserver(mockMetricsObserver)
         verify { audioVideoController.addMetricsObserver(mockMetricsObserver) }
+    }
+
+    @Test
+    fun `removeEventAnalyticsObserver should call EvenAnalyticsController removeEventAnalyticsObserver with given observer`() {
+        audioVideoFacade.removeEventAnalyticsObserver(mockEventAnalyticsObserver)
+
+        verify { eventAnalyticsController.removeEventAnalyticsObserver(mockEventAnalyticsObserver) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
@@ -4,6 +4,7 @@
  */
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 
+import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameBuffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientController
@@ -53,6 +54,9 @@ class DefaultVideoTileControllerTest {
 
     @MockK
     private lateinit var mockVideoFrameBuffer: VideoFrameBuffer
+
+    @MockK
+    private lateinit var meetingStatsCollector: MeetingStatsCollector
 
     @InjectMockKs
     private lateinit var videoTileController: DefaultVideoTileController

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtilsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.amazonaws.services.chime.sdk.BuildConfig
+import org.junit.Assert
+import org.junit.Test
+
+class DeviceUtilsTest {
+    @Test
+    fun `sdkName should return "amazon-chime-sdk-android"`() {
+        Assert.assertEquals("amazon-chime-sdk-android", DeviceUtils.sdkName)
+    }
+
+    @Test
+    fun `osName should return "Android"`() {
+        Assert.assertEquals("Android", DeviceUtils.osName)
+    }
+
+    @Test
+    fun `osVersion should return "Android"`() {
+        Assert.assertEquals(android.os.Build.VERSION.RELEASE, DeviceUtils.osVersion)
+    }
+
+    @Test
+    fun `sdkVersion should return value same as BuildConfig`() {
+        Assert.assertEquals(BuildConfig.VERSION_NAME, DeviceUtils.sdkVersion)
+    }
+
+    @Test
+    fun `deviceName should return value same as vendor + model`() {
+        Assert.assertEquals("${android.os.Build.MANUFACTURER} ${android.os.Build.MODEL}", DeviceUtils.deviceName)
+    }
+
+    @Test
+    fun `deviceModel should return value same as model`() {
+        Assert.assertEquals(android.os.Build.MODEL, DeviceUtils.deviceModel)
+    }
+
+    @Test
+    fun `deviceManufacturer should return value same as vendor`() {
+        Assert.assertEquals(android.os.Build.MANUFACTURER, DeviceUtils.deviceManufacturer)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DeviceUtilsTest.kt
@@ -2,6 +2,7 @@
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
+
 package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import com.amazonaws.services.chime.sdk.BuildConfig

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
@@ -13,6 +13,7 @@ import android.os.HandlerThread
 import android.os.Looper
 import android.util.Log
 import com.amazonaws.services.chime.sdk.meetings.TestConstant
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.DefaultCameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
@@ -67,6 +68,9 @@ class DefaultVideoClientControllerTest {
 
     @MockK
     private lateinit var mockEglCoreFactory: EglCoreFactory
+
+    @MockK
+    private lateinit var eventAnalyticsController: EventAnalyticsController
 
     @MockK(relaxed = true)
     private lateinit var mockEglCore: EglCore

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
@@ -5,8 +5,6 @@
 
 package com.amazonaws.services.chime.sdk.meetings.session
 
-import android.bluetooth.BluetoothAdapter
-import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.AssetManager
@@ -69,11 +67,6 @@ class DefaultMeetingSessionTest {
         every { context.assets } returns assetManager
         every { context.registerReceiver(any(), any()) } returns mockkClass(Intent::class)
         val audioManager = mockkClass(AudioManager::class)
-        val btManager = mockkClass(BluetoothManager::class)
-        val btAdapter = mockkClass(BluetoothAdapter::class)
-        every { btAdapter.getProfileProxy(any(), any(), any()) } returns true
-        every { btAdapter.closeProfileProxy(any(), any()) } returns Unit
-        every { btManager.adapter } returns btAdapter
         every { audioManager.mode = any() } returns Unit
         every { audioManager.mode } returns AudioManager.MODE_NORMAL
         every { audioManager.isSpeakerphoneOn } returns true

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -39,8 +39,10 @@ class MeetingActivity : AppCompatActivity(),
     private val logger = ConsoleLogger(LogLevel.DEBUG)
     private val gson = Gson()
     private val meetingSessionModel: MeetingSessionModel by lazy { ViewModelProvider(this)[MeetingSessionModel::class.java] }
+
     private lateinit var meetingId: String
     private lateinit var name: String
+
     private var cachedDevice: MediaDevice? = null
 
     private val TAG = "InMeetingActivity"
@@ -57,6 +59,7 @@ class MeetingActivity : AppCompatActivity(),
             val sessionConfig = createSessionConfiguration(meetingResponseJson)
             val meetingSession = sessionConfig?.let {
                 logger.info(TAG, "Creating meeting session for meeting Id: $meetingId")
+
                 DefaultMeetingSession(
                     it,
                     logger,
@@ -82,7 +85,9 @@ class MeetingActivity : AppCompatActivity(),
             }
 
             val surfaceTextureCaptureSourceFactory = DefaultSurfaceTextureCaptureSourceFactory(logger, meetingSessionModel.eglCoreFactory)
-            meetingSessionModel.cameraCaptureSource = DefaultCameraCaptureSource(applicationContext, logger, surfaceTextureCaptureSourceFactory)
+            meetingSessionModel.cameraCaptureSource = DefaultCameraCaptureSource(applicationContext, logger, surfaceTextureCaptureSourceFactory).apply {
+                eventAnalyticsController = meetingSession?.eventAnalyticsController
+            }
             meetingSessionModel.cpuVideoProcessor = CpuVideoProcessor(logger, meetingSessionModel.eglCoreFactory)
             meetingSessionModel.gpuVideoProcessor = GpuVideoProcessor(logger, meetingSessionModel.eglCoreFactory)
 
@@ -130,6 +135,8 @@ class MeetingActivity : AppCompatActivity(),
     }
 
     fun getAudioVideo(): AudioVideoFacade = meetingSessionModel.audioVideo
+
+    fun getMeetingSessionConfiguration(): MeetingSessionConfiguration = meetingSessionModel.configuration
 
     fun getMeetingSessionCredentials(): MeetingSessionCredentials = meetingSessionModel.credentials
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -103,7 +103,7 @@ class MeetingFragment : Fragment(),
     private var deviceDialog: AlertDialog? = null
     private var screenShareManager: ScreenShareManager? = null
     private val gson = Gson()
-    private val appName = "SDKEvent"
+    private val appName = "SDKEvents"
 
     private lateinit var mediaProjectionManager: MediaProjectionManager
     private lateinit var powerManager: PowerManager

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
@@ -11,6 +11,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.Camera
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.DefaultEglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSession
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
 import com.amazonaws.services.chime.sdkdemo.device.ScreenShareManager
 import com.amazonaws.services.chime.sdkdemo.utils.CpuVideoProcessor
@@ -25,6 +26,9 @@ class MeetingSessionModel : ViewModel() {
 
     val credentials: MeetingSessionCredentials
         get() = meetingSession.configuration.credentials
+
+    val configuration: MeetingSessionConfiguration
+        get() = meetingSession.configuration
 
     val audioVideo: AudioVideoFacade
         get() = meetingSession.audioVideo

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/LogEntry.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/LogEntry.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdkdemo.utils
+
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
+
+/**
+ * Log format for the server
+ *
+ * @property sequenceNumber sequence number of the log
+ * @property message message to log
+ * @property timestampMs time of when log occurred
+ * @property logLevel level of log
+ */
+data class LogEntry(
+    val sequenceNumber: Int,
+    val message: String,
+    val timestampMs: Long,
+    val logLevel: LogLevel
+)

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/PostLogger.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/PostLogger.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdkdemo.utils
+
+import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.google.gson.Gson
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Calendar
+import java.util.concurrent.atomic.AtomicInteger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class PostLogger(
+    private val name: String,
+    private val configuration: MeetingSessionConfiguration,
+    private val url: String,
+    private var level: LogLevel = LogLevel.INFO
+) : Logger {
+    private val gson = Gson()
+    private val uiScope = CoroutineScope(Dispatchers.Main)
+    private var sequenceNumber = AtomicInteger(0)
+    private val logEntries: MutableList<LogEntry> = mutableListOf()
+
+    override fun verbose(tag: String, msg: String) {
+        log(tag, msg, LogLevel.VERBOSE)
+    }
+
+    override fun debug(tag: String, msg: String) {
+        log(tag, msg, LogLevel.DEBUG)
+    }
+
+    override fun info(tag: String, msg: String) {
+        log(tag, msg, LogLevel.INFO)
+    }
+
+    override fun warn(tag: String, msg: String) {
+        log(tag, msg, LogLevel.WARN)
+    }
+
+    override fun error(tag: String, msg: String) {
+        log(tag, msg, LogLevel.ERROR)
+    }
+
+    override fun setLogLevel(level: LogLevel) {
+        this.level = level
+    }
+
+    override fun getLogLevel(): LogLevel {
+        return level
+    }
+
+    private fun saveLog(msg: String, type: LogLevel) {
+        logEntries.add(LogEntry(sequenceNumber.get(), msg, Calendar.getInstance().timeInMillis, type))
+        sequenceNumber.incrementAndGet()
+    }
+
+    fun publishLog(tag: String) {
+        val body = makeRequestBody(logEntries)
+        uiScope.launch {
+            makeRequest(body, tag)
+        }
+    }
+
+    private fun log(tag: String, msg: String, type: LogLevel) {
+        if (type.priority < this.level.priority) return
+        saveLog(msg, type)
+    }
+
+    private suspend fun makeRequest(body: String, tag: String) {
+        withContext(Dispatchers.IO) {
+            val serverUrl = URL(url)
+            try {
+                val response = StringBuffer()
+                with(serverUrl.openConnection() as HttpURLConnection) {
+                    requestMethod = "POST"
+                    doInput = true
+                    doOutput = true
+                    setRequestProperty("Accept", "application/json")
+
+                    outputStream.use {
+                        val input = body.toByteArray()
+                        it.write(input, 0, input.size)
+                    }
+
+                    BufferedReader(InputStreamReader(inputStream)).use {
+                        var inputLine = it.readLine()
+                        while (inputLine != null) {
+                            response.append(inputLine)
+                            inputLine = it.readLine()
+                        }
+                        it.close()
+                    }
+
+                    if (responseCode == 200) {
+                        Log.i(tag, "Publishing log was successful")
+                        response.toString()
+                        logEntries.clear()
+                    } else {
+                        Log.e(tag, "Unable to publish log. Response code: $responseCode")
+                        null
+                    }
+                }
+            } catch (exception: Exception) {
+                Log.e(tag, "There was an exception while posting logs: $exception")
+                null
+            }
+        }
+    }
+
+    private fun makeRequestBody(batch: MutableList<LogEntry>): String {
+        val body = mutableMapOf(
+            "meetingId" to configuration.meetingId,
+            "attendeeId" to configuration.credentials.attendeeId,
+            "appName" to name,
+            "logs" to batch
+        )
+        return gson.toJson(body)
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 07 22:08:29 PDT 2020
+#Mon Dec 07 00:10:41 PST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/guides/meeting_events.md
+++ b/guides/meeting_events.md
@@ -1,0 +1,180 @@
+# Meeting Events
+
+The `onEventReceived` observer method makes it easy to collect, process, and monitor meeting events.
+You can use meeting events to identify and troubleshoot the cause of device and meeting failures.
+
+To receive meeting events, add an observer, and implement the `onEventReceived` observer method.
+
+```kotlin
+val observer = object: EventAnalyticsObserver {
+    override fun onEventReceived(name, attributes) {
+      // Handle a meeting event.
+    }
+}
+
+meetingSession.audioVideo.addEventAnalyticsObserver(observer);
+```
+
+In the `onEventReceived` observer method, we recommend that you handle each meeting event so that 
+you don't have to worry about how your event processing would scale when the later versions of Chime SDK introduce new meeting events.
+
+For example, the code outputs error information for three failure events at the `error` log level.
+
+```kotlin
+override fun onEventReceived(name: EventName, attributes: EventAttributes) {
+    when (name) {
+        EventName.videoInputFailed -> 
+            logger.error(TAG, "Video input failed $name ${attributes.text()}")
+        EventName.meetingStartFailed -> 
+            logger.error(TAG, "Meeting start failed $name ${attributes.text()}")
+        EventName.meetingFailed ->
+            logger.error(TAG, "Meeting failed $name ${attributes.text()}")
+        else -> Unit
+    }
+}
+```
+
+Ensure that you are familiar with the attributes you want to use. See the following two examples.
+The code logs the last 5 minutes of the meeting history attribute when a failure event occurs.
+It's helpful to reduce the amount of data sent to your server application or analytics tool.
+```kotlin
+override fun onEventReceived(name: EventName, attributes: EventAttributes) {
+    val meetingHistory = meetingSession.audioVideo.getMeetingHistory()
+    val lastFiveMinutes = System.currentTimeMillis() - 300_000
+    val recentMeetingHistory = meetingHistory?.filter { it.timestamp >= lastFiveMinutes }
+
+    when (name) {
+        EventName.VideoInputFailed,
+        EventName.MeetingStartFailed,
+        EventName.MeetingFailed ->
+          logger.error("Failure $name ${attributes.text()} $recentMeetingHistory")
+        else -> Unit
+    }
+}
+```
+
+There could be case where builders might want to use `EventAnalyticsController` to invoke events on their custom classes. One simple example is `DefaultCameraCaptureSource`. In this case, you can simply do set the `eventAnalyticsController` with `meetingSession.eventAnalyticsController`.
+
+```kotlin
+val meetingSessionConfig = /* MeetingSessionConfiguration instance */
+val eglCoreFactory = /* instance of EglCoreFactory */
+val surfaceTextureCaptureSourceFactory = /* instance of SurfaceTextureCaptureSourceFactory */
+
+val cameraCaptureSource = DefaultCameraCaptureSource(
+    applicationContext,
+    logger,
+    surfaceTextureCaptureSourceFactory
+)
+
+val meetingSession = DefaultMeetingSession(
+    meetingSessionConfig,
+    logger,
+    applicationContext,
+    eglCoreFactory
+)
+
+cameraCaptureSource.eventAnalyticsController = meetingSession.eventAnalyticsController
+```
+
+## Meeting events and attributes
+Chime SDK sends these meeting events.
+|Event name            |Description
+|--                    |--
+|`meetingStartRequested` |The meeting will start.
+|`meetingStartSucceeded` |The meeting started.
+|`meetingStartFailed`    |The meeting failed to start.
+|`meetingEnded`          |The meeting ended.
+|`meetingFailed`         |The meeting ended with one of the following failure [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.session/-meeting-session-status-code/index.html): <br><ul><li>`AudioJoinedFromAnotherDevice`</li><li>`AudioDisconnectAudio`</li><li>`AudioAuthenticationRejected`</li><li>`AudioCallAtCapacity`</li><li>`AudioCallEnded`</li><li>`AudioInternalServerError`</li><li>`AudioServiceUnavailable`</li><li>`AudioDisconnected`</li></ul>
+|`videoInputFailed`      |The camera selection failed.
+
+### Common attributes
+Chime SDK stores common attributes for event to identify the event.
+
+```kotlin
+meetingSession.audioVideo.getCommonAttributes()
+```
+
+|Attribute|Description
+|--|--
+|`attendeeId`|The Amazon Chime SDK attendee ID.
+|`deviceName`|The manufacturer and model name of the computer or mobile device. `unknown` indicates that the device name can't be found.
+|`deviceManufacturer`|The manufacturer of the computer or mobile device. `unknown` indicates that the device name can't be found.
+|`deviceModel`|The model name of the computer or mobile device. `unknown` indicates that the device name can't be found.
+|`externalMeetingId`|The Amazon Chime SDK external meeting ID.
+|`externalUserId`|The Amazon Chime SDK external user ID that can indicate an identify managed by your application.
+|`meetingId`|The Amazon Chime SDK meeting ID.
+|`mediaSdkVersion`|The Amazon Chime Android Media SDK version.
+|`osName`|The operating system.
+|`osVersion`|The version of the operating system.
+|`sdkName`|The Amazon Chime SDK name, such as `amazon-chime-sdk-android`.
+|`sdkVersion`|The Amazon Chime SDK version.
+
+### Standard attributes
+Chime SDK sends a meeting event with attributes. These standard attributes are available as part of every event type.
+
+|Attribute|Description
+|--|--
+|`timestampMs`|The local time, in milliseconds since 00:00:00 UTC on 1 January 1970, at which an event occurred.<br><br>Unit: Milliseconds
+
+
+### Meeting attributes
+The following table describes attributes for a meeting.
+|Attribute|Description|Included in
+|--|--|--
+|`maxVideoTileCount`|The maximum number of simultaneous video tiles shared during the meeting. This includes a local tile (your video), remote tiles, and content shares.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+|`meetingDurationMs`|The time that elapsed between the beginning (`AudioVideoObserver.onAudioSessionStarted`) and the end (`AudioVideoObserver.onAudioSessionStopped`) of the meeting.<br><br>Unit: Milliseconds|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+|`meetingErrorMessage`|The error message that explains why the meeting has failed.| `meetingFailed`
+|`meetingStatus`|The meeting status when the meeting ended or failed. Note that this attribute indicates an enum name in [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.session/-meeting-session-status-code/index.html), such as `Left` or `MeetingEnded`.|`meetingStartFailed`, `meetingEnded`, `meetingFailed`
+|`poorConnectionCount`|The number of times the significant packet loss occurred during the meeting. Per count, you receive `AudioVideoObserver.onConnectionBecamePoor`.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+|`retryCount`|The number of connection retries performed during the meeting.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+
+### Device attributes
+The following table describes attributes for the camera.
+|Attribute|Description|Included in
+|--|--|--
+|`videoInputError`|The error message that explains why the camera selection failed.|`videoInputFailed`
+
+### The meeting history attribute
+The meeting history attribute is a list of states. Each state object contains the state name and timestamp.
+
+```kotlin
+meetingSession.audioVideo.getMeetingHistory()
+```
+
+```
+[
+  {
+    name: 'audioInputSelected',
+    timestampMs: 1612166400000
+  },
+  {
+    name: 'meetingStartSucceeded',
+    timestampMs: 1612167400000
+  },
+  {
+    name: 'meetingEnded',
+    timestampMs: 1612167900000
+  }
+]
+```
+You can use the meeting history to track user actions and events from the creation of the `DefaultMeetingSession` object.
+For example, if you started a meeting twice using the same `DefaultMeetingSession` object,
+the meeting history will include two `meetingStartSucceeded`.
+
+> Note: that meeting history can have a large number of states. Ensure that you process the meeting history before sending it to your server application or analytics tool.
+
+The following table lists available states.
+|State|Description
+|--|--
+|`audioInputSelected`|The microphone was selected.
+|`meetingEnded`|The meeting ended.
+|`meetingFailed`|The meeting ended with the failure status.
+|`meetingReconnected`|The meeting reconnected.
+|`meetingStartFailed`|The meeting failed to start.
+|`meetingStartRequested`|The meeting will start.
+|`meetingStartSucceeded`|The meeting started.
+|`videoInputFailed`|The camera selection failed.
+|`videoInputSelected`|The camera was selected.
+
+## Example
+[The Chime SDK serverless demo](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless) uses Amazon CloudWatch Logs to collect, process, and analyze meeting events. For more information, see [the Meeting Dashboard section](https://github.com/aws/amazon-chime-sdk-js/tree/master/demos/serverless#meeting-dashboard) on the serverless demo page.


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Add basic API for analytics and documentation

### Testing done:
Checked each event is emitted.

#### Unit test coverage
* Class coverage:  81%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [X] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [X] Switch camera
* [X] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [X] First time audio permissions
* [X] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
