### PR TITLE
update dependency to software.aws.chimesdk:amazon-chime-sdk-media

### DIFF
--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'
     implementation 'androidx.core:core-ktx:1.2.0'
-    api(name: 'amazon-chime-sdk-media', ext: 'aar') { transitive = true }
+    implementation 'software.aws.chimesdk:amazon-chime-sdk-media:0.14.2'
     implementation 'com.google.code.gson:gson:2.8.6'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.3'
     testImplementation 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation project(path: ':amazon-chime-sdk')
+    implementation 'software.aws.chimesdk:amazon-chime-sdk-media:0.14.2'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.3'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.3'


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Testing done:
Run demo app dependent on 'software.aws.chimesdk:amazon-chime-sdk-media:0.14.2' instead of local amazon-chime-sdk-media.aar.
Sanity Test done.
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
