### PR TITLE
Fix unit test for DefaultEventSenderTests

### DIFF
--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSenderTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultEventSenderTests.kt
@@ -15,9 +15,11 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import kotlin.Exception
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -41,6 +43,11 @@ class DefaultEventSenderTests {
         every { ingestionConfiguration.ingestionUrl } returns "https://example.com"
         every { ingestionConfiguration.retryCountLimit } returns 5
         eventSender = DefaultEventSender(ingestionConfiguration, logger)
+    }
+
+    @After
+    fun cleanup() {
+        unmockkObject(HttpUtils)
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
There are intermittent unit tests failures  on `DefaultSenderTests`/`HttpUtils`. This fixes that issue.

### Testing done:
Run unit tests multiple times

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
