### PR TITLE
Updated videoAdapter to use DiffUtil instead of notifyDataSetChanged …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+* [Demo] Fixed video flickering issue when active speakers were detected by using `DiffUtil` instead of `notifyDataSetChanged` to update the video adapter.
+
 ## [0.11.2] - 2021-03-04
 
 ### Changed

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoDiffCallback.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoDiffCallback.kt
@@ -1,0 +1,33 @@
+package com.amazonaws.services.chime.sdkdemo.adapter
+
+import androidx.recyclerview.widget.DiffUtil
+import com.amazonaws.services.chime.sdkdemo.data.VideoCollectionTile
+
+class VideoDiffCallback(
+    private val oldList: List<VideoCollectionTile>,
+    private val newList: List<VideoCollectionTile>
+) :
+    DiffUtil.Callback() {
+
+    override fun getOldListSize(): Int {
+        return oldList.size
+    }
+
+    override fun getNewListSize(): Int {
+        return newList.size
+    }
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldList[oldItemPosition].videoTileState.attendeeId == newList[newItemPosition].videoTileState.attendeeId
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        val oldTileState = oldList[oldItemPosition].videoTileState
+        val newTileState = newList[newItemPosition].videoTileState
+
+        return oldTileState.attendeeId == newTileState.attendeeId &&
+                oldTileState.pauseState == newTileState.pauseState &&
+                oldTileState.videoStreamContentWidth == newTileState.videoStreamContentWidth &&
+                oldTileState.videoStreamContentHeight == newTileState.videoStreamContentHeight
+    }
+}

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -25,6 +25,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsObserver
@@ -72,6 +73,7 @@ import com.amazonaws.services.chime.sdkdemo.adapter.MessageAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.MetricAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.RosterAdapter
 import com.amazonaws.services.chime.sdkdemo.adapter.VideoAdapter
+import com.amazonaws.services.chime.sdkdemo.adapter.VideoDiffCallback
 import com.amazonaws.services.chime.sdkdemo.data.Message
 import com.amazonaws.services.chime.sdkdemo.data.MetricData
 import com.amazonaws.services.chime.sdkdemo.data.RosterAttendee
@@ -887,10 +889,20 @@ class MeetingFragment : Fragment(),
     }
 
     private fun onVideoPageUpdated() {
+        val oldList = mutableListOf<VideoCollectionTile>()
+        oldList.addAll(meetingModel.videoStatesInCurrentPage)
+
         // Recalculate videos in the current page and notify videoTileAdapter
         meetingModel.updateVideoStatesInCurrentPage()
         revalidateVideoPageIndex()
-        videoTileAdapter.notifyDataSetChanged()
+
+        val newList = mutableListOf<VideoCollectionTile>()
+        newList.addAll(meetingModel.videoStatesInCurrentPage)
+
+        val videoDiffCallback = VideoDiffCallback(oldList, newList)
+        val videoDiffResult: DiffUtil.DiffResult = DiffUtil.calculateDiff(videoDiffCallback)
+
+        videoDiffResult.dispatchUpdatesTo(videoTileAdapter)
 
         // Pause/Resume remote videos accordingly based on videoTileState and the tab that user is on
         meetingModel.remoteVideoTileStates.forEach {


### PR DESCRIPTION
…for updates

### Issue #, if available:
Chime-36643

### Description of changes:
Use `DiffUtil` instead of `notifyDataSetChanged` to update the videoAdapter. Before the changes, the videos will flicker when people speak due to `onActiveSpeakerDetected` leading to `notifyDataSetChanged`. After the changes, the flickering is gone. The new active speaker's video tile will be first (or second if self video is enabled) and slide the other video tiles down.

### Testing done:
* Didn't run SDK unit tests since this is demo app change
* Tested with local video + more than 4 remote videos to see effects of scrolling and pagination. Tested having different attendees (those who were on the current page and those who were on the next page) become active speaker to see the effects. 

#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [ ] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [X] Pause remote video tile
* [X] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
