### PR TITLE
Fix demo app crashes when leaving the meeting after screen share stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Fixed
+* [Demo] Fixed demo app crashes when screen share is off and then leave meeting.
+
+
 ## [0.13.0] - 2021-11-01
 
 ### Added

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/device/ScreenShareManager.kt
@@ -31,11 +31,11 @@ class ScreenShareManager(
 
     fun start() = screenCaptureSource.start()
 
-    fun stop() {
+    fun stop(isBound: Boolean = false) {
         context.stopService(Intent(context, ScreenCaptureService::class.java))
         screenCaptureSource.stop()
         screenCaptureConnectionService?.let {
-            context.unbindService(it)
+            if (isBound) context.unbindService(it)
         }
     }
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -153,6 +153,7 @@ class MeetingFragment : Fragment(),
     private val DATA_MESSAGE_LIFETIME_MS = 300000
 
     private var screenshareServiceConnection: ServiceConnection? = null
+    private var isBound: Boolean = false
 
     enum class SubTab(val position: Int) {
         Attendees(0),
@@ -901,7 +902,7 @@ class MeetingFragment : Fragment(),
     private fun toggleScreenCapture() {
         if (meetingModel.isSharingContent) {
             audioVideo.stopContentShare()
-            screenShareManager?.stop()
+            screenShareManager?.stop(isBound)
         } else {
             startActivityForResult(
                 mediaProjectionManager.createScreenCaptureIntent(),
@@ -1132,6 +1133,7 @@ class MeetingFragment : Fragment(),
                     resultCode,
                     data
                 )
+                isBound = true
 
                 val screenCaptureSourceObserver = object : CaptureSourceObserver {
                     override fun onCaptureStarted() {
@@ -1158,6 +1160,7 @@ class MeetingFragment : Fragment(),
             }
 
             override fun onServiceDisconnected(arg0: ComponentName) {
+                isBound = false
             }
         }
 
@@ -1561,7 +1564,7 @@ class MeetingFragment : Fragment(),
         // Turn off screen share when screen locked
         if (meetingModel.isSharingContent && !powerManager.isInteractive) {
             audioVideo.stopContentShare()
-            screenShareManager?.stop()
+            screenShareManager?.stop(isBound)
         }
     }
 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
After we unbind the service, we shouldn't unbind again. Adding checks to not unbind again.

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [X] Join meeting
* [X] Leave meeting
* [X] Rejoin meeting
* [X] Send audio
* [X] Receive audio
* [X] See active speaker indicator when speaking
* [X] Mute/Unmute self
* [X] See local mute indicator when muted
* [X] See remote mute indicator when other is muted
* [X] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
