### PR TITLE
Add live transcription APIs and related data models

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -31,6 +31,7 @@ import com.amazonaws.services.chime.sdk.meetings.device.DeviceController
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
+import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.datamessage.DataMessageObserver
 
 class DefaultAudioVideoFacade(
@@ -237,5 +238,13 @@ class DefaultAudioVideoFacade(
 
     override fun getCommonEventAttributes(): EventAttributes {
         return eventAnalyticsController.getCommonEventAttributes()
+    }
+
+    override fun addRealtimeTranscriptEventObserver(observer: TranscriptEventObserver) {
+        realtimeController.addRealtimeTranscriptEventObserver(observer)
+    }
+
+    override fun removeRealtimeTranscriptEventObserver(observer: TranscriptEventObserver) {
+        realtimeController.removeRealtimeTranscriptEventObserver(observer)
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientFactory.kt
@@ -25,6 +25,7 @@ class AudioClientFactory private constructor(
             audioClientObserver,
             audioClientObserver,
             audioClientObserver,
+            audioClientObserver,
             0
         )
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientObserver.kt
@@ -7,12 +7,14 @@ package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
+import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
 import com.xodee.client.audio.audioclient.AudioClientLogListener
 import com.xodee.client.audio.audioclient.AudioClientMetricsListener
 import com.xodee.client.audio.audioclient.AudioClientPresenceListener
 import com.xodee.client.audio.audioclient.AudioClientSignalStrengthChangeListener
 import com.xodee.client.audio.audioclient.AudioClientStateChangeListener
 import com.xodee.client.audio.audioclient.AudioClientVolumeStateChangeListener
+import com.xodee.client.audio.audioclient.AudioClientTranscriptEventsReceiveListener
 
 /**
  * [AudioClientObserver]'s responsibility is to handle AudioClient callbacks and maintain all
@@ -21,11 +23,14 @@ import com.xodee.client.audio.audioclient.AudioClientVolumeStateChangeListener
 interface AudioClientObserver : AudioClientStateChangeListener,
     AudioClientVolumeStateChangeListener,
     AudioClientSignalStrengthChangeListener, AudioClientLogListener,
-    AudioClientMetricsListener, AudioClientPresenceListener {
+    AudioClientMetricsListener, AudioClientPresenceListener,
+    AudioClientTranscriptEventsReceiveListener {
 
     fun subscribeToAudioClientStateChange(observer: AudioVideoObserver)
     fun unsubscribeFromAudioClientStateChange(observer: AudioVideoObserver)
     fun notifyAudioClientObserver(observerFunction: (observer: AudioVideoObserver) -> Unit)
     fun subscribeToRealTimeEvents(observer: RealtimeObserver)
     fun unsubscribeFromRealTimeEvents(observer: RealtimeObserver)
+    fun subscribeToTranscriptEvent(observer: TranscriptEventObserver)
+    fun unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -14,6 +14,14 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.AttendeeInfo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.SignalStrength
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.SignalUpdate
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.Transcript
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptAlternative
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptEvent
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptItem
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptItemType
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptResult
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatus
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatusType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeLevel
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeUpdate
 import com.amazonaws.services.chime.sdk.meetings.internal.AttendeeStatus
@@ -21,12 +29,17 @@ import com.amazonaws.services.chime.sdk.meetings.internal.SessionStateController
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
+import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AttendeeUpdate
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.transcript.Transcript as TranscriptInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptEvent as TranscriptEventInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptionStatus as TranscriptionStatusInternal
+
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
@@ -54,6 +67,7 @@ class DefaultAudioClientObserver(
 
     private var audioClientStateObservers = mutableSetOf<AudioVideoObserver>()
     private var realtimeEventObservers = mutableSetOf<RealtimeObserver>()
+    private var transcriptEventObservers = mutableSetOf<TranscriptEventObserver>()
 
     /**
      * Volume state change can be used to figure out the meeting's current attendees.
@@ -209,6 +223,76 @@ class DefaultAudioClientObserver(
         currentAttendeeSignalMap = newAttendeeSignalMap
     }
 
+    override fun onTranscriptEventsReceived(events: Array<out TranscriptEventInternal>?) {
+        if (events == null) return
+
+        events.forEach { rawEvent ->
+            val event: TranscriptEvent?
+            when (rawEvent) {
+                is TranscriptionStatusInternal -> {
+                    event = TranscriptionStatusType.from(rawEvent.type.value)?.let {
+                        TranscriptionStatus(
+                            it,
+                            rawEvent.eventTimeMs,
+                            rawEvent.transcriptionRegion,
+                            rawEvent.transcriptionConfiguration,
+                            rawEvent.message
+                        )
+                    }
+                }
+                is TranscriptInternal -> {
+                    val results = mutableListOf<TranscriptResult>()
+                    rawEvent.results.forEach { rawResult ->
+                        val alternatives = mutableListOf<TranscriptAlternative>()
+                        rawResult.alternatives.forEach { rawAlternative ->
+                            val items = mutableListOf<TranscriptItem>()
+                            rawAlternative.items.forEach { rawItem ->
+                                val item = TranscriptItemType.from(rawItem.type.value)?.let {
+                                    TranscriptItem(
+                                        it,
+                                        rawItem.startTimeMs,
+                                        rawItem.endTimeMs,
+                                        AttendeeInfo(
+                                            rawItem.attendee.attendeeId,
+                                            rawItem.attendee.externalUserId
+                                        ),
+                                        rawItem.content,
+                                        rawItem.vocabularyFilterMatch
+                                    )
+                                }
+                                item?.let { items.add(it) }
+                            }
+                            val alternative = TranscriptAlternative(items, rawAlternative.transcript)
+                            alternatives.add(alternative)
+                        }
+                        val result = TranscriptResult(
+                            rawResult.resultId,
+                            rawResult.channelId,
+                            rawResult.isPartial,
+                            rawResult.startTimeMs,
+                            rawResult.endTimeMs,
+                            alternatives
+                        )
+                        results.add(result)
+                    }
+                    event = Transcript(results)
+                } else -> {
+                    logger.error(TAG, "Received transcript event in unknown format")
+                    event = null
+                }
+            }
+            logger.info(TAG, event.toString())
+
+            transcriptEventObservers.forEach {
+                event.let { transcriptEvent ->
+                    if (transcriptEvent != null) {
+                        it.onTranscriptEventReceived(transcriptEvent)
+                    }
+                }
+            }
+        }
+    }
+
     private fun onAttendeesMuteStateChange(volumesDelta: Map<String, VolumeUpdate>) {
         val mutedAttendeeMap: Map<String, VolumeUpdate> = volumesDelta.filter { (_, value) ->
             value.volumeLevel == VolumeLevel.Muted
@@ -351,6 +435,14 @@ class DefaultAudioClientObserver(
 
     override fun unsubscribeFromRealTimeEvents(observer: RealtimeObserver) {
         realtimeEventObservers.remove(observer)
+    }
+
+    override fun subscribeToTranscriptEvent(observer: TranscriptEventObserver) {
+        transcriptEventObservers.add(observer)
+    }
+
+    override fun unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver) {
+        transcriptEventObservers.remove(observer)
     }
 
     override fun notifyAudioClientObserver(observerFunction: (observer: AudioVideoObserver) -> Unit) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/DefaultRealtimeController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/DefaultRealtimeController.kt
@@ -54,4 +54,12 @@ class DefaultRealtimeController(
     override fun realtimeIsVoiceFocusEnabled(): Boolean {
         return audioClientController.isVoiceFocusEnabled()
     }
+
+    override fun addRealtimeTranscriptEventObserver(observer: TranscriptEventObserver) {
+        audioClientObserver.subscribeToTranscriptEvent(observer)
+    }
+
+    override fun removeRealtimeTranscriptEventObserver(observer: TranscriptEventObserver) {
+        audioClientObserver.unsubscribeFromTranscriptEvent(observer)
+    }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/RealtimeControllerFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/realtime/RealtimeControllerFacade.kt
@@ -99,4 +99,18 @@ interface RealtimeControllerFacade {
      * @return Boolean whether Amazon Voice Focus is enabled or not
      */
     fun realtimeIsVoiceFocusEnabled(): Boolean
+
+    /**
+     * Subscribes to transcript event with an observer
+     *
+     * @param observer: [TranscriptEventObserver] - Observer that handles transcript event
+     */
+    fun addRealtimeTranscriptEventObserver(observer: TranscriptEventObserver)
+
+    /**
+     * Unsubscribes from transcript event by removing the specified observer
+     *
+     * @param observer: [TranscriptEventObserver] - Observer that handles transcript event
+     */
+    fun removeRealtimeTranscriptEventObserver(observer: TranscriptEventObserver)
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -21,6 +21,7 @@ import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeControllerFacade
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
+import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.datamessage.DataMessageObserver
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -58,6 +59,9 @@ class DefaultAudioVideoFacadeTest {
 
     @MockK
     private lateinit var mockDataMessageObserver: DataMessageObserver
+
+    @MockK
+    private lateinit var mockTranscriptEventObserver: TranscriptEventObserver
 
     @MockK
     private lateinit var mockDeviceChangeObserver: DeviceChangeObserver
@@ -231,6 +235,18 @@ class DefaultAudioVideoFacadeTest {
         every { realtimeController.realtimeIsVoiceFocusEnabled() } returns false
         assertFalse(audioVideoFacade.realtimeIsVoiceFocusEnabled())
         verify { realtimeController.realtimeIsVoiceFocusEnabled() }
+    }
+
+    @Test
+    fun `addRealtimeTranscriptEventObserver should call realtimeController addRealtimeTranscriptEventObserver with given observer`() {
+        audioVideoFacade.addRealtimeTranscriptEventObserver(mockTranscriptEventObserver)
+        verify { realtimeController.addRealtimeTranscriptEventObserver(mockTranscriptEventObserver) }
+    }
+
+    @Test
+    fun `removeRealtimeTranscriptEventObserver should call realtimeController removeRealtimeTranscriptEventObserver with given observer`() {
+        audioVideoFacade.removeRealtimeTranscriptEventObserver(mockTranscriptEventObserver)
+        verify { realtimeController.removeRealtimeTranscriptEventObserver(mockTranscriptEventObserver) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
@@ -15,17 +15,34 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.AttendeeInfo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.SignalStrength
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.SignalUpdate
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.Transcript
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptAlternative
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptItem
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptItemType
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptResult
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatus
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatusType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeLevel
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeUpdate
 import com.amazonaws.services.chime.sdk.meetings.internal.AttendeeStatus
 import com.amazonaws.services.chime.sdk.meetings.internal.SessionStateControllerAction
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
+import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AttendeeUpdate
+import com.xodee.client.audio.audioclient.AttendeeInfo as AttendeeInfoInternal
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.transcript.TranscriptEvent as TranscriptEventInternal
+import com.xodee.client.audio.audioclient.transcript.Transcript as TranscriptInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptAlternative as TranscriptAlternativeInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptItem as TranscriptItemInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptItemType as TranscriptItemTypeInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptResult as TranscriptResultInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptionStatus as TranscriptionStatusInternal
+import com.xodee.client.audio.audioclient.transcript.TranscriptionStatusType as TranscriptionStatusTypeInternal
 import io.mockk.MockKAnnotations
 import io.mockk.coVerify
 import io.mockk.every
@@ -61,6 +78,9 @@ class DefaultAudioClientObserverTest {
     private lateinit var mockRealtimeObserver: RealtimeObserver
 
     @MockK
+    private lateinit var mockTranscriptEventObserver: TranscriptEventObserver
+
+    @MockK
     private lateinit var mockAudioClient: AudioClient
 
     @MockK
@@ -68,6 +88,9 @@ class DefaultAudioClientObserverTest {
 
     @MockK
     private lateinit var mockEventAnalyticsController: EventAnalyticsController
+
+    @MockK
+    private lateinit var mockTranscriptionStatusType: TranscriptionStatusTypeInternal
 
     private lateinit var audioClientObserver: DefaultAudioClientObserver
 
@@ -109,6 +132,10 @@ class DefaultAudioClientObserverTest {
     private val testDispatcher = TestCoroutineDispatcher()
 
     private val expectedAttendeeInfos: Array<AttendeeInfo> = arrayOf(testAttendeeInfo)
+
+    private val timestampMs = 1633040215L
+    private val transcriptionRegion = "us-east-1"
+    private val transcriptionConfiguration = "transcription-configuration"
 
     @Before
     fun setup() {
@@ -539,6 +566,222 @@ class DefaultAudioClientObserverTest {
         audioClientObserver.onVolumeStateChange(testInput)
 
         verify(exactly = 1) { mockRealtimeObserver.onVolumeChanged(expectedArgs) }
+    }
+
+    @Test
+    fun `onTranscriptEventsReceived should do nothing if transcript events is sent as null`() {
+        audioClientObserver.subscribeToTranscriptEvent(mockTranscriptEventObserver)
+
+        audioClientObserver.onTranscriptEventsReceived(null)
+
+        verify(exactly = 0) { mockTranscriptEventObserver.onTranscriptEventReceived(any()) }
+    }
+
+    @Test
+    fun `onTranscriptEventsReceived should send local Transcription Status with TranscriptionStatus events as input`() {
+        val successStatusMessage = "success-message"
+        val resumedStatusMessage = "resumed-message"
+
+        audioClientObserver.subscribeToTranscriptEvent(mockTranscriptEventObserver)
+
+        val transcriptionStatusStarted = TranscriptionStatusInternal(
+            TranscriptionStatusTypeInternal.TranscriptionStatusTypeStarted,
+            timestampMs,
+            transcriptionRegion,
+            transcriptionConfiguration,
+            successStatusMessage
+        )
+
+        val transcriptionStatusResumed = TranscriptionStatusInternal(
+            TranscriptionStatusTypeInternal.TranscriptionStatusTypeResumed,
+            timestampMs,
+            transcriptionRegion,
+            transcriptionConfiguration,
+            resumedStatusMessage
+        )
+
+        val expectedTranscriptionStatusStarted = TranscriptionStatus(
+            TranscriptionStatusType.TranscriptionStatusTypeStarted,
+            timestampMs,
+            transcriptionRegion,
+            transcriptionConfiguration,
+            successStatusMessage
+        )
+
+        val expectedTranscriptionStatusResume = TranscriptionStatus(
+            TranscriptionStatusType.TranscriptionStatusTypeResumed,
+            timestampMs,
+            transcriptionRegion,
+            transcriptionConfiguration,
+            resumedStatusMessage
+        )
+
+        val events : Array<TranscriptEventInternal> = arrayOf(transcriptionStatusStarted, transcriptionStatusResumed)
+
+        audioClientObserver.onTranscriptEventsReceived(events)
+
+        verify(exactly = 1) { mockTranscriptEventObserver.onTranscriptEventReceived(expectedTranscriptionStatusStarted) }
+        verify(exactly = 1) { mockTranscriptEventObserver.onTranscriptEventReceived(expectedTranscriptionStatusResume) }
+    }
+
+    @Test
+    fun `onTranscriptEventsReceived should send local Transcript with Transcript events as input`() {
+        audioClientObserver.subscribeToTranscriptEvent(mockTranscriptEventObserver)
+
+        val testResultId = "testResultId"
+        val testChannelId = "testChannelId"
+        val isPartial = true
+
+        val transcriptResultOne = TranscriptResultInternal(
+            testResultId,
+            testChannelId,
+            isPartial,
+            timestampMs,
+            timestampMs + 10L,
+            arrayOf(
+                TranscriptAlternativeInternal(
+                    arrayOf(
+                        TranscriptItemInternal(
+                            TranscriptItemTypeInternal.TranscriptItemTypePronunciation,
+                            timestampMs,
+                            timestampMs + 5L,
+                            AttendeeInfoInternal(testId1, testId1),
+                            "I",
+                            true
+                        ),
+                        TranscriptItemInternal(
+                            TranscriptItemTypeInternal.TranscriptItemTypePunctuation,
+                            timestampMs + 5L,
+                            timestampMs + 10L,
+                            AttendeeInfoInternal(testId2, testId2),
+                            "am",
+                            false
+                        )
+                    ),
+                    "I am"
+                )
+            )
+        )
+
+        val transcriptResultTwo = TranscriptResultInternal(
+            testResultId,
+            testChannelId,
+            isPartial,
+            timestampMs + 10L,
+            timestampMs + 20L,
+            arrayOf(
+                TranscriptAlternativeInternal(
+                    arrayOf(
+                        TranscriptItemInternal(
+                            TranscriptItemTypeInternal.TranscriptItemTypePunctuation,
+                            timestampMs + 10,
+                            timestampMs + 15L,
+                            AttendeeInfoInternal(testId2, testId2),
+                            "a",
+                            true
+                        ),
+                        TranscriptItemInternal(
+                            TranscriptItemTypeInternal.TranscriptItemTypePronunciation,
+                            timestampMs + 15L,
+                            timestampMs + 20L,
+                            AttendeeInfoInternal(testId1, testId1),
+                            "guardian",
+                            false
+                        )
+                    ),
+                    "a guardian"
+                )
+            )
+        )
+
+        val events : Array<TranscriptEventInternal> = arrayOf(
+            TranscriptInternal(arrayOf(transcriptResultOne)),
+            TranscriptInternal(arrayOf(transcriptResultTwo))
+        )
+
+        val expectedTranscriptOne = Transcript(
+            arrayListOf(
+                TranscriptResult(
+                    testResultId,
+                    testChannelId,
+                    isPartial,
+                    timestampMs,
+                    timestampMs + 10L,
+                    arrayListOf(
+                        TranscriptAlternative(
+                            arrayListOf(
+                                TranscriptItem(
+                                    TranscriptItemType.TranscriptItemTypePronunciation,
+                                    timestampMs,
+                                    timestampMs + 5L,
+                                    AttendeeInfo(testId1, testId1),
+                                    "I",
+                                    true
+                                ),
+                                TranscriptItem(
+                                    TranscriptItemType.TranscriptItemTypePunctuation,
+                                    timestampMs + 5L,
+                                    timestampMs + 10L,
+                                    AttendeeInfo(testId2, testId2),
+                                    "am",
+                                    false
+                                )
+                            ),
+                            "I am"
+                        )
+                    )
+                )
+            )
+        )
+
+        val expectedTranscriptTwo = Transcript(
+            arrayListOf(
+                TranscriptResult(
+                    testResultId,
+                    testChannelId,
+                    isPartial,
+                    timestampMs + 10L,
+                    timestampMs + 20L,
+                    arrayListOf(
+                        TranscriptAlternative(
+                            arrayListOf(
+                                TranscriptItem(
+                                    TranscriptItemType.TranscriptItemTypePunctuation,
+                                    timestampMs + 10L,
+                                    timestampMs + 15L,
+                                    AttendeeInfo(testId2, testId2),
+                                    "a",
+                                    true
+                                ),
+                                TranscriptItem(
+                                    TranscriptItemType.TranscriptItemTypePronunciation,
+                                    timestampMs + 15L,
+                                    timestampMs + 20L,
+                                    AttendeeInfo(testId1, testId1),
+                                    "guardian",
+                                    false
+                                )
+                            ),
+                            "a guardian"
+                        )
+                    )
+                )
+            )
+        )
+
+        audioClientObserver.onTranscriptEventsReceived(events)
+
+        verify(exactly = 1) { mockTranscriptEventObserver.onTranscriptEventReceived(expectedTranscriptOne) }
+        verify(exactly = 1) { mockTranscriptEventObserver.onTranscriptEventReceived(expectedTranscriptTwo) }
+    }
+
+    @Test
+    fun `onTranscriptEventsReceived should return if null transcript events is sent`() {
+        audioClientObserver.subscribeToTranscriptEvent(mockTranscriptEventObserver)
+
+        audioClientObserver.onTranscriptEventsReceived(null)
+
+        verify(exactly = 0) { mockTranscriptEventObserver.onTranscriptEventReceived(any()) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/realtime/DefaultRealtimeControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/realtime/DefaultRealtimeControllerTest.kt
@@ -32,6 +32,9 @@ class DefaultRealtimeControllerTest {
     private lateinit var mockDataMessageObserver: DataMessageObserver
 
     @MockK
+    private lateinit var mockTranscriptEventObserver: TranscriptEventObserver
+
+    @MockK
     private lateinit var audioClientObserver: AudioClientObserver
 
     @MockK
@@ -91,6 +94,18 @@ class DefaultRealtimeControllerTest {
     fun `removeRealtimeDataMessageObserverFromTopic should call videoClientObserver unsubscribeFromReceiveDataMessage with given topic`() {
         realtimeController.removeRealtimeDataMessageObserverFromTopic(messageTopic)
         verify { videoClientObserver.unsubscribeFromReceiveDataMessage(messageTopic) }
+    }
+
+    @Test
+    fun `addRealtimeTranscriptEventObserver should call audioClientObserver subscribeToTranscriptEvent with given observer`() {
+        realtimeController.addRealtimeTranscriptEventObserver(mockTranscriptEventObserver)
+        verify { audioClientObserver.subscribeToTranscriptEvent(mockTranscriptEventObserver) }
+    }
+
+    @Test
+    fun `removeRealtimeTranscriptEventObserver should call audioClientObserver unsubscribeFromTranscriptEvent with given observer`() {
+        realtimeController.removeRealtimeTranscriptEventObserver(mockTranscriptEventObserver)
+        verify { audioClientObserver.unsubscribeFromTranscriptEvent(mockTranscriptEventObserver) }
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:

- Chime-42058

### Description of changes:

- Add live transcription APIs and data models for Transcription
- Updated unit test cases for the functionality
- Control buttons to start/stop live transcription will be in a different PR
- Live transcription functionality in the meeting will be updated in demo app
- Required media framework changes merged (CR-57972429)


### Testing done:
- Manually tested live transcription in Android demo App using API and media changes. 
- Joined a meeting with Live Transcription enabled on JS App and Android App, which contained the ChimeTincan changes for the models
- Verified the Transcript data was sent to Android demo app by adding logs, parsing the TranscriptEvent messages


```
I/DefaultAudioClientObserver: TranscriptionStatus(type=TranscriptionStatusTypeStarted, eventTimeMs=1632996266265, transcriptionRegion=us-west-2, transcriptionConfiguration={"EngineTranscribeSettings":{"LanguageCode":"en-US","Region":"auto"}}, message=)

I/DefaultAudioClientObserver: Transcript(results=[TranscriptResult(resultId=a56adca6-b221-4259-b1ba-5ec4d2098c96, channelId=ch_0, isPartial=false, startTimeMs=1632996287718, endTimeMs=1632996288613, alternatives=[TranscriptAlternative(items=[TranscriptItem(type=TranscriptItemTypePronunciation, startTimeMs=1632996287718, endTimeMs=1632996287853, attendee=AttendeeInfo(attendeeId=65184b92-d286-09bb-dd5d-3dc2e4b23fe8, externalUserId=5675304a#ee), content=I, vocabularyFilterMatch=false), TranscriptItem(type=TranscriptItemTypePronunciation, startTimeMs=1632996287838, endTimeMs=1632996288613, attendee=AttendeeInfo(attendeeId=65184b92-d286-09bb-dd5d-3dc2e4b23fe8, externalUserId=5675304a#ee), content=repeat, vocabularyFilterMatch=false), TranscriptItem(type=TranscriptItemTypePunctuation, startTimeMs=1632996288613, endTimeMs=1632996288613, attendee=AttendeeInfo(attendeeId=65184b92-d286-09bb-dd5d-3dc2e4b23fe8, externalUserId=5675304a#ee), content=., vocabularyFilterMatch=false)], transcript=I repeat.)])])
```

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [X] See signal strength changes
* [X] See media metrics received
* [X] See roster updates when remote attendees join / leave the meeting
* [X] Enable local video
* [X] See local video tile
* [X] See remote video tile
* [X] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [X] First time audio permissions
* [X] First time video permissions



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
