### PR TITLE
Fix Jenkins automation build failure by overriding new methods in the interface VideoClientDelegate

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
@@ -18,6 +18,7 @@ import com.amazonaws.services.chime.sdk.meetings.internal.video.TURNRequestParam
 import com.amazonaws.services.chime.sdk.meetings.session.URLRewriter
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.video.RemoteVideoSource
 import com.xodee.client.video.VideoClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -165,5 +166,11 @@ class DefaultContentShareVideoClientObserver(
 
     override fun onTurnURIsReceived(uris: List<String>): List<String> {
         return uris.map(urlRewriter)
+    }
+
+    override fun onRemoteVideoSourceAvailable(sources: Array<RemoteVideoSource>?) {
+    }
+
+    override fun onRemoteVideoSourceUnavailable(sources: Array<RemoteVideoSource>?) {
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -26,6 +26,7 @@ import com.amazonaws.services.chime.sdk.meetings.session.URLRewriter
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
 import com.xodee.client.video.DataMessage as mediaDataMessage
+import com.xodee.client.video.RemoteVideoSource
 import com.xodee.client.video.VideoClient
 import com.xodee.client.video.VideoClient.VIDEO_CLIENT_NO_PAUSE
 import com.xodee.client.video.VideoClient.VIDEO_CLIENT_REMOTE_PAUSED_BY_LOCAL_BAD_NETWORK
@@ -173,6 +174,12 @@ class DefaultVideoClientObserver(
         val metricMap = mutableMapOf<Int, Double>()
         (metrics.indices).map { i -> metricMap[metrics[i]] = values[i] }
         clientMetricsCollector.processVideoClientMetrics(metricMap)
+    }
+
+    override fun onRemoteVideoSourceAvailable(sources: Array<RemoteVideoSource>?) {
+    }
+
+    override fun onRemoteVideoSourceUnavailable(sources: Array<RemoteVideoSource>?) {
     }
 
     override fun onLogMessage(logLevel: Int, message: String?) {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
New methods are introduced in the interface `VideoClientDelegate` in media SDK.
Override functions in `DefaultVideoClientObserver` and `DefaultContentShareVideoClientObserver` which both implement `VideoClientDelegate`.

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
