### PR TITLE
Fix external meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 ## [Unreleased]
 
 ### Changed
-
 * Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
 
 ### Fixed
 * Fixed `CreateMeetingResponse` and `MeetingSessionConfiguration` to have nullable `externalMeetingId` since this is not required.
+
+### Added
+* Added additional constructor of `MeetingSessionConfiguration` to create it without `externalMeetingId`
 
 ## [0.11.1] - 2021-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 * Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
 
+### Fixed
+* Fixed `CreateMeetingResponse` and `MeetingSessionConfiguration` to have nullable `externalMeetingId` since this is not required.
+
 ## [0.11.1] - 2021-02-24
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -53,7 +53,7 @@ class DefaultEventAnalyticsController(
     }
 
     override fun getCommonEventAttributes(): EventAttributes {
-        return mutableMapOf(
+        val attributes = mutableMapOf(
             EventAttributeName.deviceName to DeviceUtils.deviceName,
             EventAttributeName.deviceManufacturer to DeviceUtils.deviceManufacturer,
             EventAttributeName.deviceModel to DeviceUtils.deviceModel,
@@ -63,13 +63,18 @@ class DefaultEventAnalyticsController(
             EventAttributeName.sdkName to DeviceUtils.sdkName,
             EventAttributeName.sdkVersion to DeviceUtils.sdkVersion,
             EventAttributeName.meetingId to meetingSessionConfiguration.meetingId,
-            EventAttributeName.externalMeetingId to
-                    meetingSessionConfiguration.externalMeetingId,
+
             EventAttributeName.attendeeId to
                     meetingSessionConfiguration.credentials.attendeeId,
             EventAttributeName.externalUserId to
                     meetingSessionConfiguration.credentials.externalUserId
-        ) as EventAttributes
+        )
+
+        meetingSessionConfiguration.externalMeetingId?.let {
+            attributes[EventAttributeName.externalMeetingId] = it
+        }
+
+        return attributes as EventAttributes
     }
 
     override fun addEventAnalyticsObserver(observer: EventAnalyticsObserver) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -69,7 +69,7 @@ class DefaultEventAnalyticsController(
                     meetingSessionConfiguration.credentials.attendeeId,
             EventAttributeName.externalUserId to
                     meetingSessionConfiguration.credentials.externalUserId
-        )
+        ) as EventAttributes
     }
 
     override fun addEventAnalyticsObserver(observer: EventAnalyticsObserver) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/CreateMeetingResponse.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/CreateMeetingResponse.kt
@@ -9,7 +9,7 @@ package com.amazonaws.services.chime.sdk.meetings.session
 data class CreateMeetingResponse(val Meeting: Meeting)
 
 data class Meeting(
-    val ExternalMeetingId: String,
+    val ExternalMeetingId: String?,
     val MediaPlacement: MediaPlacement,
     val MediaRegion: String,
     val MeetingId: String

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
@@ -18,7 +18,7 @@ import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
  */
 data class MeetingSessionConfiguration(
     val meetingId: String,
-    val externalMeetingId: String,
+    val externalMeetingId: String?,
     val credentials: MeetingSessionCredentials,
     val urls: MeetingSessionURLs
 ) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
@@ -43,6 +43,12 @@ data class MeetingSessionConfiguration(
         )
     )
 
+    constructor(
+        meetingId: String,
+        credentials: MeetingSessionCredentials,
+        urls: MeetingSessionURLs
+    ) : this(meetingId, null, credentials, urls)
+
     fun createContentShareMeetingSessionConfiguration(): MeetingSessionConfiguration {
         val contentModality: String = DefaultModality.MODALITY_SEPARATOR + ModalityType.Content.value
         return MeetingSessionConfiguration(

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationJavaTest.java
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationJavaTest.java
@@ -6,6 +6,7 @@ import kotlin.jvm.functions.Function1;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 public class MeetingSessionConfigurationJavaTest {
     // Meeting
@@ -42,6 +43,54 @@ public class MeetingSessionConfigurationJavaTest {
         assertEquals(audioFallbackURL, meetingSessionConfiguration1.getUrls().getAudioFallbackURL());
         assertEquals(signalingURL, meetingSessionConfiguration1.getUrls().getSignalingURL());
         assertEquals(turnControlURL, meetingSessionConfiguration1.getUrls().getTurnControlURL());
+    }
+
+    @Test
+    public void constructorShouldSetExternalMeetingIdToNullWhenNotProvidedThroughMeeting() {
+        MediaPlacement mediaPlacement = new MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL);
+
+        Function1<String, String> urlRewrite = new Function1<String, String>() {
+            @Override
+            public String invoke(String s) {
+                return s;
+            }
+        };
+
+        MeetingSessionCredentials creds = new MeetingSessionCredentials(
+                attendeeId,
+                externalUserId,
+                joinToken
+        );
+
+        MeetingSessionURLs urls = new MeetingSessionURLs(
+                mediaPlacement.getAudioFallbackUrl(),
+                mediaPlacement.getAudioHostUrl(),
+                mediaPlacement.getTurnControlUrl(),
+                mediaPlacement.getSignalingUrl(),
+                urlRewrite
+        );
+
+        MeetingSessionConfiguration meetingSessionConfiguration = new MeetingSessionConfiguration(
+                meetingId, creds, urls);
+
+        assertNull(meetingSessionConfiguration.getExternalMeetingId());
+
+    }
+
+    @Test
+    public void constructorShouldSetExternalMeetingIdToNullWhenNotProvidedThroughConstructor() {
+        CreateMeetingResponse createMeetingNullExternal = new CreateMeetingResponse(
+                new Meeting(
+                        null,
+                        new MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL),
+                        mediaRegion,
+                        meetingId
+                )
+        );
+        MeetingSessionConfiguration meetingSessionConfiguration = new MeetingSessionConfiguration(
+                createMeetingNullExternal, createAttendee);
+
+        assertNull(meetingSessionConfiguration.getExternalMeetingId());
     }
 
     private String urlRewriter(String url) {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationTest.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.session
 
 import io.mockk.spyk
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class MeetingSessionConfigurationTest {
@@ -46,6 +47,45 @@ class MeetingSessionConfigurationTest {
         assertEquals(signalingURL, meetingSessionConfiguration.urls.signalingURL)
         assertEquals(attendeeId, meetingSessionConfiguration.credentials.attendeeId)
         assertEquals(joinToken, meetingSessionConfiguration.credentials.joinToken)
+    }
+
+    @Test
+    fun `constructor should return null externalMeetingId when not provided through Meeting`() {
+        val meetingSessionConfiguration = MeetingSessionConfiguration(
+            CreateMeetingResponse(
+                Meeting(
+                    null,
+                    MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL),
+                    mediaRegion,
+                    meetingId
+                )
+            ), CreateAttendeeResponse(Attendee(attendeeId, externalUserId, joinToken))
+        )
+
+        assertNull(meetingSessionConfiguration.externalMeetingId)
+    }
+
+    @Test
+    fun `constructor should return null externalMeetingId when not provided through constructor`() {
+        val creds = MeetingSessionCredentials(
+            attendeeId,
+            externalUserId,
+            joinToken
+        )
+        val urls = MeetingSessionURLs(
+            audioFallbackURL,
+            audioHostURL,
+            turnControlURL,
+            signalingURL,
+            ::defaultUrlRewriter
+        )
+        val meetingSessionConfiguration = MeetingSessionConfiguration(
+            meetingId,
+            creds,
+            urls
+        )
+
+        assertNull(meetingSessionConfiguration.externalMeetingId)
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
This is to make ExternalMeetingId Nullable, so that if builders createMeeting with empty external Id, it doesn't crash.

### Testing done:
Deployed server without external meeting id and was able to join and run audio
Also tested on server with external meeting id. 

#### Unit test coverage
* Class coverage: 84%
* Line coverage: 67%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
