### PR TITLE
Add delay to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Added
+* [Demo] Added delay between service start and screen share to avoid condition where screen share starts before service.
+
 ### Fixed
 * Fixed an issue where `DefaultCameraCaptureSource` cannot be used without `DefaultMeetingSession` (Issue #309)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-* [Demo] Added delay between service start and screen share to avoid condition where screen share starts before service.
+* [Demo] Added binding to screen share service to avoid condition where screen share starts before service.
 
 ### Fixed
 * Fixed an issue where `DefaultCameraCaptureSource` cannot be used without `DefaultMeetingSession` (Issue #309)

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdkdemo.device
 
 import android.content.Context
 import android.content.Intent
+import android.content.ServiceConnection
 import android.media.projection.MediaProjection
 import android.os.Build
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
@@ -26,11 +27,16 @@ class ScreenShareManager(
 ) : ContentShareSource() {
     override var videoSource: VideoSource? = screenCaptureSource
 
+    var screenCaptureConnectionService: ServiceConnection? = null
+
     fun start() = screenCaptureSource.start()
 
     fun stop() {
         context.stopService(Intent(context, ScreenCaptureService::class.java))
         screenCaptureSource.stop()
+        screenCaptureConnectionService?.let {
+            context.unbindService(it)
+        }
     }
 
     fun release() = screenCaptureSource.release()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/service/ScreenCaptureService.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/service/ScreenCaptureService.kt
@@ -10,6 +10,7 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.os.Binder
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
@@ -21,6 +22,12 @@ class ScreenCaptureService : Service() {
     private val CHANNEL_ID = "ScreenCaptureServiceChannelID"
     private val CHANNEL_NAME = "Screen Share"
     private val SERVICE_ID = 1
+
+    private val binder = ScreenCaptureBinder()
+
+    inner class ScreenCaptureBinder : Binder() {
+        fun getService(): ScreenCaptureService = this@ScreenCaptureService
+    }
 
     override fun onCreate() {
         super.onCreate()
@@ -51,5 +58,5 @@ class ScreenCaptureService : Service() {
         return START_STICKY
     }
 
-    override fun onBind(intent: Intent?): IBinder? = null
+    override fun onBind(intent: Intent?): IBinder? = binder
 }


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Add delay to starting screen share.

There seem few other ways to solve this issue. (I haven't tested those yet)
1. Put all the logic into Service onStartCommand. This might be complicated given we have to pass audiovideo instance to Service


### Testing done:
Start screen share multiple times. Seeing no failures compared to some failures before.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
