### PR TITLE
Maven support

### DIFF
--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+apply from: rootProject.file('publishing.gradle')
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,25 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+GROUP=software.aws.chimesdk
+ARTIFACT_ID_SDK=amazon-chime-sdk
+ARTIFACT_ID_SDK_MEDIA=amazon-chime-sdk-media
+POM_SDK_NAME=Amazon Chime SDK
+POM_SDK_MEDIA_NAME=Amazon Chime SDK Media
+
+POM_URL=https://github.com/aws/amazon-chime-sdk-android
+POM_SCM_URL=https://github.com/aws/amazon-chime-sdk-android
+POM_SCM_CONNECTION=scm:git:git://github.com/aws/amazon-chime-sdk-android.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/aws/amazon-chime-sdk-android.git
+        
+POM_LICENCE_NAME=Apache License 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+
+POM_DEVELOPER_ID=amazonwebservices
+POM_DEVELOPER_ORGANIZATION=Amazon Web Services
+POM_DEVELOPER_ORGANIZATION_URL=http://aws.amazon.com
+
+POM_DESCRIPTION_SDK=Amazon Chime Android SDK
+POM_DESCRIPTION_SDK_MEDIA=Amazon Chime Android SDK Media

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -1,0 +1,131 @@
+apply plugin: 'maven'
+apply plugin: 'signing'
+apply plugin: 'maven-publish'
+
+def localPropertiesFile = new File(getRootDir(), "local.properties")
+Properties localProperties = new Properties()
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withInputStream { instr ->
+        localProperties.load(instr)
+    }
+}
+
+def versionFile = new File(getRootDir(),  "version.properties")
+Properties versionProperties = new Properties()
+if (versionFile.exists()) {
+    versionFile.withInputStream { instr ->
+        versionProperties.load(instr)
+    }
+}
+version = versionProperties.getProperty('VERSION')
+
+task createZip(type: Zip) {
+    from("$rootDir") {
+        include "NOTICE.txt", "LICENSE.txt", "THIRD-PARTY.txt"
+    }
+    archiveFileName = "LICENSE.zip"
+    destinationDirectory = file("$rootDir/amazon-chime-sdk")
+}
+
+signing {
+    if (!project.hasProperty('signing.key') || !project.hasProperty('signing.password') || !project.hasProperty('signing.keyId')) {
+        logger.error('Missing GPG Signing Properties.')
+    }
+    def signingKey = findProperty("signing.key")
+    def signingPassword = findProperty("signing.password")
+    def keyId = findProperty("signing.keyId")
+    useInMemoryPgpKeys(keyId, signingKey, signingPassword)
+
+    sign(publishing.publications)
+}
+
+project.afterEvaluate {
+    publishing {
+        publications {
+            publishChimeSDK(MavenPublication) {
+                afterEvaluate {
+                    from components.release
+                }
+                groupId = GROUP
+                version = version
+                artifactId = ARTIFACT_ID_SDK
+                artifact ("$rootDir/amazon-chime-sdk/LICENSE.zip") {
+                    builtBy createZip
+                }
+
+                pom {
+                    name = POM_SDK_NAME
+                    description = POM_DESCRIPTION_SDK
+                    url = POM_URL
+                    licenses {
+                        license {
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
+                        }
+                    }
+                    scm {
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                    }
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            organization = POM_DEVELOPER_ORGANIZATION
+                            organizationUrl = POM_DEVELOPER_ORGANIZATION_URL
+                        }
+                    }
+                }
+            }
+            publishChimeSDKMedia(MavenPublication) {
+                groupId = GROUP
+                version = version
+                artifactId = ARTIFACT_ID_SDK_MEDIA
+                artifact("$buildDir/../libs/amazon-chime-sdk-media.aar")
+                artifact ("$rootDir/amazon-chime-sdk/LICENSE.zip") {
+                    builtBy createZip
+                }
+
+                pom {
+                    name = POM_SDK_MEDIA_NAME
+                    description = POM_DESCRIPTION_SDK_MEDIA
+                    url = POM_URL
+                    licenses {
+                        license {
+                            name = POM_LICENCE_NAME
+                            url = POM_LICENCE_URL
+                            distribution = POM_LICENCE_DIST
+                        }
+                    }
+                    scm {
+                        url = POM_SCM_URL
+                        connection = POM_SCM_CONNECTION
+                        developerConnection = POM_SCM_DEV_CONNECTION
+                    }
+                    developers {
+                        developer {
+                            id = POM_DEVELOPER_ID
+                            organization = POM_DEVELOPER_ORGANIZATION
+                            organizationUrl = POM_DEVELOPER_ORGANIZATION_URL
+                        }
+                    }
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                def releasesRepoUrl = "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/"
+                def snapshotsRepoUrl = "https://aws.oss.sonatype.org/content/repositories/snapshots/"
+                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+                credentials {
+                    username = localProperties.getProperty('SONATYPE_USERNAME')
+                    password = localProperties.getProperty('SONATYPE_PASSWORD')
+                }
+            }
+        }
+    }
+}
+
+


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/52
### Description of changes:
Develop Maven Support for Chime Android SDK.

####  publishing.gradle:
It allows to publish build artifacts to the Maven repository. There are 2 publications: publishChimeSDK and publishChimeSDKMedia, which will separately publish amazon-chime-sdk and amazon-chime-sdk-media.

####  gradle.properties:
Store variables.

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
