### PR TITLE
Support 48KHz and stereo

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -38,6 +38,7 @@ class DefaultAudioClientController(
     private val DEFAULT_MIC_AND_SPEAKER = false
     private val DEFAULT_PRESENTER = true
     private val AUDIO_CLIENT_RESULT_SUCCESS = AudioClient.AUDIO_CLIENT_OK
+    private val SAMPLE_RATE_48KHZ = 48000
 
     private val uiScope = CoroutineScope(Dispatchers.Main)
     private val audioManager: AudioManager =
@@ -63,9 +64,11 @@ class DefaultAudioClientController(
         )
 
         // Result is in bytes, so we divide by 2 (16-bit samples)
+        val channelConfig = if (AudioClient.OUTPUT_CHANNEL_COUNT == 1) AudioFormat.CHANNEL_OUT_MONO
+            else AudioFormat.CHANNEL_OUT_STEREO
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
-            AudioFormat.CHANNEL_OUT_MONO,
+            channelConfig,
             AudioFormat.ENCODING_PCM_16BIT
         ) / 2
 
@@ -147,6 +150,9 @@ class DefaultAudioClientController(
 
         val appInfo = AppInfoUtil.initializeAudioClientAppInfo(context)
 
+        val codec = if (AudioClient.AUDIO_CLIENT_SAMPLE_RATE == SAMPLE_RATE_48KHZ)
+            AudioClient.kCodecOpus48KHz else AudioClient.kCodecOpusLow
+
         uiScope.launch {
             val res = audioClient.startSessionV2(
                 AudioClient.XTL_DEFAULT_TRANSPORT,
@@ -155,14 +161,17 @@ class DefaultAudioClientController(
                 joinToken,
                 meetingId,
                 attendeeId,
-                AudioClient.kCodecOpusLow,
-                AudioClient.kCodecOpusLow,
+                codec,
+                codec,
                 DEFAULT_MIC_AND_SPEAKER,
                 DEFAULT_MIC_AND_SPEAKER,
                 DEFAULT_PRESENTER,
                 audioFallbackUrl,
                 null,
-                appInfo
+                appInfo,
+                AudioClient.AUDIO_CLIENT_SAMPLE_RATE,
+                AudioClient.INPUT_CHANNEL_COUNT,
+                AudioClient.OUTPUT_CHANNEL_COUNT
             )
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -138,6 +138,9 @@ class DefaultAudioClientControllerTest {
                 any(),
                 any(),
                 any(),
+                any(),
+                any(),
+                any(),
                 any()
             )
         } returns testAudioClientSuccessCode
@@ -297,6 +300,9 @@ class DefaultAudioClientControllerTest {
 
         verify {
             mockAudioClient.startSessionV2(
+                any(),
+                any(),
+                any(),
                 any(),
                 any(),
                 any(),


### PR DESCRIPTION
### Description of changes:

In order to support 48KHz in demo app the appropriate codec needs to be chosen. Also, the new startSession method is used that allows to specify sample rate and channel count for input and output.

### Testing done:

Manual testing on server supporting 48KHz and stereo.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ x] Send audio
* [ x] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
