### PR TITLE
Fix naming for Amazon Voice Focus in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Fixed
+* [Documentation] Fixed documentation to say `Amazon Voice Focus` instead of `voice focus`
+
 ## [0.11.4] - 2021-04-14
 
 ### Changed
@@ -107,8 +112,8 @@
 This release includes support for custom video sources, and therefore includes a lot of additional APIs.  Though most builders who have not been making modifications to internal render path should not need to make any changes and will not hit any compile time issues, there are some small breaking changes to certain render path APIs to ensure consistency within data flow across the SDK.  Recommendations are below, and all breaking changes should result in compile time errors (if you implemented the class yourself), if you continue to have difficulty resolving issues please cut an issue.
 
 ### Added
-* Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus.
-* Added Voice Focus feature in Android demo app.
+* Added new APIs in `RealtimeControllerFacade` to enable/disable Amazon Voice Focus (ML-based noise suppression) and get the on/off status of Amazon Voice Focus.
+* Added Amazon Voice Focus feature in Android demo app.
 * Added `VideoFrame`, `VideoRotation`, `VideoContentHint`, `VideoFrameBuffer`, `VideoFrameI420Buffer`, `VideoFrameRGBABuffer`, `VideoFrameTextureBuffer` classes, enums, and interfaces to hold video frames of various raw types.
 * Added `VideoSource` and `VideoSink` to facilitate transfer of `VideoFrame` objects.
 * Added `CameraCaptureSource`, `CaptureSourceError`, `CaptureSourceObserver`, `VideoCaptureFormat`, and `VideoCaptureSource` interfaces and enums to facilitate releasing capturers as part of the SDK.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If you discover a potential security issue in this project we ask that you notif
   - [Metrics](#metrics)
   - [Data Message](#data-message)
   - [Stopping a session](#stopping-a-session)
-  - [Voice Focus](#voice-focus)
+  - [Amazon Voice Focus](#amazon-voice-focus)
   - [Custom Video Source](#custom-video-source)
 
 ### Starting a session
@@ -564,16 +564,16 @@ meetingSession.audioVideo.addAudioVideoObserver(observer)
 meetingSession.audioVideo.stop()
 ```
 
-### Voice Focus
+### Amazon Voice Focus
 
-Voice focus reduces the background noise in the meeting for better meeting experience. For more details, see [Amazon Voice Focus](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/api_overview.md#11-using-amazon-voice-focus-optional).
+Amazon Voice Focus reduces the background noise in the meeting for better meeting experience. For more details, see [Amazon Voice Focus](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/api_overview.md#11-using-amazon-voice-focus-optional).
 
-#### Use case 24. Enable/Disable voice focus.
+#### Use case 24. Enable/Disable Amazon Voice Focus.
 
 ```kotlin
-val enbabled = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(true) // enabling voice focus successful
+val enbabled = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(true) // enabling Amazon Voice Focus successful
 
-val disabled = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(false) // disabling voice focus successful
+val disabled = meetingSession.audioVideo.realtimeSetVoiceFocusEnabled(false) // disabling Amazon Voice Focus successful
 ```
 
 ### Custom Video Source

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/RealtimeControllerFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/RealtimeControllerFacade.kt
@@ -84,19 +84,19 @@ interface RealtimeControllerFacade {
     fun removeRealtimeDataMessageObserverFromTopic(topic: String)
 
     /**
-     * Enable or disable Voice Focus (ML-based noise suppression) on the audio input.
+     * Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.
      *
-     * Voice Focus is disabled by default when audioClient starts.
+     * Amazon Voice Focus is disabled by default when audioClient starts.
      *
-     * @param enabled: Boolean - whether to enable Voice Focus or not
+     * @param enabled: Boolean - whether to enable Amazon Voice Focus or not
      * @return Boolean whether the enable/disable action succeeded
      */
     fun realtimeSetVoiceFocusEnabled(enabled: Boolean): Boolean
 
     /**
-     * Checks if Voice Focus is enabled.
+     * Checks if Amazon Voice Focus is enabled.
      *
-     * @return Boolean whether Voice Focus is enabled or not
+     * @return Boolean whether Amazon Voice Focus is enabled or not
      */
     fun realtimeIsVoiceFocusEnabled(): Boolean
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1089,7 +1089,7 @@ class MeetingFragment : Fragment(),
         notifyHandler(
             "Audio successfully started. reconnecting: $reconnecting"
         )
-        // Start Voice Focus as soon as audio session started
+        // Start Amazon Voice Focus as soon as audio session started
         setVoiceFocusEnabled(true)
         logWithFunctionName(
             object {}.javaClass.enclosingMethod?.name,

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/index.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/index.html
@@ -168,7 +168,7 @@ e.g. one passed in via <a href="../-audio-video-controller-facade/start-local-vi
 <h4><a href="realtime-is-voice-focus-enabled.html">realtimeIsVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <code><span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>
@@ -206,7 +206,7 @@ Up to 1024 messages may be stored for a maximum of 5 minutes.</p>
 <h4><a href="realtime-set-voice-focus-enabled.html">realtimeSetVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
 <code><span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.audiovideo.DefaultAudioVideoFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/realtime-is-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/realtime-is-voice-focus-enabled.html
@@ -10,8 +10,8 @@
 <h1>realtimeIsVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.audiovideo.DefaultAudioVideoFacade$realtimeIsVoiceFocusEnabled()"></a>
 <code><span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <p><strong>Return</strong><br/>
-Boolean whether Voice Focus is enabled or not</p>
+Boolean whether Amazon Voice Focus is enabled or not</p>
 </BODY>
 </HTML>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/realtime-set-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-default-audio-video-facade/realtime-set-voice-focus-enabled.html
@@ -10,11 +10,11 @@
 <h1>realtimeSetVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.audiovideo.DefaultAudioVideoFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)"></a>
 <code><span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.audiovideo.DefaultAudioVideoFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
-<p>Voice Focus is disabled by default when audioClient starts.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Amazon Voice Focus is disabled by default when audioClient starts.</p>
 <h3>Parameters</h3>
 <p><a name="enabled"></a>
-<code>enabled</code> - : Boolean - whether to enable Voice Focus or not</p>
+<code>enabled</code> - : Boolean - whether to enable Amazon Voice Focus or not</p>
 <p><strong>Return</strong><br/>
 Boolean whether the enable/disable action succeeded</p>
 </BODY>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/index.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/index.html
@@ -46,7 +46,7 @@ observers per topic</p>
 <h4><a href="realtime-is-voice-focus-enabled.html">realtimeIsVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <code><span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>
@@ -84,7 +84,7 @@ Up to 1024 messages may be stored for a maximum of 5 minutes.</p>
 <h4><a href="realtime-set-voice-focus-enabled.html">realtimeSetVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
 <code><span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.realtime.DefaultRealtimeController$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/realtime-is-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/realtime-is-voice-focus-enabled.html
@@ -10,8 +10,8 @@
 <h1>realtimeIsVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.realtime.DefaultRealtimeController$realtimeIsVoiceFocusEnabled()"></a>
 <code><span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <p><strong>Return</strong><br/>
-Boolean whether Voice Focus is enabled or not</p>
+Boolean whether Amazon Voice Focus is enabled or not</p>
 </BODY>
 </HTML>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/realtime-set-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-default-realtime-controller/realtime-set-voice-focus-enabled.html
@@ -10,11 +10,11 @@
 <h1>realtimeSetVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.realtime.DefaultRealtimeController$realtimeSetVoiceFocusEnabled(kotlin.Boolean)"></a>
 <code><span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.realtime.DefaultRealtimeController$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
-<p>Voice Focus is disabled by default when audioClient starts.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Amazon Voice Focus is disabled by default when audioClient starts.</p>
 <h3>Parameters</h3>
 <p><a name="enabled"></a>
-<code>enabled</code> - : Boolean - whether to enable Voice Focus or not</p>
+<code>enabled</code> - : Boolean - whether to enable Amazon Voice Focus or not</p>
 <p><strong>Return</strong><br/>
 Boolean whether the enable/disable action succeeded</p>
 </BODY>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/index.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/index.html
@@ -42,7 +42,7 @@ observers per topic</p>
 <h4><a href="realtime-is-voice-focus-enabled.html">realtimeIsVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <code><span class="keyword">abstract</span> <span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>
@@ -80,7 +80,7 @@ Up to 1024 messages may be stored for a maximum of 5 minutes.</p>
 <h4><a href="realtime-set-voice-focus-enabled.html">realtimeSetVoiceFocusEnabled</a></h4>
 </td>
 <td>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
 <code><span class="keyword">abstract</span> <span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code></td>
 </tr>
 <tr>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-is-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-is-voice-focus-enabled.html
@@ -10,8 +10,8 @@
 <h1>realtimeIsVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade$realtimeIsVoiceFocusEnabled()"></a>
 <code><span class="keyword">abstract</span> <span class="keyword">fun </span><span class="identifier">realtimeIsVoiceFocusEnabled</span><span class="symbol">(</span><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Checks if Voice Focus is enabled.</p>
+<p>Checks if Amazon Voice Focus is enabled.</p>
 <p><strong>Return</strong><br/>
-Boolean whether Voice Focus is enabled or not</p>
+Boolean whether Amazon Voice Focus is enabled or not</p>
 </BODY>
 </HTML>

--- a/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-set-voice-focus-enabled.html
+++ b/docs/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.realtime/-realtime-controller-facade/realtime-set-voice-focus-enabled.html
@@ -10,11 +10,11 @@
 <h1>realtimeSetVoiceFocusEnabled</h1>
 <a name="com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)"></a>
 <code><span class="keyword">abstract</span> <span class="keyword">fun </span><span class="identifier">realtimeSetVoiceFocusEnabled</span><span class="symbol">(</span><span class="identifier" id="com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade$realtimeSetVoiceFocusEnabled(kotlin.Boolean)/enabled">enabled</span><span class="symbol">:</span>&nbsp;<a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a><span class="symbol">)</span><span class="symbol">: </span><a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html"><span class="identifier">Boolean</span></a></code>
-<p>Enable or disable Voice Focus (ML-based noise suppression) on the audio input.</p>
-<p>Voice Focus is disabled by default when audioClient starts.</p>
+<p>Enable or disable Amazon Voice Focus (ML-based noise suppression) on the audio input.</p>
+<p>Amazon Voice Focus is disabled by default when audioClient starts.</p>
 <h3>Parameters</h3>
 <p><a name="enabled"></a>
-<code>enabled</code> - : Boolean - whether to enable Voice Focus or not</p>
+<code>enabled</code> - : Boolean - whether to enable Amazon Voice Focus or not</p>
 <p><strong>Return</strong><br/>
 Boolean whether the enable/disable action succeeded</p>
 </BODY>


### PR DESCRIPTION
### Issue #, if available:
NA
### Description of changes:
Fix naming of Amazon Voice Focus in documentation
### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
