### PR TITLE
Update targetSdkVersion to 30 and update DefaultScreenCaptureSource t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## Unreleased
 
 ### Fixed
-* Fixed issue where `DefaultCameraCaptureSource` cannot be used without `DefaultMeetingSession` (Issue #309)
+* Fixed an issue where `DefaultCameraCaptureSource` cannot be used without `DefaultMeetingSession` (Issue #309)
+
+### Changed
+* **Breaking** Changed the behavior of `DefaultScreenCaptureSource` to better handle failure cases (Issue #317).
+  - Previously errors with getting the media projection either resulted in a SecurityException or silently failed.
+  - Now `onCaptureFailed` from `CaptureSourceObserver` will be called to handle errors with getting the media projection.
+* Updated targetSdkVersion from 28 to 30
 
 ## [0.11.6] - 2021-07-21
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CaptureSourceError.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CaptureSourceError.kt
@@ -27,7 +27,7 @@ enum class CaptureSourceError {
     SystemFailure,
 
     /**
-     * A failure observer during configuration
+     * A failure observed during configuration
      */
     ConfigurationFailure;
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/SurfaceRenderView.kt
@@ -108,21 +108,19 @@ open class SurfaceRenderView @JvmOverloads constructor(
         renderer.release()
     }
 
-    override fun surfaceChanged(holder: SurfaceHolder?, format: Int, width: Int, height: Int) {}
+    override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
 
-    override fun surfaceDestroyed(holder: SurfaceHolder?) {
+    override fun surfaceDestroyed(holder: SurfaceHolder) {
         logger.info(TAG, "Surface destroyed, releasing EGL surface")
         renderer.releaseEglSurface()
     }
 
-    override fun surfaceCreated(holder: SurfaceHolder?) {
+    override fun surfaceCreated(holder: SurfaceHolder) {
         updateSurfaceSize()
 
         // Create the EGL surface and set it as current
-        holder?.let {
-            logger.info(TAG, "Surface created, creating EGL surface with resource")
-            renderer.createEglSurface(it.surface)
-        }
+        logger.info(TAG, "Surface created, creating EGL surface with resource")
+        renderer.createEglSurface(holder.surface)
     }
 
     override fun onMeasure(widthSpec: Int, heightSpec: Int) {

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ allprojects {
     project.ext {
         chimeBuildToolsVersion = "29.0.2"
         chimeMinSdkVersion = 21
-        chimeTargetSdkVersion = 28
-        chimeCompileSdkVersion = 29
+        chimeTargetSdkVersion = 30
+        chimeCompileSdkVersion = 30
         sdkDir = localProperties.getProperty('sdk.dir')
         ndkDir = localProperties.getProperty('ndk.dir')
     }


### PR DESCRIPTION
…o handle SecurityException when getting MediaProjection

### Issue #, if available:
* https://github.com/aws/amazon-chime-sdk-android/issues/316
* https://github.com/aws/amazon-chime-sdk-android/issues/317

### Description of changes:
* Update targetSdkVersion from 28 to 30 ([see Android docs](https://developer.android.com/distribute/best-practices/develop/target-sdk))
* Update `DefaultScreenCaptureSource` documentation and `start` method to handle `SecurityException`. SDK demo app updates to remove the race condition as explained in https://github.com/aws/amazon-chime-sdk-android/issues/317 will be done in a different PR.

### Testing done:
* Ran unit tests
* Tested in a meeting with 2 attendees (Android and JS). In addition to the manual test cases, specifically tested:
   - Verified video send and receive was successful
   - Verified content share send and receive was successful
   - Verified attendees with content modality showed up on roster for both attendees
   - `DefaultScreenCaptureSource` no longer causes a crash via `SecurityException` due to race condition in SDK demo app. One can try again and it will succeed on the second `start` call
   - `onCaptureStarted` is called when `DefaultScreenCaptureSource` successfully started
   - `onCaptureStarted` is NOT called when `DefaultScreenCaptureSource` failed to start due to race condition in SDK demo app. Note that one can just try again afterwards and it'll succeed on the second `start` call
   - onCaptureFailed` is called when `DefaultScreenCaptureSource` failed to start due to race condition in SDK demo app.
   -  Verified that screen capture still works when rotating the device
 
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
