### PR TITLE
Update documentation for DataMessageObserver

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ val YOUR_ATTENDEE_ID = meetingSession.configuration.credentials.attendeeId
 
 val observer = object: DataMessageObserver {
     override fun onDataMessageReceived(dataMessage: DataMessage) {
-        // A throttled message is returned by backend from local sender
+        // A throttled message is returned by backend
         if (!dataMessage.throttled) {
             logger.info(TAG, "[${dataMessage.timestampMs}][{$dataMessage.senderAttendeeId}] : ${dataMessage.text()}")
     }

--- a/README.md
+++ b/README.md
@@ -513,13 +513,15 @@ meetingSession.audioVideo.addMetricsObserver(observer)
 
 You can receive real-time messages from multiple topics after starting the meeting session.
 
+> Note: Data messages sent from local participant will not trigger this callback.
+
 ```kotlin
 val YOUR_ATTENDEE_ID = meetingSession.configuration.credentials.attendeeId
 
 val observer = object: DataMessageObserver {
     override fun onDataMessageReceived(dataMessage: DataMessage) {
         // A throttled message is returned by backend from local sender
-        if (!dataMessage.throttled && dataMessage.senderAttendeeId != YOUR_ATTENDEE_ID) {
+        if (!dataMessage.throttled) {
             logger.info(TAG, "[${dataMessage.timestampMs}][{$dataMessage.senderAttendeeId}] : ${dataMessage.text()}")
     }
 }

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ meetingSession.audioVideo.addMetricsObserver(observer)
 
 You can receive real-time messages from multiple topics after starting the meeting session.
 
-> Note: Data messages sent from local participant will not trigger this callback.
+> Note: Data messages sent from local participant will not trigger this callback unless it's throttled.
 
 ```kotlin
 val YOUR_ATTENDEE_ID = meetingSession.configuration.credentials.attendeeId

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/datamessage/DataMessageObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/datamessage/DataMessageObserver.kt
@@ -16,6 +16,8 @@ interface DataMessageObserver {
     /**
      * Handles data message being received.
      *
+     * Note: Data messages sent from local participant will not trigger this callback unless it's throttled.
+     *
      * @param dataMessage: [DataMessage] - data message being received
      */
     fun onDataMessageReceived(dataMessage: DataMessage)


### PR DESCRIPTION
### Issue #, if available:
#325 
### Description of changes:

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
