### PR TITLE
Add event ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* Added events ingestion to report meeting events to Amazon Chime backend.
+
 ## 2021-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ And review the following guides:
 * [Video Pagination with Active Speaker-Based Policy](guides/video_pagination.md)
 * [Content Share](guides/content_share.md)
 * [Meeting Events](guides/meeting_events.md)
+* [Event Ingestion](guides/event_ingestion.md)
 
 ## Setup
 

--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -65,6 +65,10 @@ android {
             }
         }
     }
+
+    defaultConfig {
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
 }
 
 private Integer generateVersionCode() {
@@ -86,4 +90,9 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3'
     testImplementation 'junit:junit:4.12'
     testImplementation "io.mockk:mockk:1.10.0"
+    // Android Test only
+    androidTestImplementation 'androidx.test:core:1.3.0'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.1.0'
 }

--- a/amazon-chime-sdk/src/androidTest/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/SQLiteDatabaseManagerIntegrationTests.kt
+++ b/amazon-chime-sdk/src/androidTest/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/SQLiteDatabaseManagerIntegrationTests.kt
@@ -1,0 +1,357 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import android.content.ContentValues
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DatabaseTable
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.IN_MEMORY_DATABASE
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.SQLiteDatabaseManager
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.ConsoleLogger
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SQLiteDatabaseManagerIntegrationTests {
+    private class TestTable : DatabaseTable {
+        val pKName = "id"
+        val pKType = "TEXT"
+        val cDataName = "data"
+        val cDataType = "TEXT"
+        val cIntName = "number"
+        val cIntType = "INTEGER"
+
+        override val tableName: String = "test"
+        override val columns: Map<String, String> =
+            mapOf(cDataName to cDataType, cIntName to cIntType)
+        override val primaryKey: Pair<String, String> = (pKName to pKType)
+    }
+
+    private val testTable = TestTable()
+
+    private val contentValues: ContentValues = createEntry(5)
+
+    private class MalformedTestTable : DatabaseTable {
+        override val tableName: String = "malformmmeee"
+        override val columns: Map<String, String> = mapOf("data" to "TEXTTEEEEEEE")
+        override val primaryKey: Pair<String, String> = ("id" to "HELLO YYPEEE;;;;;;")
+    }
+
+    companion object {
+        private lateinit var sqliteDatabaseManager: SQLiteDatabaseManager
+
+        @BeforeClass
+        @JvmStatic
+        fun classSetup() {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+            val logger = ConsoleLogger(LogLevel.INFO)
+            sqliteDatabaseManager = SQLiteDatabaseManager(context, logger, IN_MEMORY_DATABASE)
+        }
+    }
+
+    @Before
+    fun setup() {
+        sqliteDatabaseManager.createTable(testTable)
+    }
+
+    @After
+    fun tearDown() {
+        sqliteDatabaseManager.clear(testTable.tableName)
+        dropTable()
+        sqliteDatabaseManager.close()
+    }
+
+    // Create Table
+    @Test
+    fun createTableShouldCreateNewTableIfNotExists() {
+        dropTable()
+        val created = sqliteDatabaseManager.createTable(testTable)
+
+        Assert.assertEquals(true, created)
+    }
+
+    @Test
+    fun createTableShouldNotFailWhenTableExists() {
+        val created = sqliteDatabaseManager.createTable(testTable)
+
+        Assert.assertEquals(true, created)
+    }
+
+    @Test
+    fun createTableShouldFailWhenGivenColumnIsMalformed() {
+        val created = sqliteDatabaseManager.createTable(MalformedTestTable())
+
+        Assert.assertEquals(false, created)
+    }
+
+    // Query
+    @Test
+    fun queryShouldBeAbleToLimitItemSize() {
+        val contents = createEntries(5)
+        sqliteDatabaseManager.insert(testTable.tableName, contents)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 2)
+
+        Assert.assertEquals(2, resp.size)
+    }
+
+    @Test
+    fun queryShouldReturnEmptyListWhenTableIsEmpty() {
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 10)
+
+        Assert.assertEquals(0, resp.size)
+    }
+
+    @Test
+    fun queryShouldBeAbleToReturnSameDataAsInserted() {
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+        Assert.assertEquals(true, isInsertSuccessful)
+
+        val expectedId = contentValues.get(testTable.pKName)
+        val expectedData = contentValues.get(testTable.cDataName)
+        val expectedNumber = contentValues.get(testTable.cIntName)
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 2)
+
+        Assert.assertEquals(1, resp.size)
+        Assert.assertEquals(expectedId, resp[0][testTable.pKName])
+        Assert.assertEquals(expectedData, resp[0][testTable.cDataName])
+        Assert.assertEquals((expectedNumber as Int).toLong(), resp[0][testTable.cIntName])
+    }
+
+    @Test
+    fun queryItemShouldReturnEmptyListWhenTableDoesNotExist() {
+        dropTable()
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 2)
+
+        Assert.assertEquals(0, resp.size)
+    }
+
+    // Insert
+    @Test
+    fun insertShouldBeAbleToInsertAnItem() {
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+
+        Assert.assertEquals(true, isInsertSuccessful)
+    }
+
+    @Test
+    fun insertItemShouldReturnFalseWhenTableDoesNotExist() {
+        dropTable()
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+
+        Assert.assertEquals(false, isInsertSuccessful)
+    }
+
+    @Test
+    fun insertShouldBeAbleToInsertEmptyList() {
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf())
+
+        Assert.assertEquals(true, isInsertSuccessful)
+    }
+
+    @Test
+    fun insertShouldFailWhenInsertingAnMalformedItem() {
+        val malformedContent = ContentValues().apply {
+            put("malformed zzzz", "zzzzzz")
+            put("malformed2", "ewww")
+        }
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(malformedContent))
+
+        Assert.assertEquals(false, isInsertSuccessful)
+    }
+
+    @Test
+    fun insertMultipleShouldBeAbleToInsertMultipleItems() {
+        val size = 5
+        val contents = createEntries(size)
+
+        val isInsertSuccessful = sqliteDatabaseManager.insert(testTable.tableName, contents)
+
+        Assert.assertEquals(true, isInsertSuccessful)
+
+        val items = sqliteDatabaseManager.query(testTable.tableName, size)
+
+        Assert.assertEquals(size, items.size)
+        val itemsIdSet = items.map { it[testTable.pKName] }.toSet()
+
+        for (content in contents) {
+            Assert.assertTrue(itemsIdSet.contains(content[testTable.pKName]))
+        }
+    }
+
+    @Test
+    fun insertShouldFailToInsertTheSameItemAgain() {
+        val isInsertSuccessful1 =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+        val isInsertSuccessful2 =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+
+        Assert.assertEquals(true, isInsertSuccessful1)
+        Assert.assertEquals(false, isInsertSuccessful2)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 10)
+
+        Assert.assertEquals(1, resp.size)
+    }
+
+    // DELETE
+    @Test
+    fun deleteShouldBeAbleToDeleteAnItem() {
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+        Assert.assertEquals(true, isInsertSuccessful)
+
+        val id = contentValues.get(testTable.pKName)
+        val deleted = sqliteDatabaseManager.delete(
+            testTable.tableName,
+            testTable.pKName,
+            listOf(id as String)
+        )
+
+        Assert.assertEquals(1, deleted)
+    }
+
+    @Test
+    fun deleteShouldReturnZeroWhenEmptyTable() {
+        val deleted = sqliteDatabaseManager.delete(
+            testTable.tableName,
+            testTable.pKName,
+            listOf("abc")
+        )
+
+        Assert.assertEquals(0, deleted)
+    }
+
+    @Test
+    fun deleteShouldBeAbleToDeleteMultipleItems() {
+        val count = 3
+        val contents = createEntries(count)
+        sqliteDatabaseManager.insert(testTable.tableName, contents)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, count)
+        val ids = resp.map { it[testTable.pKName] as String }
+        val deleted =
+            sqliteDatabaseManager.delete(testTable.tableName, testTable.pKName, ids)
+
+        Assert.assertEquals(count, deleted)
+    }
+
+    @Test
+    fun deleteShouldBeAbleToDeleteItemsFewerThanInserted() {
+        val count = 5
+        val expectedDeletedCount = 3
+        val contents = createEntries(count)
+        sqliteDatabaseManager.insert(testTable.tableName, contents)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, expectedDeletedCount)
+        val ids = resp.map { it[testTable.pKName] as String }
+        val deleted =
+            sqliteDatabaseManager.delete(testTable.tableName, testTable.pKName, ids)
+
+        Assert.assertEquals(expectedDeletedCount, deleted)
+
+        val resp2 = sqliteDatabaseManager.query(testTable.tableName, count)
+
+        Assert.assertEquals(count - expectedDeletedCount, resp2.size)
+    }
+
+    @Test
+    fun deleteEventItemShouldDeleteValidEventItemsWhenPassedWithExtraneousEventItems() {
+        val isInsertSuccessful =
+            sqliteDatabaseManager.insert(testTable.tableName, listOf(contentValues))
+
+        Assert.assertEquals(true, isInsertSuccessful)
+
+        val id = contentValues.get(testTable.pKName)
+
+        val deleted = sqliteDatabaseManager.delete(
+            testTable.tableName,
+            testTable.pKName,
+            listOf(id as String, "fake-id", "exxxx-id-didid-ddd")
+        )
+
+        Assert.assertEquals(1, deleted)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 2)
+
+        Assert.assertEquals(0, resp.size)
+    }
+
+    @Test
+    fun deleteItemsShouldReturnErrorWhenTableDoesNotExist() {
+        dropTable()
+        val deletedCount = sqliteDatabaseManager.delete(
+            testTable.tableName,
+            testTable.pKName,
+            listOf("aese-dsdfdf-sdfd")
+        )
+        Assert.assertEquals(-1, deletedCount)
+    }
+
+    @Test
+    fun clearShouldDeleteAllItems() {
+        val contents = createEntries(5)
+        val inserted = sqliteDatabaseManager.insert(testTable.tableName, contents)
+        val removed = sqliteDatabaseManager.clear(testTable.tableName)
+
+        Assert.assertEquals(true, inserted)
+        Assert.assertEquals(true, removed)
+
+        val resp = sqliteDatabaseManager.query(testTable.tableName, 5)
+
+        Assert.assertEquals(0, resp.size)
+    }
+
+    // DROP
+    @Test
+    fun dropTableShouldReturnTrueWhenTableDoesNotExist() {
+        dropTable()
+        val dropped = sqliteDatabaseManager.dropTable(testTable.tableName)
+
+        Assert.assertTrue(dropped)
+    }
+
+    @Test
+    fun dropTableShouldReturnTrueWhenTableExist() {
+        sqliteDatabaseManager.createTable(testTable)
+        val dropped = sqliteDatabaseManager.dropTable(testTable.tableName)
+
+        Assert.assertTrue(dropped)
+    }
+
+    @Test
+    fun dropTableShouldReturnFalseWhenInputIsMalformed() {
+        val dropped = sqliteDatabaseManager.dropTable("zzz:Ewewer;;;;")
+
+        Assert.assertFalse(dropped)
+    }
+
+    private fun dropTable() {
+        sqliteDatabaseManager.dropTable(testTable.tableName)
+    }
+
+    private fun createEntry(id: Int): ContentValues =
+        ContentValues().apply {
+            put(testTable.pKName, id.toString())
+            put(testTable.cDataName, "data$id")
+            put(testTable.cIntName, id)
+        }
+
+    private fun createEntries(size: Int): List<ContentValues> =
+        (1..size).map { createEntry(it) }.toList()
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventName.kt
@@ -6,7 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
 /**
- * [EventName] represent some major event that could help builders to analyze the data.
+ * [EventName] represent sdk event that could help builders to analyze the data.
  */
 enum class EventName {
     /**
@@ -37,5 +37,5 @@ enum class EventName {
     /**
      * The meeting ended with failure.
      */
-    meetingFailed;
+    meetingFailed
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventReporter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventReporter.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.util.Timer
+import java.util.TimerTask
+
+class DefaultEventReporter constructor(
+    private val ingestionConfiguration: IngestionConfiguration,
+    private val eventBuffer: EventBuffer,
+    private val logger: Logger,
+    // isDaemon is false to kill when app gets killed.
+    // This is to make sure timer doesn't continuously run after app is killed.
+    private val timer: Timer = Timer("DefaultEventReporter", false)
+) : EventReporter {
+    private val TAG = "DefaultEventReporter"
+
+    private var isStarted = false
+    init {
+        start()
+    }
+
+    override fun report(event: SDKEvent) {
+        // Add meeting id and attendee id are meta data that changes
+        // from meeting to meeting. Therefore, we would need to store these
+        // value just in case it was not be able to be sent.
+        when (ingestionConfiguration.clientConfiguration) {
+            is MeetingEventClientConfiguration -> {
+                event.eventAttributes.putAll(
+                    mutableMapOf(
+                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
+                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
+                    )
+                )
+            }
+        }
+
+        eventBuffer.add(event)
+    }
+
+    override fun start() {
+        if (isStarted) {
+            return
+        }
+
+        timer.scheduleAtFixedRate(
+            object : TimerTask() {
+                override fun run() = eventBuffer.process()
+            },
+            ingestionConfiguration.flushIntervalMs,
+            ingestionConfiguration.flushIntervalMs
+        )
+    }
+
+    override fun stop() {
+        if (!isStarted) {
+            return
+        }
+
+        timer.cancel()
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSender.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSender.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.DefaultBackOffRetry
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.HttpUtils
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.google.gson.Gson
+import java.net.URL
+
+class DefaultEventSender(
+    private val ingestionConfiguration: IngestionConfiguration,
+    private val logger: Logger
+) : EventSender {
+    private val TAG = "DefaultEventSender"
+    private val gson = Gson()
+    private val AUTHORIZATION_HEADER = "Authorization"
+    private val BEARER = "Bearer"
+    private val eventUrl: URL = URL(ingestionConfiguration.ingestionUrl)
+
+    // 408: Request Timeout
+    // 429: Too many request
+    // 500: Internal Server Error
+    // 502: Bad Gateway
+    // 503: Service Unavailable
+    // 504: Gateway timeout
+    private val retryableCodeSet = setOf<Int>(
+        408, 429, 500, 502, 503, 504
+    )
+
+    override suspend fun sendRecord(record: IngestionRecord): Boolean {
+        return try {
+            val body = gson.toJson(record)
+            val response = HttpUtils.post(
+                eventUrl,
+                body,
+                DefaultBackOffRetry(
+                    ingestionConfiguration.retryCountLimit,
+                    retryableStatusCodes = retryableCodeSet
+                ),
+                logger,
+                mapOf(
+                    AUTHORIZATION_HEADER to "$BEARER ${ingestionConfiguration.clientConfiguration.eventClientJoinToken}"
+                )
+            )
+            response.httpException == null
+        } catch (err: Exception) {
+            logger.error(
+                TAG,
+                "Unable to send record ${err.localizedMessage}"
+            )
+            false
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
@@ -1,0 +1,172 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyEventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyMeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.IngestionEventConverter
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.MeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.util.Calendar
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+class DefaultMeetingEventBuffer @JvmOverloads constructor(
+    private val ingestionConfiguration: IngestionConfiguration,
+    private val eventDao: EventDao,
+    private val dirtyEventDao: DirtyEventDao,
+    private val eventSender: EventSender,
+    private val logger: Logger,
+    private val eventScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+) : EventBuffer {
+    private val TAG = "DefaultMeetingEventBuffer"
+    private val TWO_DAYS_IN_MILLISECONDS = 172_800_000
+
+    private var isRunning = false
+
+    init {
+        // process dirty events when init
+        processDirtyEvents()
+    }
+
+    override fun add(item: SDKEvent) {
+        val meetingEventItem = MeetingEventItem(data = item)
+        // Meeting event is also added in case of immediate send
+        // due to the fact that people will likely close the app,
+        // leading to possible loss of data. To make sure data is not lost,
+        // we first add it to the database.
+        eventDao.insertMeetingEvent(meetingEventItem)
+
+        if (shouldProcessImmediately(item)) {
+            eventScope.launch {
+                processEvents(listOf(meetingEventItem))
+            }
+        }
+    }
+
+    override fun process() {
+        eventScope.launch {
+            if (isRunning) {
+                return@launch
+            }
+            isRunning = true
+
+            val meetingEventItems = eventDao.listMeetingEventItems(ingestionConfiguration.flushSize)
+            processEvents(meetingEventItems)
+            isRunning = false
+        }
+    }
+
+    private suspend fun processEvents(eventItems: List<MeetingEventItem>) {
+        /*
+         * This will do few things
+         * 1. Send data if not empty
+         * 2. Retry if it is failure
+         * 3. If success, remove from event
+         * 4. If failure, add it to dirty event
+         * 5. Remove ids from event table
+         */
+        try {
+            if (eventItems.isEmpty()) {
+                return
+            }
+
+            val eventRecord =
+                IngestionEventConverter.fromMeetingEventItems(eventItems)
+
+            val idsToRemove = eventItems.map { it.id }.toList()
+
+            val isSuccess = eventSender.sendRecord(eventRecord)
+
+            if (!isSuccess) {
+                logger.info(
+                    TAG,
+                    "Unable to publish data to ingestion service. Putting it in the dirtyMeetingEvent"
+                )
+
+                dirtyEventDao.insertDirtyMeetingEventItems(
+                    toDirtyMeetingEventItems(
+                        eventItems.map { it.data }.toList()
+                    )
+                )
+            }
+            eventDao.deleteMeetingEventsByIds(idsToRemove)
+        } catch (exception: Exception) {
+            logger.error(
+                TAG,
+                "Unable to process event ${exception.localizedMessage}"
+            )
+        }
+    }
+
+    private fun toDirtyMeetingEventItems(events: List<SDKEvent>): List<DirtyMeetingEventItem> {
+        val currentTime = Calendar.getInstance().timeInMillis
+        return events.map {
+            DirtyMeetingEventItem(
+                data = it,
+                ttl = currentTime + TWO_DAYS_IN_MILLISECONDS
+            )
+        }.toList()
+    }
+
+    private fun shouldProcessImmediately(
+        event: SDKEvent
+    ): Boolean {
+        val eventName = event.name
+        val eventAttributes = event.eventAttributes
+
+        return (eventName == EventName.meetingFailed.name &&
+                eventAttributes[EventAttributeName.meetingStatus] == MeetingSessionStatusCode.AudioAuthenticationRejected ||
+                eventAttributes[EventAttributeName.meetingStatus] == MeetingSessionStatusCode.AudioInternalServerError ||
+                eventAttributes[EventAttributeName.meetingStatus] == MeetingSessionStatusCode.AudioServiceUnavailable ||
+                eventAttributes[EventAttributeName.meetingStatus] == MeetingSessionStatusCode.AudioDisconnected)
+    }
+
+    private fun processDirtyEvents() {
+        eventScope.launch {
+            // This logic will do following
+            // 1. Send dirty data events
+            // 2. If failed to send, check ttl and delete
+            // 3. If succeeded, remove dirtyEvents
+
+            var dirtyEvents =
+                dirtyEventDao.listDirtyMeetingEventItems(ingestionConfiguration.flushSize)
+            var ingestionRecord =
+                IngestionEventConverter.fromDirtyMeetingEventItems(dirtyEvents)
+
+            var isSentSuccessful = true
+            try {
+                while (ingestionRecord.events.isNotEmpty() && isSentSuccessful) {
+                    isSentSuccessful = eventSender.sendRecord(ingestionRecord)
+                    // Find the ids that will be removed based on success status
+                    val idsToRemove: List<String> = if (!isSentSuccessful) {
+                        val currentTime = Calendar.getInstance().timeInMillis
+                        dirtyEvents.filter { it.ttl <= currentTime }.map { it.id }
+                    } else {
+                        dirtyEvents.map { it.id }
+                    }
+                    dirtyEventDao.deleteDirtyEventsByIds(idsToRemove)
+                    dirtyEvents = dirtyEventDao.listDirtyMeetingEventItems(
+                        ingestionConfiguration.flushSize
+                    )
+                    ingestionRecord =
+                        IngestionEventConverter.fromDirtyMeetingEventItems(
+                            dirtyEvents
+                        )
+                }
+            } catch (exception: Exception) {
+                logger.error(TAG, "Unable to create URL $exception")
+            }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactory.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import android.content.Context
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DirtyEventSQLiteDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.EventSQLiteDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.SQLiteDatabaseManager
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+class DefaultMeetingEventReporterFactory(
+    private val context: Context,
+    private val ingestionConfiguration: IngestionConfiguration,
+    private val logger: Logger
+) : EventReporterFactory {
+    override fun createEventReporter(): EventReporter? {
+        if (ingestionConfiguration.disabled) {
+            return null
+        }
+        val eventSender = DefaultEventSender(
+            ingestionConfiguration,
+            logger
+        )
+        val sqliteManager =
+            SQLiteDatabaseManager(
+                context,
+                logger
+            )
+        val eventDao =
+            EventSQLiteDao(
+                sqliteManager,
+                logger
+            )
+        val dirtyEventDao =
+            DirtyEventSQLiteDao(
+                sqliteManager,
+                logger
+            )
+
+        val eventBuffer = DefaultMeetingEventBuffer(
+            ingestionConfiguration,
+            eventDao,
+            dirtyEventDao,
+            eventSender,
+            logger
+        )
+        return DefaultEventReporter(
+            ingestionConfiguration,
+            eventBuffer,
+            logger
+        )
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventBuffer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventBuffer.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+
+/**
+ * [EventBuffer] defines a buffer which will consume the [SDKEvent] internally.
+ */
+interface EventBuffer {
+    /**
+     * Add a meeting event to the buffer.
+     *
+     * @param item: [SDKEvent] - meeting event
+     */
+    fun add(item: SDKEvent)
+
+    /**
+     * Consume the data.
+     */
+    fun process()
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventClientConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventClientConfiguration.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * [EventClientType] defines the type of event client configuration that will be
+ * sent to the server.
+ */
+enum class EventClientType {
+    /**
+     * Meeting related type
+     */
+    Meet
+}
+
+/**
+ * [EventClientConfiguration] defines core properties needed for every event client configuration.
+ */
+interface EventClientConfiguration {
+    /**
+     * type: [EventClientType] - type of [EventClientConfiguration]
+     */
+    val type: EventClientType
+
+    /**
+     * eventClientJoinToken: [String] - authentication token needed for ingestion url
+     */
+    val eventClientJoinToken: String
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventReporter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventReporter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+
+/**
+ * [EventReporter] is class that process meeting event that is created in [EventAnalyticsController].
+ */
+interface EventReporter {
+    /**
+     * Report the meeting event
+     *
+     * @param event: [SDKEvent] - Event that has name and attributes associated.
+     */
+    fun report(event: SDKEvent)
+
+    /**
+     * Start [EventReporter] and process data
+     */
+    fun start()
+
+    /**
+     * Stop [EventReporter] and processing data
+     */
+    fun stop()
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventReporterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventReporterFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * [EventReporterFactory] facilitates creating [EventReporter]
+ */
+interface EventReporterFactory {
+    /**
+     * Create [EventReporter] and return null if no-op is needed on event reporting.
+     *
+     * @return [EventReporter] - event reporter created.
+     */
+    fun createEventReporter(): EventReporter?
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventSender.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/EventSender.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * [EventSender] is responsible for sending [IngestionRecord].
+ */
+interface EventSender {
+    /**
+     * Send ingestion record.
+     *
+     * @param record: [IngestionRecord] - record to send
+     * @return whether sending was successful or not.
+     */
+    suspend fun sendRecord(record: IngestionRecord): Boolean
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionConfiguration.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+const val FLUSH_SIZE_LIMIT_MAXIMUM = 100
+const val FLUSH_INTERVAL_LIMIT_MINIMUM: Long = 100
+const val RETRY_COUNT_LIMIT_MAXIMUM = 5
+/**
+ * [IngestionConfiguration] defines the configuration that can customize [DefaultEventReporter].
+ *
+ * @property clientConfiguration: [EventClientConfiguration] - configuration needed for metadata.
+ * @property ingestionUrl: [String] - ingestion server url.
+ * @property disabled: [Boolean] - whether ingestion is enabled or disabled. defaults [true].
+ * @property flushSize: [Int] - number of payloads to send as a batch. <= 100 and > 0. defaults 20.
+ * @property flushIntervalMs: [Long] - duration to wait, pull, and send the data. >= 100. defaults 5000.
+ * @property retryCountLimit: [Int] - retry count limit. 0 >= and <= 5. defaults 2.
+ */
+data class IngestionConfiguration @JvmOverloads constructor(
+    val clientConfiguration: EventClientConfiguration,
+    var ingestionUrl: String,
+    val disabled: Boolean = true,
+    var flushSize: Int = 20,
+    var flushIntervalMs: Long = 5000,
+    var retryCountLimit: Int = 2
+) {
+
+    init {
+        // Force the max size to 100 as maximum
+        // Max payload is 256 kb.
+        // Assumption is that each event is max 2kb so we could send ~100 in batch
+        // Metadata is about 300~400 bytes so worst case 200 + 300 + extra = 1kb
+        // Assumes the worst case 1kb * 2 = 2 kb
+        flushSize = flushSize.coerceAtLeast(1).coerceAtMost(FLUSH_SIZE_LIMIT_MAXIMUM)
+        // Force the interval to 100 ms minimum
+        flushIntervalMs = flushIntervalMs.coerceAtLeast(FLUSH_INTERVAL_LIMIT_MINIMUM)
+        // Force retry count to at most 5
+        retryCountLimit = retryCountLimit.coerceAtLeast(0).coerceAtMost(RETRY_COUNT_LIMIT_MAXIMUM)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionEvent.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionEvent.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.google.gson.annotations.SerializedName
+
+typealias IngestionPayload = Map<String, Any>
+
+/**
+ * [IngestionEvent] defines the event format ingestion server will accept
+ *
+ * @property type: [EventClientType] - type of Event.
+ * @property payloads: [List<Map<String, Any>] - list of map that contains details of event
+ * @property version: [Int] - version of this event. If the format changes, it will have different version.
+ */
+data class IngestionEvent(
+    val type: EventClientType,
+    val metadata: IngestionMetadata,
+    val payloads: List<IngestionPayload>,
+    @SerializedName("v")
+    val version: Int = 1
+)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionRecord.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionRecord.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+
+/**
+ * A record that contains batch of [IngestionEvent] to send.
+ * This contains metadata that is shared among events.
+ * @property metadata
+ * @property events
+ *
+ * This will have format of following
+ * Payload will look like
+ * {
+ *   "metadata": {
+ *        "deviceName": "samsung SM-G960U",
+ *        "deviceManufacturer": "samsung",
+ *        "deviceModel": "SM-G960U",
+ *        "mediaSdkVersion": "0.11.2",
+ *        "osName": "Android",
+ *        "meetingId": "eb783287-94aa-43c4-9a73-9ead14e697a5",
+ *        "attendeeId": "c2435dfb-0c70-4152-be18-efc8773b8b2b"
+ *        "osVersion": "10",
+ *        "sdkName": "amazon-chime-sdk-android",
+ *        "sdkVersion": "0.11.4"
+ *    }
+ *  "events": [
+ *    {
+ *      "type": "Meet",
+ *      "v": 1,
+ *      "payloads": [
+ *        {
+ *          "ts": 78645356720,
+ *          "name": "meetingStartSucceeded",
+ *          "maxVideoTileCount": 0,
+ *          "poorConnectionCount": 0,
+ *          "retryCount": 0,
+ *          "signalingOpenDurationMs": 666
+ *        },
+ *        {
+ *          "ts": 78645356797,
+ *          "name": "meetingEnded",
+ *          "maxVideoTileCount": 0,
+ *          "poorConnectionCount": 0,
+ *          "retryCount": 0,
+ *          "signalingOpenDurationMs": 444
+ *        }
+ *      ]
+ *    }
+ *  ]
+ * }
+ */
+typealias IngestionMetadata = EventAttributes
+
+data class IngestionRecord(val metadata: IngestionMetadata, val events: List<IngestionEvent>)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/MeetingEventClientConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/MeetingEventClientConfiguration.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * [MeetingEventClientConfiguration] defines one type of [EventClientConfiguration]
+ * that is needed for [DefaultEventReporter]
+ *
+ * @property eventClientJoinToken: [String] - an authorization token to send
+ * @property meetingId: [String] - meeting id
+ * @property attendeeId: [String] - attendee id
+ */
+data class MeetingEventClientConfiguration(
+    override val eventClientJoinToken: String,
+    val meetingId: String,
+    val attendeeId: String
+) : EventClientConfiguration {
+    override val type: EventClientType = EventClientType.Meet
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/NoopEventReporterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/NoopEventReporterFactory.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * [NoopEventReporterFactory] returns null [EventReporter]
+ */
+class NoopEventReporterFactory : EventReporterFactory {
+    override fun createEventReporter(): EventReporter? {
+        return null
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventDao.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+interface DirtyEventDao {
+    /**
+     * List dirty meeting events items which includes all the fields in the table.
+     *
+     * @param size: [Int] - size to query
+     * @return list of dirty meeting event items from database
+     */
+    fun listDirtyMeetingEventItems(size: Int): List<DirtyMeetingEventItem>
+
+    /**
+     * Delete dirty events by given ids.
+     *
+     * @param ids: [List<String>] - ids of dirty events
+     * @return number of events removed or -1 if delete failed
+     */
+    fun deleteDirtyEventsByIds(ids: List<String>): Int
+
+    /**
+     * Insert multiple dirty meeting events.
+     *
+     * @param dirtyEvents: [List<DirtyMeetingEventItem>] - List of DirtyMeetingEventItem
+     * @return whether insertion was successful or not
+     */
+    fun insertDirtyMeetingEventItems(dirtyEvents: List<DirtyMeetingEventItem>): Boolean
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyMeetingEventItem.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyMeetingEventItem.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import java.util.UUID
+
+/**
+ * [DirtyMeetingEventItem] is a data type of an entry inside DirtyEvents Sqlite table.
+ *
+ * @property id unique id of the database entry
+ * @property data data/meeting event associated with the entry
+ * @property ttl lifetime of that entry that will be checked when ingestion service runs
+ */
+data class DirtyMeetingEventItem(
+    val id: String = UUID.randomUUID().toString(),
+    val data: SDKEvent,
+    val ttl: Long
+)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventDao.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+interface EventDao {
+    /**
+     * List meeting events items which includes all the fields in the table.
+     *
+     * @param size: [Int] - size of events to list
+     * @return list of [MeetingEventItem]
+     */
+    fun listMeetingEventItems(size: Int): List<MeetingEventItem>
+
+    /**
+     *  Delete meeting events by given ids.
+     *
+     * @param ids: [List<String>] - list of ids to remove
+     * @return number of events removed or -1 if delete failed
+     */
+    fun deleteMeetingEventsByIds(ids: List<String>): Int
+
+    /**
+     * Insert a meeting event item.
+     *
+     * @param event: [MeetingEventItem] - meeting event to insert
+     * @return whether insertion is successful or not
+     */
+    fun insertMeetingEvent(event: MeetingEventItem): Boolean
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConverters.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConverters.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.google.gson.Gson
+
+/**
+ * EventTypeConverters facilitate the conversion on some common event types
+ */
+object EventTypeConverters {
+    val gson = Gson()
+    fun toMeetingEvent(data: String): SDKEvent = gson.fromJson(data, SDKEvent::class.java)
+    fun fromMeetingEvent(event: SDKEvent): String = gson.toJson(event)
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.ingestion.EventClientType
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionEvent
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionMetadata
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionPayload
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionRecord
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
+
+object IngestionEventConverter {
+    private const val NAME_KEY = "name"
+    private const val TIMESTAMP_KEY = "ts"
+    private const val ID_KEY = "id"
+    private const val TTL_KEY = "ttl"
+
+    private val attributesToFilter =
+        setOf(EventAttributeName.meetingId, EventAttributeName.attendeeId)
+    private val eventMetadataAttributeNames =
+        listOf(EventAttributeName.meetingId, EventAttributeName.attendeeId)
+
+    fun fromDirtyMeetingEventItems(items: List<DirtyMeetingEventItem>): IngestionRecord {
+        if (items.isEmpty()) {
+            return IngestionRecord(mutableMapOf(), listOf())
+        }
+
+        // When sending a batch, server accepts the data as
+        // "metadata": { "meetingId": "meetingId0" },
+        // "events": [
+        //   {
+        //      "metadata": { "meetingId": "meetingId2" } // This overrides record-level metadata
+        //      "type": "Meet",
+        //      "v": 1,
+        //      "payloads": []
+        //   },
+        //   {
+        //      "metadata": { "meetingId": "meetingId1" } // This overrides record-level metadata
+        //      "type": "Meet",
+        //      "v": 1,
+        //      "payloads": []
+        //   },
+        // ]
+        // This is to group events so that each event contains metadata to override the record-level metadata
+        // in case they are different.
+        val dirtyMeetingEventsByMeetingId: Map<String, List<DirtyMeetingEventItem>> =
+            items.groupBy {
+                it.data.eventAttributes[EventAttributeName.meetingId] as? String ?: ""
+            }
+
+        val ingestionEvents: List<IngestionEvent> = dirtyMeetingEventsByMeetingId.map {
+            IngestionEvent(
+                EventClientType.Meet,
+                toIngestionMetadata(it.value.first()),
+                it.value.map { meetingEventItem ->
+                    toIngestionPayload(
+                        meetingEventItem
+                    )
+                })
+        }
+
+        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
+
+        return IngestionRecord(rootMetadata, ingestionEvents)
+    }
+
+    // Need to have different name due to Kotlin name collision on List
+    fun fromMeetingEventItems(items: List<MeetingEventItem>): IngestionRecord {
+        if (items.isEmpty()) {
+            return IngestionRecord(mutableMapOf(), listOf())
+        }
+
+        // When sending a batch, server accepts the data as
+        // "events": [
+        //   {
+        //      "metadata": { "meetingId": "meetingId2" } // This overrides record-level metadata
+        //      "type": "Meet",
+        //      "v": 1,
+        //      "payloads": []
+        //   },
+        //   {
+        //      "metadata": { "meetingId": "meetingId1" } // This overrides record-level metadata
+        //      "type": "Meet",
+        //      "v": 1,
+        //      "payloads": []
+        //   },
+        // ]
+        // This is to group events so that each event contains metadata to override the record-level metadata
+        // in case they are different.
+        val meetingEventsByMeetingId: Map<String, List<MeetingEventItem>> =
+            items.groupBy {
+                it.data.eventAttributes[EventAttributeName.meetingId] as? String ?: ""
+            }
+
+        val ingestionEvents = meetingEventsByMeetingId.map {
+            IngestionEvent(
+                EventClientType.Meet,
+                toIngestionMetadata(it.value.first()),
+                it.value.map { meetingEventItem ->
+                    toIngestionPayload(
+                        meetingEventItem
+                    )
+                })
+        }
+
+        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
+
+        return IngestionRecord(rootMetadata, ingestionEvents)
+    }
+
+    private fun toIngestionMetadata(eventItem: MeetingEventItem): IngestionMetadata {
+        return toIngestionMetadata(eventItem.data.eventAttributes)
+    }
+
+    private fun toIngestionMetadata(dirtyEventItem: DirtyMeetingEventItem): IngestionMetadata {
+        return toIngestionMetadata(dirtyEventItem.data.eventAttributes)
+    }
+
+    private fun toIngestionMetadata(eventAttributes: EventAttributes): IngestionMetadata {
+        val ingestionMetadata = mutableMapOf<EventAttributeName, Any>()
+
+        // These converts to some of overridden ingestion meta data
+        for (attributeName in eventMetadataAttributeNames) {
+            val value = eventAttributes[attributeName]
+            value?.let {
+                ingestionMetadata[attributeName] = it
+            }
+        }
+
+        return ingestionMetadata
+    }
+
+    private fun toIngestionPayload(event: MeetingEventItem): IngestionPayload {
+        val payload = mutableMapOf(
+            NAME_KEY to event.data.name,
+            TIMESTAMP_KEY to (event.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
+            ID_KEY to event.id
+        )
+        // Filter out meeting id and attendee id since this is not needed for payload
+        event.data.eventAttributes.filterNot { attributesToFilter.contains(it.key) }
+            .forEach {
+                payload[it.key.name] = it.value
+            }
+
+        return payload
+    }
+
+    private fun toIngestionPayload(dirtyEvent: DirtyMeetingEventItem): IngestionPayload {
+        val payload = mutableMapOf(
+            NAME_KEY to dirtyEvent.data.name,
+            TTL_KEY to dirtyEvent.ttl,
+            TIMESTAMP_KEY to (dirtyEvent.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
+            ID_KEY to dirtyEvent.id
+        )
+        dirtyEvent.data.eventAttributes.filterNot { attributesToFilter.contains(it.key) }
+            .forEach {
+                payload[it.key.name] = it.value
+            }
+
+        return payload
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/MeetingEventItem.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/MeetingEventItem.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import java.util.UUID
+
+/**
+ * [MeetingEventItem] is a data type of an entry inside Events SQLite table.
+ *
+ * @property id unique id of the database entry
+ * @property data data/meeting event associated with the entry
+ */
+data class MeetingEventItem(
+    val id: String = UUID.randomUUID().toString(),
+    val data: SDKEvent
+)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/SDKEvent.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/SDKEvent.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEventName
+
+class SDKEvent {
+    val name: String
+    val eventAttributes: EventAttributes
+
+    constructor(eventName: EventName, eventAttributes: EventAttributes) {
+        this.name = eventName.name
+        this.eventAttributes = eventAttributes
+    }
+    constructor(eventName: MeetingHistoryEventName, eventAttributes: EventAttributes) {
+        this.name = eventName.name
+        this.eventAttributes = eventAttributes
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DatabaseManager.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DatabaseManager.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database
+
+import android.content.ContentValues
+
+interface DatabaseManager {
+    /**
+     * Create Table based on the primary keys and other keys defined.
+     *
+     * @param table: [DatabaseTable] - Table to create
+     * @return whether creating table was successful or not
+     */
+    fun createTable(table: DatabaseTable): Boolean
+
+    /**
+     * Drop/Delete Table based on given table name
+     *
+     * @param tableName: [String] - Table name to drop
+     * @return whether dropping table was successful or not
+     */
+    fun dropTable(tableName: String): Boolean
+
+    /**
+     * Query table based on size. Since the order is not specified, it will most likely get based on
+     * insertion order.
+     *
+     * @param tableName: [String] - Name of table to query
+     * @param size: [Int] - size to query. It will return fewer if table contains fewer.
+     * @return list of map whose key is column name and value is value of that column.
+     */
+    fun query(tableName: String, size: Int? = 1000): List<Map<String, Any?>>
+
+    /**
+     * Insert a list of items into the table.
+     *
+     * @param tableName: [String] - name of table
+     * @param contentValues: [List<ContentValues>] - values to insert
+     * @return whether insertion was successful or not.
+     */
+    fun insert(tableName: String, contentValues: List<ContentValues>): Boolean
+
+    /**
+     * Delete items based on the table name, given primary key, and values.
+     *
+     * @param tableName: [String] - name of table
+     * @param keyName: [String] - column name of primary key
+     * @param ids: [List<String>] - ids to delete
+     * @return number of rows deleted. Returns -1 if there is error
+     */
+    fun delete(tableName: String, keyName: String, ids: List<String>): Int
+
+    /**
+     * Clear the table.
+     *
+     * @param tableName: [String] - name of table
+     * @return whether clear was successful or not.
+     */
+    fun clear(tableName: String): Boolean
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DatabaseTable.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DatabaseTable.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database
+
+/**
+ * Database Table that defines the columns and the primary key.
+ * Currently foreign keys are not supported.
+ * Only single primary key is supported.
+ */
+interface DatabaseTable {
+    /**
+     * Name of database table.
+     */
+    val tableName: String
+
+    /**
+     * Columns other than primary keys.
+     * Key would be column name and value would be type.
+     * For example, mapOf("data" to "TEXT")
+     */
+    val columns: Map<String, String>
+
+    /**
+     * A primary key for the database
+     */
+    val primaryKey: Pair<String, String>
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DirtyEventSQLiteDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DirtyEventSQLiteDao.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database
+
+import android.content.ContentValues
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyEventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyMeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventTypeConverters
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+class DirtyEventSQLiteDao(
+    private val databaseManager: DatabaseManager,
+    private val logger: Logger
+) : DirtyEventDao, DatabaseTable {
+    override val tableName = "DirtyEvents"
+    override val columns: Map<String, String>
+        get() = mapOf(dataColumnName to dataColumnType, ttlColumnName to ttlColumnType)
+    override val primaryKey: Pair<String, String>
+        get() = (idColumnName to idColumnType)
+
+    private val TAG = "DirtyEventSQLiteDao"
+    private val idColumnName = "id"
+    private val dataColumnName = "data"
+    private val ttlColumnName = "ttl"
+    private val idColumnType = "TEXT"
+    private val dataColumnType = "TEXT NOT NULL"
+    private val ttlColumnType = "INTEGER NOT NULL"
+    init {
+        databaseManager.createTable(this)
+    }
+
+    override fun listDirtyMeetingEventItems(size: Int): List<DirtyMeetingEventItem> {
+        val retrievedDataList = databaseManager.query(tableName, size)
+
+        return retrievedDataList.map { retrievedData ->
+            DirtyMeetingEventItem(
+                retrievedData[idColumnName] as String,
+                EventTypeConverters.toMeetingEvent(retrievedData[dataColumnName] as String),
+                retrievedData[ttlColumnName] as Long
+            )
+        }
+    }
+
+    override fun deleteDirtyEventsByIds(ids: List<String>): Int {
+        return databaseManager.delete(tableName, idColumnName, ids)
+    }
+
+    override fun insertDirtyMeetingEventItems(dirtyEvents: List<DirtyMeetingEventItem>): Boolean {
+        return databaseManager.insert(tableName, dirtyEvents.map { dirtyEvent ->
+            ContentValues().apply {
+                put(idColumnName, dirtyEvent.id)
+                put(dataColumnName, EventTypeConverters.fromMeetingEvent(dirtyEvent.data))
+                put(ttlColumnName, dirtyEvent.ttl)
+            }
+        })
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/EventSQLiteDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/EventSQLiteDao.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database
+
+import android.content.ContentValues
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventTypeConverters
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.MeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+class EventSQLiteDao(
+    private val databaseManager: DatabaseManager,
+    private val logger: Logger
+) : EventDao, DatabaseTable {
+    override val tableName = "Events"
+    override val columns: Map<String, String>
+        get() = mapOf(
+            dataColumnName to dataColumnType
+        )
+    override val primaryKey: Pair<String, String>
+        get() = (idColumnName to idColumnType)
+    private val TAG = "EventSQLiteDao"
+
+    private val idColumnName = "id"
+    private val dataColumnName = "data"
+    private val idColumnType = "TEXT"
+    private val dataColumnType = "TEXT NOT NULL"
+
+    init {
+        databaseManager.createTable(this)
+    }
+
+    override fun listMeetingEventItems(size: Int): List<MeetingEventItem> {
+        val retrievedDataList = databaseManager.query(tableName, size)
+
+        return retrievedDataList.map { retrievedData ->
+            MeetingEventItem(
+                retrievedData[idColumnName] as String,
+                EventTypeConverters.toMeetingEvent(retrievedData[dataColumnName] as String)
+            )
+        }
+    }
+
+    override fun insertMeetingEvent(event: MeetingEventItem): Boolean {
+        val values = ContentValues().apply {
+            put(idColumnName, event.id)
+            put(dataColumnName, EventTypeConverters.fromMeetingEvent(event.data))
+        }
+
+        return databaseManager.insert(tableName, listOf(values))
+    }
+
+    override fun deleteMeetingEventsByIds(ids: List<String>): Int {
+        return databaseManager.delete(tableName, idColumnName, ids)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/SQLiteDatabaseManager.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/SQLiteDatabaseManager.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database
+
+import android.content.ContentValues
+import android.content.Context
+import android.database.Cursor
+import android.database.Cursor.FIELD_TYPE_BLOB
+import android.database.Cursor.FIELD_TYPE_FLOAT
+import android.database.Cursor.FIELD_TYPE_INTEGER
+import android.database.Cursor.FIELD_TYPE_NULL
+import android.database.Cursor.FIELD_TYPE_STRING
+import android.database.sqlite.SQLiteDatabase
+import android.database.sqlite.SQLiteOpenHelper
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+const val DATABASE_NAME = "AmazonChimeSDKEvent.db"
+const val IN_MEMORY_DATABASE = ":memory:"
+
+class SQLiteDatabaseManager(
+    context: Context,
+    private val logger: Logger,
+    databaseName: String = DATABASE_NAME
+) :
+    // Context, DatabaseName, Factory (We have no factory), version (It will be 1 for first version)
+    SQLiteOpenHelper(context, databaseName, null, 1), DatabaseManager {
+    private val TAG = "SQLiteDatabaseManager"
+    private val invalidDeleteCount = -1
+
+    override fun onCreate(database: SQLiteDatabase?) {
+    }
+
+    override fun onUpgrade(db: SQLiteDatabase?, oldVersion: Int, newVersion: Int) {
+        // We don't do anything on upgrade. We'll create different table
+    }
+
+    override fun createTable(table: DatabaseTable): Boolean {
+        val builder = StringBuilder()
+        // TODO: sanitize tableName
+        builder.append("CREATE TABLE IF NOT EXISTS ${table.tableName} ")
+
+        val primaryKeyList =
+            listOf("${table.primaryKey.first} ${table.primaryKey.second} PRIMARY KEY")
+        val columnList =
+            table.columns.entries.map { entry -> "${entry.key} ${entry.value}" }.toList()
+
+        val keyList = primaryKeyList + columnList
+        builder.append("(${keyList.joinToString(",")})")
+        return try {
+            writableDatabase.execSQL(builder.toString())
+            true
+        } catch (exception: Exception) {
+            logger.error(TAG, "Unable to create table $builder: ${exception.localizedMessage}")
+            false
+        }
+    }
+
+    override fun query(tableName: String, size: Int?): List<Map<String, Any?>> {
+        val retrievedData = mutableListOf<Map<String, Any?>>()
+        try {
+            val cursor =
+                writableDatabase.query(tableName, null, null, null, null, null, null, size?.toString())
+            cursor.use {
+                while (it.moveToNext()) {
+                    try {
+                        retrievedData.add(retrieveColumn(it))
+                    } catch (exception: Exception) {
+                        logger.error(
+                            TAG,
+                            "Unable to query an item from $tableName: ${exception.localizedMessage}"
+                        )
+                    }
+                }
+            }
+        } catch (exception: Exception) {
+            logger.error(TAG, "Unable to obtain data from $tableName: ${exception.message}")
+        }
+
+        return retrievedData
+    }
+
+    override fun dropTable(tableName: String): Boolean {
+        // TODO: sanitize tableName
+        return try {
+            writableDatabase.execSQL("DROP TABLE IF EXISTS $tableName;")
+            true
+        } catch (exception: Exception) {
+            logger.error(
+                TAG,
+                "Unable to drop table $tableName: ${exception.localizedMessage}"
+            )
+            false
+        }
+    }
+
+    override fun insert(
+        tableName: String,
+        contentValues: List<ContentValues>
+    ): Boolean {
+        if (contentValues.isEmpty()) return true
+
+        // Handle multiple
+        writableDatabase.beginTransaction()
+
+        try {
+            for (contentValue in contentValues) {
+                writableDatabase.insertOrThrow(tableName, null, contentValue)
+            }
+            writableDatabase.setTransactionSuccessful()
+        } catch (exception: Exception) {
+            logger.error(
+                TAG,
+                "Unable to insert items into $tableName: ${exception.localizedMessage}"
+            )
+            return false
+        } finally {
+            writableDatabase.endTransaction()
+        }
+        return true
+    }
+
+    override fun delete(tableName: String, keyName: String, ids: List<String>): Int {
+        if (ids.isEmpty()) return 0
+
+        val idsString = ids.toTypedArray()
+        val whereClause = ids.joinToString(",") { "?" }
+        return delete(tableName, "$keyName in ($whereClause)", idsString)
+    }
+
+    override fun clear(tableName: String): Boolean {
+        return delete(tableName, null, null) != invalidDeleteCount
+    }
+
+    private fun retrieveColumn(cursor: Cursor): Map<String, Any?> {
+        val column = mutableMapOf<String, Any?>()
+        val columnCount = cursor.columnCount
+        for (columnIndex in 0 until columnCount) {
+            if (!cursor.isNull(columnIndex)) {
+                column[cursor.getColumnName(columnIndex)] = retrieveValue(cursor, columnIndex)
+            }
+        }
+
+        return column
+    }
+
+    private fun retrieveValue(cursor: Cursor, columnIndex: Int): Any? {
+        return when (cursor.getType(columnIndex)) {
+            FIELD_TYPE_NULL -> null
+            FIELD_TYPE_FLOAT -> cursor.getDouble(columnIndex)
+            FIELD_TYPE_STRING -> cursor.getString(columnIndex)
+            FIELD_TYPE_INTEGER -> cursor.getLong(columnIndex)
+            FIELD_TYPE_BLOB -> cursor.getBlob(columnIndex)
+            else -> null
+        }
+    }
+
+    private fun delete(tableName: String, whereClause: String?, whereArgs: Array<String>?): Int {
+        return try {
+            writableDatabase.delete(tableName, whereClause, whereArgs)
+        } catch (exception: Exception) {
+            logger.error(
+                TAG,
+                "Unable to delete from $tableName, whereClause: $whereClause, whereArgs: ${whereArgs?.joinToString(
+                    ","
+                )}: ${exception.localizedMessage}"
+            )
+            invalidDeleteCount
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/BackOffRetry.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/BackOffRetry.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+interface BackOffRetry {
+    fun calculateBackOff(): Long
+    fun getRetryCount(): Int
+    fun isRetryCountLimitReached(): Boolean
+    fun incrementRetryCount()
+    fun isRetryableCode(responseCode: Int): Boolean
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DefaultBackOffRetry.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/DefaultBackOffRetry.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import kotlin.math.pow
+
+class DefaultBackOffRetry(
+    private val maxRetry: Int = 0,
+    private val backOff: Long = 0,
+    private val retryableStatusCodes: Set<Int> = HashSet()
+) : BackOffRetry {
+    private val multiplier = 1
+    private var currentRetry = 0
+
+    override fun calculateBackOff(): Long {
+        return (backOff * multiplier.toDouble().pow(currentRetry.toDouble())).toLong()
+    }
+
+    override fun getRetryCount(): Int {
+        return currentRetry
+    }
+
+    override fun isRetryCountLimitReached(): Boolean {
+        return maxRetry > currentRetry
+    }
+
+    override fun incrementRetryCount() {
+        currentRetry++
+    }
+
+    override fun isRetryableCode(responseCode: Int): Boolean {
+        return retryableStatusCodes.isEmpty() || retryableStatusCodes.contains(responseCode)
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/EventAttributesUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/EventAttributesUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
+
+object EventAttributesUtils {
+    fun getCommonAttributes(meetingSessionConfiguration: MeetingSessionConfiguration): EventAttributes {
+        val attributes = getCommonAttributes()
+
+        attributes.putAll(mapOf(
+            EventAttributeName.meetingId to meetingSessionConfiguration.meetingId,
+            EventAttributeName.attendeeId to
+                    meetingSessionConfiguration.credentials.attendeeId,
+            EventAttributeName.externalUserId to
+                    meetingSessionConfiguration.credentials.externalUserId
+        ))
+
+        meetingSessionConfiguration.externalMeetingId?.let {
+            attributes[EventAttributeName.externalMeetingId] = it
+        }
+
+        return attributes
+    }
+
+    fun getCommonAttributes(): EventAttributes {
+        val attributes = mutableMapOf(
+            EventAttributeName.deviceName to DeviceUtils.deviceName,
+            EventAttributeName.deviceManufacturer to DeviceUtils.deviceManufacturer,
+            EventAttributeName.deviceModel to DeviceUtils.deviceModel,
+            EventAttributeName.mediaSdkVersion to DeviceUtils.mediaSDKVersion,
+            EventAttributeName.osName to DeviceUtils.osName,
+            EventAttributeName.osVersion to DeviceUtils.osVersion,
+            EventAttributeName.sdkName to DeviceUtils.sdkName,
+            EventAttributeName.sdkVersion to DeviceUtils.sdkVersion
+        )
+        return attributes as EventAttributes
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpException.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpException.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+data class HttpException(val errorCode: Int? = null, val errorReason: String? = "") :
+    Exception()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpResponse.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpResponse.kt
@@ -1,0 +1,8 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+data class HttpResponse(val data: String? = null, val httpException: HttpException? = null)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpUtils.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+object HttpUtils {
+    private val TAG = "HttpUtils"
+    private val SYSPROP_USER_AGENT = "http.agent"
+    private val USER_AGENT_HEADER = "User-Agent"
+
+    /**
+     * Post request. In order to get value, one has to do
+     * dispatcher.launch {
+     *      result = post(...)
+     *      use result to do sth
+     * }
+     *
+     * @param url: [URL] - URL of the server
+     * @param body: [String] - json String body
+     * @param backOffRetry: [BackOffRetry] - Retry policy
+     * @param logger - [Logger] - logger to log the data
+     * @param headers - [Map<String, String>] - headers to add the http call
+     * @return HttpResponse containing data and error
+     */
+    suspend fun post(
+        url: URL,
+        body: String,
+        backOffRetry: BackOffRetry = DefaultBackOffRetry(),
+        logger: Logger? = null,
+        headers: Map<String, String> = emptyMap()
+    ): HttpResponse {
+        var response: HttpResponse
+        do {
+            response = makePostRequest(url, body, logger, headers)
+            if (response.httpException == null || !backOffRetry.isRetryableCode(
+                    response.httpException?.errorCode ?: 0
+                )
+            ) {
+                return response
+            }
+            backOffRetry.incrementRetryCount()
+            val waitTime = backOffRetry.calculateBackOff()
+            if (waitTime > 0) {
+                delay(waitTime)
+            }
+        } while (backOffRetry.isRetryCountLimitReached())
+        return response
+    }
+
+    private suspend fun makePostRequest(url: URL, body: String, logger: Logger?, headers: Map<String, String>): HttpResponse {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = StringBuffer()
+                with(url.openConnection() as HttpURLConnection) {
+                    requestMethod = "POST"
+                    doInput = true
+                    doOutput = true
+                    for (header in headers) {
+                        setRequestProperty(header.key, header.value)
+                    }
+                    setRequestProperty("Content-Type", "application/json")
+                    val userAgent = System.getProperty(SYSPROP_USER_AGENT)
+                    setRequestProperty(USER_AGENT_HEADER, userAgent)
+                    outputStream.use {
+                        val input = body.toByteArray()
+                        it.write(input, 0, input.size)
+                    }
+
+                    val inStream = if (responseCode in 200..299) inputStream else errorStream
+                    BufferedReader(InputStreamReader(inStream)).use {
+                        var inputLine = it.readLine()
+                        while (inputLine != null) {
+                            response.append(inputLine)
+                            inputLine = it.readLine()
+                        }
+                        it.close()
+                    }
+
+                    if (responseCode in 200..299) {
+                        return@withContext HttpResponse(response.toString(), null)
+                    }
+
+                    return@withContext HttpResponse(
+                        response.toString(),
+                        HttpException(errorCode = responseCode)
+                    )
+                }
+            } catch (exception: Exception) {
+                logger?.error(TAG, "Unable to send request $exception")
+                return@withContext HttpResponse(null, HttpException(null, exception.toString()))
+            }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/CreateMeetingResponse.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/CreateMeetingResponse.kt
@@ -15,9 +15,10 @@ data class Meeting(
     val MeetingId: String
 )
 
-data class MediaPlacement(
+data class MediaPlacement @JvmOverloads constructor(
     val AudioFallbackUrl: String,
     val AudioHostUrl: String,
     val SignalingUrl: String,
-    val TurnControlUrl: String
+    val TurnControlUrl: String,
+    val EventIngestionUrl: String? = null
 )

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfiguration.kt
@@ -22,7 +22,8 @@ data class MeetingSessionConfiguration(
     val credentials: MeetingSessionCredentials,
     val urls: MeetingSessionURLs
 ) {
-    @JvmOverloads constructor(
+    @JvmOverloads
+    constructor(
         createMeetingResponse: CreateMeetingResponse,
         createAttendeeResponse: CreateAttendeeResponse,
         urlRewriter: URLRewriter = ::defaultUrlRewriter
@@ -39,7 +40,8 @@ data class MeetingSessionConfiguration(
             createMeetingResponse.Meeting.MediaPlacement.AudioHostUrl,
             createMeetingResponse.Meeting.MediaPlacement.TurnControlUrl,
             createMeetingResponse.Meeting.MediaPlacement.SignalingUrl,
-            urlRewriter
+            urlRewriter,
+            createMeetingResponse.Meeting.MediaPlacement.EventIngestionUrl
         )
     )
 
@@ -50,7 +52,8 @@ data class MeetingSessionConfiguration(
     ) : this(meetingId, null, credentials, urls)
 
     fun createContentShareMeetingSessionConfiguration(): MeetingSessionConfiguration {
-        val contentModality: String = DefaultModality.MODALITY_SEPARATOR + ModalityType.Content.value
+        val contentModality: String =
+            DefaultModality.MODALITY_SEPARATOR + ModalityType.Content.value
         return MeetingSessionConfiguration(
             meetingId,
             externalMeetingId,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionURLs.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionURLs.kt
@@ -9,15 +9,17 @@ package com.amazonaws.services.chime.sdk.meetings.session
  * [MeetingSessionURLs] contains the URLs that will be used to reach the
  * meeting service.
  */
-data class MeetingSessionURLs(
+data class MeetingSessionURLs @JvmOverloads constructor(
     private val _audioFallbackURL: String,
     private val _audioHostURL: String,
     private val _turnControlURL: String,
     private val _signalingURL: String,
-    val urlRewriter: URLRewriter
+    val urlRewriter: URLRewriter,
+    private val _ingestionURL: String? = null
 ) {
     val audioHostURL = urlRewriter(_audioHostURL)
     val audioFallbackURL = urlRewriter(_audioFallbackURL)
     val turnControlURL = urlRewriter(_turnControlURL)
     val signalingURL = urlRewriter(_signalingURL)
+    val ingestionURL = _ingestionURL?.let { urlRewriter(it) }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsControllerTest.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.analytics
 
+import com.amazonaws.services.chime.sdk.meetings.ingestion.EventReporter
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.DeviceUtils
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
@@ -44,6 +45,9 @@ class DefaultEventAnalyticsControllerTest {
     private lateinit var mockMeetingSessionConfiguration: MeetingSessionConfiguration
 
     @MockK
+    private lateinit var eventReporter: EventReporter
+
+    @MockK
     private lateinit var mockMeetingStatsCollector: MeetingStatsCollector
 
     private val meetingDurationAttribute: EventAttributes =
@@ -58,7 +62,8 @@ class DefaultEventAnalyticsControllerTest {
             DefaultEventAnalyticsController(
                 mockLogger,
                 mockMeetingSessionConfiguration,
-                mockMeetingStatsCollector
+                mockMeetingStatsCollector,
+                eventReporter
             )
         every { mockMeetingStatsCollector.getMeetingStatsEventAttributes() } returns meetingDurationAttribute
         every { mockMeetingStatsCollector.getMeetingHistory() } returns emptyList()
@@ -112,6 +117,20 @@ class DefaultEventAnalyticsControllerTest {
         }
 
         verify(exactly = 0) { observer.onEventReceived(any(), any()) }
+    }
+
+    @Test
+    fun `publishEvent should invoked EventReporter's report`() {
+        testEventAnalyticsController.publishEvent(EventName.meetingFailed)
+
+        verify(exactly = 1) { eventReporter.report(any()) }
+    }
+
+    @Test
+    fun `pushHistory should invoked EventReporter's report`() {
+        testEventAnalyticsController.pushHistory(MeetingHistoryEventName.meetingReconnected)
+
+        verify(exactly = 1) { eventReporter.report(any()) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventReporterTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventReporterTests.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.util.Timer
+import org.junit.Before
+import org.junit.Test
+
+class DefaultEventReporterTests {
+    @MockK
+    private lateinit var ingestionConfiguration: IngestionConfiguration
+
+    @MockK
+    private lateinit var eventBuffer: EventBuffer
+
+    @MockK
+    private lateinit var timer: Timer
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+        every { ingestionConfiguration.flushSize } returns 20
+        every { ingestionConfiguration.flushIntervalMs } returns 200
+    }
+
+    @Test
+    fun `constructor should not invoke timer schedule if disabled`() {
+        every { ingestionConfiguration.disabled } returns true
+
+        DefaultEventReporter(
+            ingestionConfiguration,
+            eventBuffer,
+            logger
+        )
+
+        verify(exactly = 0) { timer.scheduleAtFixedRate(any(), any<Long>(), any()) }
+        verify(exactly = 0) { eventBuffer.process() }
+    }
+
+    @Test
+    fun `constructor should invoke timer schedule if enabled`() {
+        every { ingestionConfiguration.disabled } returns false
+
+        DefaultEventReporter(
+            ingestionConfiguration,
+            eventBuffer,
+            logger,
+            timer
+        )
+
+        verify(exactly = 1) { timer.scheduleAtFixedRate(any(), any<Long>(), any()) }
+    }
+
+    @Test
+    fun `report should call eventBuffer add`() {
+        val meetingId = "meetingId"
+        val attendeeId = "attendeeId"
+        val joinToken = ""
+        every { ingestionConfiguration.disabled } returns false
+        every { ingestionConfiguration.clientConfiguration } returns MeetingEventClientConfiguration(joinToken, meetingId, attendeeId)
+
+        val defaultEventReporter = DefaultEventReporter(
+            ingestionConfiguration,
+            eventBuffer,
+            logger
+        )
+        defaultEventReporter.report(SDKEvent(EventName.meetingFailed, mutableMapOf()))
+
+        verify(exactly = 1) { eventBuffer.add(match {
+            it.eventAttributes[EventAttributeName.meetingId] == meetingId &&
+                    it.eventAttributes[EventAttributeName.attendeeId] == attendeeId }
+        ) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSenderTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSenderTests.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.HttpException
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.HttpResponse
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.HttpUtils
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkObject
+import kotlin.Exception
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class DefaultEventSenderTests {
+    @MockK
+    private lateinit var ingestionConfiguration: IngestionConfiguration
+    @MockK
+    private lateinit var logger: Logger
+
+    private lateinit var eventSender: EventSender
+
+    @MockK
+    private lateinit var ingestionRecord: IngestionRecord
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+        mockkObject(HttpUtils)
+        every { ingestionConfiguration.ingestionUrl } returns "https://example.com"
+        every { ingestionConfiguration.retryCountLimit } returns 5
+        eventSender = DefaultEventSender(ingestionConfiguration, logger)
+    }
+
+    @Test
+    fun `send should invoke HttpUtils send and return true if succeeded`() {
+        coEvery { HttpUtils.post(any(), any(), any(), any(), any()) }.returns(HttpResponse("", null))
+
+        runBlockingTest {
+            val result = eventSender.sendRecord(ingestionRecord)
+
+            coVerify { HttpUtils.post(any(), any(), any(), any(), any()) }
+            Assert.assertEquals(true, result)
+        }
+    }
+
+    @Test
+    fun `send should return false if failed`() {
+        coEvery { HttpUtils.post(any(), any(), any(), any(), any()) }.returns(
+            HttpResponse(
+                null,
+                HttpException(errorCode = 420)
+            )
+        )
+
+        runBlockingTest {
+            val result = eventSender.sendRecord(ingestionRecord)
+
+            coVerify { HttpUtils.post(any(), any(), any(), any(), any()) }
+            Assert.assertEquals(false, result)
+        }
+    }
+
+    @Test
+    fun `send should return false if thrown exception`() {
+        coEvery { HttpUtils.post(any(), any(), any(), any(), any()) }.throws(
+            Exception()
+        )
+
+        runBlockingTest {
+            val result = eventSender.sendRecord(ingestionRecord)
+
+            coVerify { HttpUtils.post(any(), any(), any(), any(), any()) }
+            Assert.assertEquals(false, result)
+        }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBufferTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBufferTests.kt
@@ -1,0 +1,252 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyEventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.DirtyMeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventDao
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.IngestionEventConverter
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.MeetingEventItem
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.verify
+import java.util.Calendar
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class DefaultMeetingEventBufferTests {
+    @MockK
+    private lateinit var ingestionConfiguration: IngestionConfiguration
+
+    @MockK
+    private lateinit var eventDao: EventDao
+
+    @MockK
+    private lateinit var dirtyEventDao: DirtyEventDao
+
+    @MockK
+    private lateinit var eventSender: EventSender
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var calendar: Calendar
+
+    @ExperimentalCoroutinesApi
+    private val eventScope: CoroutineScope = TestCoroutineScope()
+
+    private lateinit var defaultMeetingEventBuffer: EventBuffer
+
+    private val id = "id"
+    private val attendeeId = "attendeeId"
+    private val meetingId = "meetingId"
+    private val meetingEvent = SDKEvent(EventName.meetingFailed, mutableMapOf())
+    private val meetingEventItem = MeetingEventItem(id, meetingEvent)
+    private val dirtyMeetingEventItem = DirtyMeetingEventItem(id, meetingEvent, 1214124L)
+    private val ingestionRecord = IngestionRecord(
+        mutableMapOf(), listOf(
+            IngestionEvent(
+                EventClientType.Meet, mutableMapOf(), listOf(
+                    mutableMapOf(
+                        "status" to "ok",
+                        "id" to id
+                    )
+                )
+            )
+        )
+    )
+    private val flushSize = 5
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+        mockkObject(IngestionEventConverter)
+        every { ingestionConfiguration.flushSize } returns flushSize
+        every { calendar.timeInMillis } returns 100L
+        mockkStatic(Calendar::class)
+        every { Calendar.getInstance() } returns calendar
+        every { ingestionConfiguration.clientConfiguration } returns MeetingEventClientConfiguration(
+            "joinToken",
+            meetingId,
+            attendeeId
+        )
+
+        defaultMeetingEventBuffer = DefaultMeetingEventBuffer(
+            ingestionConfiguration,
+            eventDao,
+            dirtyEventDao,
+            eventSender,
+            logger,
+            eventScope
+        )
+    }
+
+    @Test
+    fun `defaultMeetingEventBuffer should process expired dirtyEvents if send failed`() {
+        val expiredEventId = "newId"
+        val ttl = 100L
+        coEvery { eventSender.sendRecord(any()) } returns false
+        every { calendar.timeInMillis } returns 101L
+        every { IngestionEventConverter.fromDirtyMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+        every { dirtyEventDao.listDirtyMeetingEventItems(any()) } returns listOf(
+            dirtyMeetingEventItem,
+            DirtyMeetingEventItem(expiredEventId, meetingEvent, ttl)
+        )
+
+        DefaultMeetingEventBuffer(
+            ingestionConfiguration,
+            eventDao,
+            dirtyEventDao,
+            eventSender,
+            logger,
+            eventScope
+        )
+
+        runBlockingTest {
+            verify { dirtyEventDao.deleteDirtyEventsByIds(listOf(expiredEventId)) }
+        }
+    }
+
+    @Test
+    fun `add should invoke EventDao insertMeetingEvent`() {
+        defaultMeetingEventBuffer.add(meetingEvent)
+
+        verify(exactly = 1) { eventDao.insertMeetingEvent(any()) }
+    }
+
+    @Test
+    fun `add should send immediately if it is meeting failed`() {
+        coEvery { eventSender.sendRecord(any()) } returns true
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+
+        val currentMeetingEvent = SDKEvent(
+            EventName.meetingFailed, mapOf(
+                EventAttributeName.meetingStatus to MeetingSessionStatusCode.AudioInternalServerError
+            ) as EventAttributes
+        )
+        defaultMeetingEventBuffer.add(currentMeetingEvent)
+
+        runBlockingTest {
+            verify(exactly = 1) { eventDao.insertMeetingEvent(any()) }
+            coVerify(exactly = 1) { eventSender.sendRecord(any()) }
+        }
+    }
+
+    @Test
+    fun `add should not send immediately if it is not meeting failed`() {
+        coEvery { eventSender.sendRecord(any()) } returns true
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+
+        val currentMeetingEvent = SDKEvent(
+            EventName.meetingStartSucceeded, mapOf(
+                EventAttributeName.meetingStatus to MeetingSessionStatusCode.OK
+            ) as EventAttributes
+        )
+        defaultMeetingEventBuffer.add(currentMeetingEvent)
+
+        runBlockingTest {
+            coVerify(exactly = 0) { eventSender.sendRecord(any()) }
+        }
+    }
+
+    @Test
+    fun `process should not invoke eventSender sendRecord when there is no stored events`() {
+        every { eventDao.listMeetingEventItems(any()) } returns emptyList()
+
+        runBlockingTest {
+            defaultMeetingEventBuffer.process()
+
+            coVerify(exactly = 0) { eventSender.sendRecord(any()) }
+        }
+    }
+
+    @Test
+    fun `process should invoke eventSender sendRecord when there is stored events`() {
+        every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+        coEvery { eventSender.sendRecord(any()) } returns true
+
+        runBlockingTest {
+            defaultMeetingEventBuffer.process()
+
+            coVerify(exactly = 1) { eventSender.sendRecord(any()) }
+            verify(exactly = 1) { eventDao.listMeetingEventItems(any()) }
+            verify(exactly = 1) { eventDao.deleteMeetingEventsByIds(any()) }
+        }
+    }
+
+    @Test
+    fun `process should remove processed ids when sent succeeded`() {
+        every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+        coEvery { eventSender.sendRecord(any()) } returns true
+
+        runBlockingTest {
+            defaultMeetingEventBuffer.process()
+
+            verify(exactly = 1) { eventDao.deleteMeetingEventsByIds(listOf(id)) }
+        }
+    }
+
+    @Test
+    fun `process should remove processed ids when sent failed`() {
+        every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+        coEvery { eventSender.sendRecord(any()) } returns false
+
+        runBlockingTest {
+            defaultMeetingEventBuffer.process()
+
+            verify(exactly = 1) { eventDao.deleteMeetingEventsByIds(listOf(id)) }
+        }
+    }
+
+    @Test
+    fun `process should insert events as dirtyEvents when failed to send`() {
+        every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
+        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+            ingestionRecord
+        )
+        coEvery { eventSender.sendRecord(any()) } returns false
+
+        runBlockingTest {
+            defaultMeetingEventBuffer.process()
+
+            coVerify(exactly = 1) { eventSender.sendRecord(any()) }
+            verify(exactly = 1) { eventDao.deleteMeetingEventsByIds(any()) }
+            verify(exactly = 1) { dirtyEventDao.insertDirtyMeetingEventItems(any()) }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionConfigurationTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionConfigurationTests.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class IngestionConfigurationTests {
+    @MockK
+    private lateinit var clientConfiguration: MeetingEventClientConfiguration
+    private val ingestionUrl = "https://ingesitonurl.com"
+    private val disabled = false
+    private val flushSize = 70
+    private val flushIntervalMs = 3000L
+    private val retryCountLimit = 3
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+    }
+
+    @Test
+    fun `constructor should return values passed in`() {
+        val ingestionConfiguration = IngestionConfiguration(
+            clientConfiguration,
+            ingestionUrl,
+            disabled,
+            flushSize,
+            flushIntervalMs,
+            retryCountLimit
+        )
+
+        Assert.assertEquals(clientConfiguration, ingestionConfiguration.clientConfiguration)
+        Assert.assertEquals(ingestionUrl, ingestionConfiguration.ingestionUrl)
+        Assert.assertEquals(disabled, ingestionConfiguration.disabled)
+        Assert.assertEquals(flushSize, ingestionConfiguration.flushSize)
+        Assert.assertEquals(flushIntervalMs, ingestionConfiguration.flushIntervalMs)
+        Assert.assertEquals(retryCountLimit, ingestionConfiguration.retryCountLimit)
+    }
+
+    @Test
+    fun `constructor should restrict numerical values`() {
+        val ingestionConfiguration = IngestionConfiguration(
+            clientConfiguration,
+            ingestionUrl,
+            disabled,
+            100000000,
+            -5,
+            100000000
+        )
+
+        Assert.assertEquals(FLUSH_SIZE_LIMIT_MAXIMUM, ingestionConfiguration.flushSize)
+        Assert.assertEquals(FLUSH_INTERVAL_LIMIT_MINIMUM, ingestionConfiguration.flushIntervalMs)
+        Assert.assertEquals(RETRY_COUNT_LIMIT_MAXIMUM, ingestionConfiguration.retryCountLimit)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionEventTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/IngestionEventTests.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.google.gson.Gson
+import org.junit.Assert
+import org.junit.Test
+
+class IngestionEventTests {
+    private val metadata = mapOf(
+        EventAttributeName.meetingId to "eeeeeeieei"
+    ) as EventAttributes
+    private val payloads = listOf(mapOf(
+        "1" to "2",
+        "hello" to 5
+    ))
+
+    @Test
+    fun `IngestionEvent version should be encoded as v`() {
+        val ingestionEvent = IngestionEvent(EventClientType.Meet, metadata, payloads)
+        val gson = Gson()
+
+        val ingestionEventJson = gson.toJson(ingestionEvent)
+
+        Assert.assertTrue(ingestionEventJson.contains("\"v\":"))
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventSQLiteDaoTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventSQLiteDaoTests.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DatabaseManager
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DirtyEventSQLiteDao
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.google.gson.Gson
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.util.UUID
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class DirtyEventSQLiteDaoTests {
+    private val tableName = "DirtyEvents"
+    private val gson = Gson()
+    private lateinit var dirtyEventDao: DirtyEventSQLiteDao
+
+    @MockK
+    private lateinit var databaseManager: DatabaseManager
+
+    @MockK
+    private lateinit var logger: Logger
+
+    private val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
+
+    private val mockEvent = SDKEvent(
+        EventName.meetingFailed, mutableMapOf(
+            EventAttributeName.meetingErrorMessage to "test fail",
+            EventAttributeName.meetingStatus to MeetingSessionStatusCode.AudioAuthenticationRejected
+        )
+    )
+
+    private fun buildMockMeetingEventItem(): DirtyMeetingEventItem =
+        DirtyMeetingEventItem(UUID.randomUUID().toString(), mockEvent, 200000)
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every { databaseManager.dropTable(any()) } returns true
+        every { databaseManager.createTable(any()) } returns true
+        every { databaseManager.delete(any(), any(), any()) } returns 0
+        every { databaseManager.query(any(), any()) } returns listOf(
+            mapOf(
+                "id" to "51ed7a0b-906c-4ab6-9b4b-2ba9a012105b",
+                "data" to gson.toJson(mockEvent),
+                "ttl" to 1242312412424
+            )
+        )
+
+        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger)
+    }
+
+    @Test
+    fun `insertDirtyMeetingEventItems should invoke database manager insert`() {
+        every { databaseManager.insert(any(), any()) } returns true
+
+        dirtyEventDao.insertDirtyMeetingEventItems(listOf(buildMockMeetingEventItem()))
+
+        verify(exactly = 1) { databaseManager.insert(tableName, any()) }
+    }
+
+    @Test
+    fun `insertDirtyMeetingEventItems should return false if database manager insert fails`() {
+        every { databaseManager.insert(any(), any()) } returns false
+
+        val inserted = dirtyEventDao.insertDirtyMeetingEventItems(listOf(buildMockMeetingEventItem()))
+
+        Assert.assertEquals(false, inserted)
+    }
+
+    @Test
+    fun `queryDirtyMeetingEventItems should invoke database manager query`() {
+        dirtyEventDao.listDirtyMeetingEventItems(5)
+
+        verify(exactly = 1) { databaseManager.query(tableName, 5) }
+    }
+
+    @Test
+    fun `queryDirtyMeetingEventItems should return a list of DirtyMeetingEventItems`() {
+        val dirtyMeetingItems = dirtyEventDao.listDirtyMeetingEventItems(5)
+
+        Assert.assertEquals(1, dirtyMeetingItems.size)
+        Assert.assertEquals(mockEvent.name, dirtyMeetingItems[0].data.name)
+        Assert.assertEquals(
+            mockEvent.eventAttributes[EventAttributeName.meetingErrorMessage],
+            dirtyMeetingItems[0].data.eventAttributes[EventAttributeName.meetingErrorMessage]
+        )
+    }
+
+    @Test
+    fun `deleteDirtyEventsByIds should invoke database manager delete`() {
+        val uuids = listOf(uuid)
+        dirtyEventDao.deleteDirtyEventsByIds(uuids)
+
+        verify(exactly = 1) { databaseManager.delete(tableName, dirtyEventDao.primaryKey.first, uuids) }
+    }
+
+    @Test
+    fun `deleteDirtyEventsByIds should return zero if database manager delete returns 0`() {
+        val uuids = listOf(uuid)
+        val rowsDeleted = dirtyEventDao.deleteDirtyEventsByIds(uuids)
+
+        Assert.assertEquals(0, rowsDeleted)
+    }
+
+    @Test
+    fun `constructor should invoke database manager createTable`() {
+        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger)
+
+        verify { databaseManager.createTable(dirtyEventDao) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventSQLiteDaoTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventSQLiteDaoTests.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DatabaseManager
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.EventSQLiteDao
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import com.google.gson.Gson
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.util.UUID
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class EventSQLiteDaoTests {
+    private val tableName = "Events"
+    private lateinit var eventDao: EventSQLiteDao
+    private val gson = Gson()
+
+    @MockK
+    private lateinit var databaseManager: DatabaseManager
+
+    @MockK
+    private lateinit var logger: Logger
+
+    private val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
+
+    private val mockEvent = SDKEvent(
+        EventName.meetingFailed, mutableMapOf(
+            EventAttributeName.meetingErrorMessage to "test fail",
+            EventAttributeName.meetingStatus to MeetingSessionStatusCode.AudioAuthenticationRejected
+        )
+    )
+
+    private fun buildMockMeetingEventItem(): MeetingEventItem =
+        MeetingEventItem(UUID.randomUUID().toString(), mockEvent)
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every { databaseManager.dropTable(any()) } returns true
+        every { databaseManager.createTable(any()) } returns true
+        every { databaseManager.delete(any(), any(), any()) } returns 0
+        every { databaseManager.query(any(), any()) } returns listOf(
+            mapOf(
+                "id" to "51ed7a0b-906c-4ab6-9b4b-2ba9a012105b",
+                "data" to gson.toJson(mockEvent)
+            )
+        )
+
+        eventDao =
+            EventSQLiteDao(
+                databaseManager,
+                logger
+            )
+    }
+
+    @Test
+    fun `insertMeetingEvent should invoke database manager insert`() {
+        every { databaseManager.insert(any(), any()) } returns true
+
+        eventDao.insertMeetingEvent(buildMockMeetingEventItem())
+
+        verify(exactly = 1) { databaseManager.insert(tableName, any()) }
+    }
+
+    @Test
+    fun `queryMeetingEventItems should invoke database manager query`() {
+        eventDao.listMeetingEventItems(5)
+
+        verify(exactly = 1) { databaseManager.query(tableName, 5) }
+    }
+
+    @Test
+    fun `queryMeetingEventItems should return a list of MeetingEventItem`() {
+        val meetingItems = eventDao.listMeetingEventItems(5)
+
+        Assert.assertEquals(1, meetingItems.size)
+        Assert.assertEquals(
+            mockEvent.eventAttributes[EventAttributeName.meetingErrorMessage],
+            meetingItems[0].data.eventAttributes[EventAttributeName.meetingErrorMessage]
+        )
+    }
+
+    @Test
+    fun `deleteEventsByIds should invoke database manager delete`() {
+        val uuids = listOf(uuid)
+        eventDao.deleteMeetingEventsByIds(uuids)
+
+        verify(exactly = 1) { databaseManager.delete(tableName, eventDao.primaryKey.first, uuids) }
+    }
+
+    @Test
+    fun `deleteEventsByIds should return zero if database manager delete returns 0`() {
+        val uuids = listOf(uuid)
+        val rowsDeleted = eventDao.deleteMeetingEventsByIds(uuids)
+
+        Assert.assertEquals(0, rowsDeleted)
+    }
+
+    @Test
+    fun `constructor should invoke database manager createTable`() {
+        eventDao =
+            EventSQLiteDao(
+                databaseManager,
+                logger
+            )
+
+        verify { databaseManager.createTable(eventDao) }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/HttpUtilsTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+class HttpUtilsTest {
+    val body = "hello"
+
+    @MockK
+    private lateinit var connectionMock: HttpURLConnection
+
+    @MockK
+    private lateinit var outputStreamMock: OutputStream
+
+    @MockK
+    private lateinit var inputStreamMock: InputStream
+
+    @MockK
+    private lateinit var urlMock: URL
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every { inputStreamMock.read(any()) } returns -1
+        every { inputStreamMock.read(any(), any(), any()) } returns -1
+        every { connectionMock.requestMethod = any() } returns Unit
+        every { connectionMock.doInput = any() } returns Unit
+        every { connectionMock.doOutput = any() } returns Unit
+        every { connectionMock.setRequestProperty(any(), any()) } returns Unit
+        every { connectionMock.outputStream } returns outputStreamMock
+        every { connectionMock.inputStream } returns inputStreamMock
+        every { connectionMock.errorStream } returns inputStreamMock
+        every { urlMock.openConnection() } returns connectionMock
+    }
+
+    @Test
+    fun `HttpUtils should return responseCode 400`() {
+        every { (connectionMock).responseCode } returns 400
+        runBlocking {
+            val result = HttpUtils.post(urlMock, body)
+
+            Assert.assertEquals(400, result.httpException?.errorCode)
+        }
+    }
+
+    @Test
+    fun `HttpUtils should return responseCode 200`() {
+        every { (connectionMock).responseCode } returns 200
+
+        runBlocking {
+            val result = HttpUtils.post(urlMock, body)
+
+            Assert.assertNotNull(result.data)
+            Assert.assertNull(result.httpException)
+        }
+    }
+
+    @Test
+    fun `HttpUtils should return httpException when exception is thrown`() {
+        every { (connectionMock).responseCode } returns 200
+        every { connectionMock.outputStream } returns null
+
+        runBlocking {
+            val result = HttpUtils.post(urlMock, body)
+
+            Assert.assertNull(result.data)
+            Assert.assertNotNull(result.httpException)
+            Assert.assertNotNull(result.httpException?.errorReason)
+        }
+    }
+
+    @Test
+    fun `HttpUtils should retry if it is in the retryableSet`() {
+        every { (connectionMock).responseCode } returns 400
+        val retry = 5
+
+        runBlocking {
+            HttpUtils.post(urlMock, body, DefaultBackOffRetry(retry, 0, setOf(400)))
+
+            verify(exactly = retry) { urlMock.openConnection() }
+        }
+    }
+
+    @Test
+    fun `HttpUtils should not retry if it is not in the retryableSet`() {
+        every { (connectionMock).responseCode } returns 400
+        val retry = 5
+
+        runBlocking {
+            HttpUtils.post(urlMock, body, DefaultBackOffRetry(retry, 0, setOf(404)))
+
+            verify(exactly = 1) { urlMock.openConnection() }
+        }
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/DefaultMeetingSessionTest.kt
@@ -14,6 +14,7 @@ import android.os.HandlerThread
 import android.os.Looper
 import android.util.Log
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
+import com.amazonaws.services.chime.sdk.meetings.ingestion.EventReporterFactory
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientFactory
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
@@ -55,6 +56,9 @@ class DefaultMeetingSessionTest {
     @MockK
     private lateinit var mockLooper: Looper
 
+    @MockK
+    private lateinit var eventReporterFactory: EventReporterFactory
+
     private lateinit var meetingSession: DefaultMeetingSession
 
     @Before
@@ -78,12 +82,12 @@ class DefaultMeetingSessionTest {
         every { AudioClientFactory.getAudioClient(any(), any()) } returns mockAudioClient
         every { logger.info(any(), any()) } just runs
         every { configuration.createContentShareMeetingSessionConfiguration() } returns contentConfiguration
-
+        every { eventReporterFactory.createEventReporter() } returns null
         mockkConstructor(HandlerThread::class)
         every { anyConstructed<HandlerThread>().looper } returns mockLooper
         every { anyConstructed<HandlerThread>().run() } just runs
 
-        meetingSession = DefaultMeetingSession(configuration, logger, context, mockEglCoreFactory)
+        meetingSession = DefaultMeetingSession(configuration, logger, context, mockEglCoreFactory, eventReporterFactory)
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionConfigurationTest.kt
@@ -26,6 +26,7 @@ class MeetingSessionConfigurationTest {
     private val audioHostURL = "audioHostURL"
     private val turnControlURL = "turnControlURL"
     private val signalingURL = "signalingURL"
+    private val ingestionURL = "ingestionURL"
 
     @Test
     fun `constructor should return object with data from parameters`() {
@@ -33,7 +34,7 @@ class MeetingSessionConfigurationTest {
             CreateMeetingResponse(
                 Meeting(
                     externalMeetingId,
-                    MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL),
+                    MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL, ingestionURL),
                     mediaRegion,
                     meetingId
                 )
@@ -47,6 +48,7 @@ class MeetingSessionConfigurationTest {
         assertEquals(signalingURL, meetingSessionConfiguration.urls.signalingURL)
         assertEquals(attendeeId, meetingSessionConfiguration.credentials.attendeeId)
         assertEquals(joinToken, meetingSessionConfiguration.credentials.joinToken)
+        assertEquals(ingestionURL, meetingSessionConfiguration.urls.ingestionURL)
     }
 
     @Test
@@ -63,6 +65,22 @@ class MeetingSessionConfigurationTest {
         )
 
         assertNull(meetingSessionConfiguration.externalMeetingId)
+    }
+
+    @Test
+    fun `constructor should return null ingestionUrl when not provided through Meeting`() {
+        val meetingSessionConfiguration = MeetingSessionConfiguration(
+            CreateMeetingResponse(
+                Meeting(
+                    null,
+                    MediaPlacement(audioFallbackURL, audioHostURL, signalingURL, turnControlURL),
+                    mediaRegion,
+                    meetingId
+                )
+            ), CreateAttendeeResponse(Attendee(attendeeId, externalUserId, joinToken))
+        )
+
+        assertNull(meetingSessionConfiguration.urls.ingestionURL)
     }
 
     @Test

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -144,6 +144,7 @@ class MeetingActivity : AppCompatActivity(),
     fun resetCachedDevice() {
         cachedDevice = null
     }
+
     fun getEglCoreFactory(): EglCoreFactory = meetingSessionModel.eglCoreFactory
 
     fun getCameraCaptureSource(): CameraCaptureSource = meetingSessionModel.cameraCaptureSource
@@ -165,7 +166,6 @@ class MeetingActivity : AppCompatActivity(),
 
     private fun createSessionConfiguration(response: String?): MeetingSessionConfiguration? {
         if (response.isNullOrBlank()) return null
-
         return try {
             val joinMeetingResponse = gson.fromJson(response, JoinMeetingResponse::class.java)
             MeetingSessionConfiguration(

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingSessionModel.kt
@@ -38,6 +38,7 @@ class MeetingSessionModel : ViewModel() {
     lateinit var cameraCaptureSource: CameraCaptureSource
     lateinit var gpuVideoProcessor: GpuVideoProcessor
     lateinit var cpuVideoProcessor: CpuVideoProcessor
+
     // Source for screen capture and share, will be set only if created in call
     var screenShareManager: ScreenShareManager? = null
 }

--- a/guides/event_ingestion.md
+++ b/guides/event_ingestion.md
@@ -1,0 +1,26 @@
+# Event Ingestion
+
+We send the [Amazon Chime SDK meeting events](meeting_events.md) to the Amazon Chime backend to analyze meeting health trends or identify common failures. This helps us to improve your meeting experience.
+
+## Sensitive attributes
+The Amazon Chime SDK for Android will not send below sensitive attributes to the Amazon Chime backend.
+|Attribute|Description
+|--|--
+|`externalMeetingId`|The Amazon Chime SDK external meeting ID.
+|`externalUserId`|The Amazon Chime SDK external user ID that can indicate an identity managed by your application.
+
+## Opt out of Event Ingestion
+
+To opt out of event ingestion, provide `NoopEventReporterFactory` to `DefaultMeetingSession` while creating the
+meeting session.
+
+See following example code:
+```kotlin
+    DefaultMeetingSession(
+        meetingSessionConfiguration,
+        logger,
+        applicationContext,
+        DefaultEglCoreFactory(),
+        NoopEventReporterFactory()
+    )
+```


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Add event ingestion

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [X] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
