### PR TITLE
Pass correct route to media layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * [Demo] Fixed video flickering issue when active speakers were detected by using `DiffUtil` instead of `notifyDataSetChanged` to update the video adapter.
+* Fixed `DefaultDeviceController` not passing correct route for USB headset.
 
 ## [0.11.2] - 2021-03-04
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -165,6 +165,7 @@ class DefaultDeviceController(
             MediaDeviceType.AUDIO_BUILTIN_SPEAKER -> AudioClient.SPK_STREAM_ROUTE_SPEAKER
             MediaDeviceType.AUDIO_BLUETOOTH -> AudioClient.SPK_STREAM_ROUTE_BT_AUDIO
             MediaDeviceType.AUDIO_WIRED_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
+            MediaDeviceType.AUDIO_USB_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
             else -> AudioClient.SPK_STREAM_ROUTE_RECEIVER
         }
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
@@ -290,6 +290,22 @@ class DefaultDeviceControllerTest {
     }
 
     @Test
+    fun `chooseAudioDevice should call AudioClientController setRoute with headset`() {
+        setupForOldAPILevel()
+        every { audioClientController.setRoute(any()) } returns true
+        mockkStatic(DefaultAudioClientController::class)
+        DefaultAudioClientController.audioClientState = AudioClientState.STARTED
+        deviceController.chooseAudioDevice(
+            MediaDevice(
+                "usb headset",
+                MediaDeviceType.AUDIO_USB_HEADSET
+            )
+        )
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_HEADSET) }
+    }
+
+    @Test
     fun `chooseAudioDevice should call audioManager startBluetoothSco when choosing bluetooth device`() {
         setupForOldAPILevel()
         every { audioClientController.setRoute(any()) } returns true


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
It was not passing correct value to media layer. USB_HEADSET should pass `SPK_STREAM_ROUTE_HEADSET` to media layer.

### Testing done:
#### Unit test coverage
* Class coverage: 85%
* Line coverage: 67%

Able to verify that USB still works on Pixel 3XL.

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
