### PR TITLE
Add loadLibrary on DefaultCameraCaptureSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed issue where `DefaultCameraCaptureSource` cannot be used without `DefaultMeetingSession` (Issue #309)
+
 ## [0.11.6] - 2021-07-21
 
 ### Fixed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -99,6 +99,8 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
         }
 
     init {
+        // Load library so that some of webrtc definition is linked properly
+        System.loadLibrary("amazon_chime_media_client")
         val thread = HandlerThread("DefaultCameraCaptureSource")
         thread.start()
         handler = Handler(thread.looper)


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/309
### Description of changes:
Add loadlibrary of media client to `DefaultCameraCaptureSource` so that it can be used without `DefaultMeetingSession`

### Testing done:
Comment out all `DefaultMeetingSession` initialization and run the demo application.

#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [X] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
