### PR TITLE
Fixed calling start multiple times without stop crashes video in some…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@
 * Added the meetingStartDurationMs event in ingestionEvents to record the time that elapsed between the start request and the beginning of the meeting.
 * Added priority based downlink policy to control the way how a recipient subscribes to the remote video sources
 
+### Fixed
+* Fixed calling start multiple times without stop crashes video in some phones. (Issue #356)
+
 ## [0.14.3] - 2022-02-10
 
 ## [0.14.2] - 2022-01-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Added
 * Added `audioStreamType` in `AudioVideoConfiguration` for supporting audio stream configuration.
 
+### Fixed
+* Fixed calling start multiple times without stop crashes video in some phones. (Issue #356)
+
 ## [0.15.4] - 2022-04-21
 
 ## [0.15.3] - 2022-04-07
@@ -33,9 +36,6 @@
 ### Added
 * Added the meetingStartDurationMs event in ingestionEvents to record the time that elapsed between the start request and the beginning of the meeting.
 * Added priority based downlink policy to control the way how a recipient subscribes to the remote video sources
-
-### Fixed
-* Fixed calling start multiple times without stop crashes video in some phones. (Issue #356)
 
 ## [0.14.3] - 2022-02-10
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -195,7 +195,7 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
             handleCameraCaptureFail(CaptureSourceError.PermissionError)
             throw SecurityException("Missing necessary camera permissions")
         }
-
+        stop()
         logger.info(TAG, "Camera capture start requested with device: $device")
         val device = device ?: run {
             logger.info(TAG, "Cannot start camera capture with null device")


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/356
### Description of changes:
call stop before start in order to prevent multiple start is done

### Testing done:
Tested on Xiaomi Mi MIX 2 by calling start multiple times. No crash observed.

#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [X] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [X] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
