### PR TITLE
Pass app info to audio client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+### Added
+* Added `initializeAudioClientAppInfo` to `AppInfoUtil` for use with audio client
+
 ## [0.11.0] - 2021-02-04
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -14,6 +14,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
@@ -143,8 +144,11 @@ class DefaultAudioClientController(
             )
         }
         audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
+
+        val appInfo = AppInfoUtil.initializeAudioClientAppInfo(context)
+
         uiScope.launch {
-            val res = audioClient.startSession(
+            val res = audioClient.startSessionV2(
                 AudioClient.XTL_DEFAULT_TRANSPORT,
                 host,
                 port,
@@ -157,7 +161,8 @@ class DefaultAudioClientController(
                 DEFAULT_MIC_AND_SPEAKER,
                 DEFAULT_PRESENTER,
                 audioFallbackUrl,
-                null
+                null,
+                appInfo
             )
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
@@ -6,25 +6,51 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import android.content.Context
+import com.xodee.client.audio.audioclient.AppInfo
 import com.xodee.client.video.VideoClient
 
 object AppInfoUtil {
-    fun initializeVideoClientAppDetailedInfo(context: Context) {
-        val manufacturer = DeviceUtils.deviceManufacturer
-        val model = DeviceUtils.deviceModel
-        val osVersion = DeviceUtils.osVersion
+    private lateinit var manufacturer: String
+    private lateinit var model: String
+    private lateinit var osVersion: String
+    private lateinit var appName: String
+    private lateinit var appCode: String
+    private const val clientSource = "amazon-chime-sdk"
+    private lateinit var sdkVersion: String
+
+    private fun initializeAppInfo(context: Context) {
+        manufacturer = DeviceUtils.deviceManufacturer
+        model = DeviceUtils.deviceModel
+        osVersion = DeviceUtils.osVersion
         val packageName = context.packageName
         val packageInfo = context.packageManager.getPackageInfo(packageName, 0)
-        val appVer = packageInfo.versionName
-        val appCode = packageInfo.versionCode.toString()
-        val clientSource = "amazon-chime-sdk"
-        val sdkVersion = DeviceUtils.sdkVersion
+        appName = String.format("Android %s", packageInfo.versionName)
+        appCode = packageInfo.versionCode.toString()
+        sdkVersion = DeviceUtils.sdkVersion
+    }
+
+    fun initializeVideoClientAppDetailedInfo(context: Context) {
+        initializeAppInfo(context)
 
         VideoClient.AppDetailedInfo.initialize(
-            String.format("Android %s", appVer),
+            appName,
             appCode,
             model,
             manufacturer,
+            osVersion,
+            clientSource,
+            sdkVersion
+        )
+    }
+
+    fun initializeAudioClientAppInfo(context: Context): AppInfo {
+        initializeAppInfo(context)
+
+        return AppInfo(
+            appName,
+            appCode,
+            manufacturer,
+            model,
             osVersion,
             clientSource,
             sdkVersion

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -15,13 +15,16 @@ import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.xodee.client.audio.audioclient.AppInfo
 import com.xodee.client.audio.audioclient.AudioClient
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
 import io.mockk.mockkClass
+import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
@@ -121,7 +124,8 @@ class DefaultAudioClientControllerTest {
     private fun setupStartTests() {
         every { mockAudioClient.sendMessage(any(), any()) } returns testAudioClientSuccessCode
         every {
-            mockAudioClient.startSession(
+            mockAudioClient.startSessionV2(
+                any(),
                 any(),
                 any(),
                 any(),
@@ -145,6 +149,19 @@ class DefaultAudioClientControllerTest {
         every { AudioTrack.getMinBufferSize(any(), any(), any()) } returns testSampleBuffer
         every { AudioRecord.getMinBufferSize(any(), any(), any()) } returns testSampleBuffer
         DefaultAudioClientController.audioClientState = AudioClientState.INITIALIZED
+
+        val testAppInfo = AppInfo(
+            "name",
+            "versionCode",
+            "make",
+            "model",
+            "version",
+            "amazon-chime-sdk",
+            "sdkVersion"
+        )
+
+        mockkObject(AppInfoUtil)
+        every { AppInfoUtil.initializeAudioClientAppInfo(any()) } returns testAppInfo
     }
 
     @Test
@@ -267,7 +284,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start should call AudioClient startSession`() {
+    fun `start should call AudioClient startSessionV2`() {
         setupStartTests()
 
         audioClientController.start(
@@ -279,7 +296,8 @@ class DefaultAudioClientControllerTest {
         )
 
         verify {
-            mockAudioClient.startSession(
+            mockAudioClient.startSessionV2(
+                any(),
                 any(),
                 any(),
                 any(),


### PR DESCRIPTION
### Issue #, if available:
Chime-28001

### Description of changes:
Pass app info to audio client just like we are currently passing to video client

### Testing done:
* Ran unit tests successfully
* Started a meeting and tested audio send / receive
* Verified that app info was passed to both audio client and video client

Audio client / video client logs
```
2021-02-09 11:24:30.012 16136-16136/com.amazonaws.services.chime.sdkdemo I/videoclient_jni: Reported App Detail Info: { app_version_name: Android 1.0, app_version_code: 1, device_model: SM-G950U1, device_make: samsung, platform_name: android, platform_version: 9, client_source: amazon-chime-sdk, chime_sdk_version: 0.11.0 }
2021-02-09 11:24:30.228 16136-16136/com.amazonaws.services.chime.sdkdemo I/audioclient_jni: Reported AppInfo: { app_version_name: Android 1.0, app_version_code: 1, device_make: samsung, device_model: SM-G950U1, platform_name: Android, platform_version: 9, client_source: amazon-chime-sdk, chime_sdk_version: 0.11.0 }
```

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [ ] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [X] See signal strength changes
* [X] See media metrics received
* [X] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
