### PR TITLE
Fix screen share rotation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Fixed
-* Fixed Screen share rotation issue (Issue #292)
+* Fixed Screen share rotation issue (Issue #289)
 * [Demo] Fixed crash when end meeting while screen sharing
 
 ## [0.11.5] - 2021-06-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed Screen share rotation issue (Issue #292)
+
 ## [0.11.5] - 2021-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed Screen share rotation issue (Issue #292)
+* [Demo] Fixed crash when end meeting while screen sharing
 
 ## [0.11.5] - 2021-06-24
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultScreenCaptureSource.kt
@@ -145,14 +145,19 @@ class DefaultScreenCaptureSource(
         val rotation = display.rotation
         isOrientationInPortrait = rotation == Surface.ROTATION_0 || rotation == Surface.ROTATION_180
 
+        // Sometimes, Android changes displayMetrics widthPixels and heightPixels
+        // and return inconsistent height and width for surfaceTextureSource VS virtualDisplay
+        val width = displayMetrics.widthPixels
+        val height = displayMetrics.heightPixels
+
         // Note that in landscape, for some reason `getRealMetrics` doesn't account for the status bar correctly
         // so we try to account for it with a manual adjustment to the surface size to avoid letterboxes
         // Some android device H.264 encoder is not able to handle size that is not multiples of 16 (such as Pixel3),
         // so screenCapture surface size is aligned manually to avoid the issue
         surfaceTextureSource =
             surfaceTextureCaptureSourceFactory.createSurfaceTextureCaptureSource(
-                alignNumberBy16(displayMetrics.widthPixels - (if (isOrientationInPortrait) 0 else getStatusBarHeight())),
-                alignNumberBy16(displayMetrics.heightPixels),
+                alignNumberBy16(width - (if (isOrientationInPortrait) 0 else getStatusBarHeight())),
+                alignNumberBy16(height),
                 contentHint
             )
         surfaceTextureSource?.minFps = MIN_FPS
@@ -162,8 +167,8 @@ class DefaultScreenCaptureSource(
 
         virtualDisplay = mediaProjection?.createVirtualDisplay(
             TAG,
-            displayMetrics.widthPixels,
-            displayMetrics.heightPixels,
+            width,
+            height,
             displayMetrics.densityDpi,
             DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR,
             surfaceTextureSource?.surface,

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1372,7 +1372,7 @@ class MeetingFragment : Fragment(),
             audioVideo.unbindVideoView(it.videoTileState.tileId)
         }
         audioVideo.stopLocalVideo()
-        audioVideo.stopRemoteVideo()
+        audioVideo.stopContentShare()
         audioVideo.stopRemoteVideo()
         audioVideo.stop()
     }


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/289
### Description of changes:
When you rotate while screen share multiple times, sometimes it shows cropped screen. 

### Testing done:

Rotated multiple times, but no cropped screen.

#### Unit test coverage
* Class coverage: 82%
* Line coverage: 66%

#### Manual test cases (add more as needed):
* [X] Join meeting
* [x] Leave meeting
* [X] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
