### PR TITLE
Enable send-side bandwidth estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Changed
+
+* Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
+
 ## [0.11.1] - 2021-02-24
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -38,6 +38,7 @@ class DefaultContentShareVideoClientController(
 
     private val TAG = "DefaultContentShareVideoClientController"
 
+    private val VIDEO_CLIENT_FLAG_ENABLE_SEND_SIDE_BWE = 1 shl 5
     private val VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER = 1 shl 6
     private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 1 shl 12
     private val VIDEO_CLIENT_FLAG_DISABLE_CAPTURER = 1 shl 20
@@ -90,6 +91,7 @@ class DefaultContentShareVideoClientController(
     private fun startVideoClient(): Boolean {
         logger.info(TAG, "Starting content share video client for content share")
         var flag = 0
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_SEND_SIDE_BWE
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -41,6 +41,7 @@ class DefaultVideoClientController(
     private val TOPIC_REGEX = "^[a-zA-Z0-9_-]{1,36}$".toRegex()
     private val TAG = "DefaultVideoClientController"
 
+    private val VIDEO_CLIENT_FLAG_ENABLE_SEND_SIDE_BWE = 1 shl 5
     private val VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER = 1 shl 6
     private val VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS = 1 shl 12
     private val VIDEO_CLIENT_FLAG_DISABLE_CAPTURER = 1 shl 20
@@ -191,6 +192,7 @@ class DefaultVideoClientController(
         logger.info(TAG, "Starting video client")
         videoClient?.setReceiving(false)
         var flag = 0
+        flag = flag or VIDEO_CLIENT_FLAG_ENABLE_SEND_SIDE_BWE
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_USE_HW_DECODE_AND_RENDER
         flag = flag or VIDEO_CLIENT_FLAG_ENABLE_TWO_SIMULCAST_STREAMS
         flag = flag or VIDEO_CLIENT_FLAG_DISABLE_CAPTURER


### PR DESCRIPTION
### Issue #, if available:
ChimeVideo-984

### Description of changes:
Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.

### Testing done:
- Send-side bandwidth estimation has been enabled in Amazon Chime mobile clients since Jun 23, 2020. We did not see any regression after enabling it. Test results showed that bandwidth estimation improved after we enabled send-side bandwidth estimation.
- Kicked an ad-hoc build and ran sanity tests.

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
