### PR TITLE
Move to another thread

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -29,7 +29,8 @@ class DefaultAudioClientController(
     private val audioClientObserver: AudioClientObserver,
     private val audioClient: AudioClient,
     private val meetingStatsCollector: MeetingStatsCollector,
-    private val eventAnalyticsController: EventAnalyticsController
+    private val eventAnalyticsController: EventAnalyticsController,
+    private val audioClientScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) : AudioClientController {
     private val TAG = "DefaultAudioClientController"
     private val DEFAULT_PORT = 0 // In case the URL does not have port
@@ -38,7 +39,6 @@ class DefaultAudioClientController(
     private val DEFAULT_PRESENTER = true
     private val AUDIO_CLIENT_RESULT_SUCCESS = AudioClient.AUDIO_CLIENT_OK
 
-    private val audioClientScope = CoroutineScope(Dispatchers.IO)
     private val audioManager: AudioManager =
         context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
     private var audioModePreCall: Int = audioManager.mode

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -21,6 +21,7 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 class DefaultAudioClientController(
@@ -30,7 +31,7 @@ class DefaultAudioClientController(
     private val audioClient: AudioClient,
     private val meetingStatsCollector: MeetingStatsCollector,
     private val eventAnalyticsController: EventAnalyticsController,
-    private val audioClientScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+    private val audioClientScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 ) : AudioClientController {
     private val TAG = "DefaultAudioClientController"
     private val DEFAULT_PORT = 0 // In case the URL does not have port


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/260

### Description of changes:
Put audioClient start logic into different thread.

### Testing done:
There are few test cases I have done

1. Start and stop (normal) and rejoin
2. Use same audioVideo and start and stop multiple times really fast. (It seems to be queued and does not start while stopping)

Theoretical side effect (not observed)
Instead of main thread, we are running on IO thread, so it could be possible that it is executed later.


#### Unit test coverage
* Class coverage: 84%
* Line coverage: 67% 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
