### PR TITLE
Fix crash when rgba frames sent to DefaultVideoRenderView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * [Demo] Fixed demo app crashes when screen share is off and then leave meeting.
+* Fixed crash when rgba video frames are sent to DefaultVideoRenderView directly in preview use case.
 
 ### Changed
 * Changed the silence threshold to 0.2 from 0.0 for `DefaultActiveSpeakerPolicy` (Issue #259) to be more consistent with other platform.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
@@ -491,7 +491,7 @@ class DefaultGlVideoFrameDrawer() : GlVideoFrameDrawer {
             """
         precision mediump float;
         varying vec2 vTextureCoordinate;
-        uniform samplerExternalOES sTexture;
+        uniform sampler2D sTexture;
         void main() {
             gl_FragColor = texture2D(sTexture, vTextureCoordinate);
         }


### PR DESCRIPTION
### Issue #, if available:
#344
### Description of changes:
Fix crash when rgba frames sent to DefaultVideoRenderView
### Testing done:
#### Unit test coverage
* Class coverage: 62
* Line coverage: 56

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
