### PR TITLE
Update docs about decreasing order of active speakers in onActiveSpeakerDetected()

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/activespeakerdetector/ActiveSpeakerObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/activespeakerdetector/ActiveSpeakerObserver.kt
@@ -21,7 +21,7 @@ interface ActiveSpeakerObserver {
     /**
      * Notifies observers of changes to active speaker.
      *
-     * @param attendeeInfo: Array<[AttendeeInfo]> - An array of active speakers.
+     * @param attendeeInfo: Array<[AttendeeInfo]> - An array of active speakers in decreasing order of score.
      */
     fun onActiveSpeakerDetected(attendeeInfo: Array<AttendeeInfo>)
 


### PR DESCRIPTION

### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/282

### Description of changes:

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
