### PR TITLE
Fixed out of order logging on `TextureRenderView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Fixed out of order logging on `TextureRenderView`
+
 ## [0.14.0] - 2021-12-21
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/TextureRenderView.kt
@@ -113,10 +113,10 @@ open class TextureRenderView @JvmOverloads constructor(
                 rotatedFrameHeight != frame.getRotatedHeight() ||
                 frameRotation != frame.rotation
         ) {
-            logger.info(TAG, "Video frame rotated size changed to ${rotatedFrameWidth}x$rotatedFrameHeight")
             rotatedFrameWidth = frame.getRotatedWidth()
             rotatedFrameHeight = frame.getRotatedHeight()
             frameRotation = frame.rotation
+            logger.info(TAG, "Video frame rotated size changed to ${rotatedFrameWidth}x$rotatedFrameHeight")
 
             CoroutineScope(Dispatchers.Main).launch {
                 requestLayout()


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
We should log after we assign changes.

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
