### PR TITLE
Fix crash rgba preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixed
 * [Demo] Fixed demo app crashes when screen share is off and then leave meeting.
 
+### Changed
+* Updated compileSdkVersion and targetSdkVersion from 30 to 31.
+
 
 ## [0.13.0] - 2021-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ### Changed
 * Updated compileSdkVersion and targetSdkVersion from 30 to 31.
-
+* Changed the silence threshold to 0.2 from 0.0 for `DefaultActiveSpeakerPolicy` (Issue #259) to be more consistent with other platform.
+* Expose weights/rates/thresholds to `DefaultActiveSpeakerPolicy` constructor to make builders easier to customize `DefaultActiveSpeakerPolicy`.
 
 ## [0.13.0] - 2021-11-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * [Demo] Fixed demo app crashes when screen share is off and then leave meeting.
+* Fixed crash when video frames with VideoFrameRGBABuffer are passed directly to DefaultVideoRenderView in video preview use case.
 
 ### Changed
 * Updated compileSdkVersion and targetSdkVersion from 30 to 31.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
@@ -491,7 +491,7 @@ class DefaultGlVideoFrameDrawer() : GlVideoFrameDrawer {
             """
         precision mediump float;
         varying vec2 vTextureCoordinate;
-        uniform samplerExternalOES sTexture;
+        uniform sampler2D sTexture;
         void main() {
             gl_FragColor = texture2D(sTexture, vTextureCoordinate);
         }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".activity.SplashActivity">
+        <activity android:name=".activity.SplashActivity" android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,8 @@ allprojects {
     project.ext {
         chimeBuildToolsVersion = "29.0.2"
         chimeMinSdkVersion = 21
-        chimeTargetSdkVersion = 30
-        chimeCompileSdkVersion = 30
+        chimeTargetSdkVersion = 31
+        chimeCompileSdkVersion = 31
         sdkDir = localProperties.getProperty('sdk.dir')
         ndkDir = localProperties.getProperty('ndk.dir')
     }


### PR DESCRIPTION
### Issue #, if available:
#344 
### Description of changes:
Fix crash when rgba frames are passed directly into DefaultVideoRenderView for a local preview use case.
### Testing done:
Smoke tested
#### Unit test coverage
* Class coverage: 62%
* Line coverage: 56%

#### Manual test cases (add more as needed):
* [x ] Join meeting
* [x ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x ] Enable local video
* [x ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
