### PR TITLE
add meetingStartDurationMs event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-###Fixed
-* Fixed Mobile SDK metrics missing issue by adding meetingStartDurationMs event
+###Added
+* Added the meetingStartDurationMs event in ingestionEvents to record the time that elapsed between the start request and the beginning of the meeting.
 
 ## [0.14.2] - 2022-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+###Fixed
+* Fixed Mobile SDK metrics missing issue by adding meetingStartDurationMs event
+
 ## [0.14.2] - 2022-01-27
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
@@ -58,7 +58,7 @@ class DefaultMeetingStatsCollector(
             EventAttributeName.retryCount to retryCount,
             EventAttributeName.poorConnectionCount to poorConnectionCount,
             EventAttributeName.meetingDurationMs to if (meetingStartTimeMs == 0L) 0L else Calendar.getInstance().timeInMillis - meetingStartTimeMs,
-            EventAttributeName.meetingStartDurationMs to if (meetingStartConnectingTimeMs == 0L) 0L else meetingStartTimeMs - meetingStartConnectingTimeMs
+            EventAttributeName.meetingStartDurationMs to if (meetingStartTimeMs == 0L) 0L else meetingStartTimeMs - meetingStartConnectingTimeMs
         )
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultMeetingStatsCollector.kt
@@ -11,6 +11,8 @@ import java.util.Calendar
 class DefaultMeetingStatsCollector(
     private val logger: Logger
 ) : MeetingStatsCollector {
+    // The time that the meeting is requested to be started
+    private var meetingStartConnectingTimeMs: Long = 0L
     // The time meeting has started
     private var meetingStartTimeMs: Long = 0L
     // The number of attempts to reconnect to the meeting
@@ -34,11 +36,16 @@ class DefaultMeetingStatsCollector(
         maxVideoTileCount = videoTileCount.coerceAtLeast(maxVideoTileCount)
     }
 
+    override fun updateMeetingStartConnectingTimeMs() {
+        meetingStartConnectingTimeMs = Calendar.getInstance().timeInMillis
+    }
+
     override fun updateMeetingStartTimeMs() {
         meetingStartTimeMs = Calendar.getInstance().timeInMillis
     }
 
     override fun resetMeetingStats() {
+        meetingStartConnectingTimeMs = 0L
         meetingStartTimeMs = 0L
         retryCount = 0
         poorConnectionCount = 0
@@ -50,7 +57,8 @@ class DefaultMeetingStatsCollector(
             EventAttributeName.maxVideoTileCount to maxVideoTileCount,
             EventAttributeName.retryCount to retryCount,
             EventAttributeName.poorConnectionCount to poorConnectionCount,
-            EventAttributeName.meetingDurationMs to if (meetingStartTimeMs == 0L) 0L else Calendar.getInstance().timeInMillis - meetingStartTimeMs
+            EventAttributeName.meetingDurationMs to if (meetingStartTimeMs == 0L) 0L else Calendar.getInstance().timeInMillis - meetingStartTimeMs,
+            EventAttributeName.meetingStartDurationMs to if (meetingStartConnectingTimeMs == 0L) 0L else meetingStartTimeMs - meetingStartConnectingTimeMs
         )
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
@@ -84,6 +84,11 @@ enum class EventAttributeName {
     maxVideoTileCount,
 
     /**
+     * Duration of the meeting starting process
+     */
+    meetingStartDurationMs,
+
+    /**
      * Duration of the meeting
      */
     meetingDurationMs,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingStatsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/MeetingStatsCollector.kt
@@ -29,6 +29,11 @@ interface MeetingStatsCollector {
     fun updateMeetingStartTimeMs()
 
     /**
+     * Update meeting start request time.
+     */
+    fun updateMeetingStartConnectingTimeMs()
+
+    /**
      * Clear meeting stats.
      */
     fun resetMeetingStats()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
@@ -82,7 +82,7 @@ class DefaultMeetingEventBuffer @JvmOverloads constructor(
             }
 
             val eventRecord =
-                IngestionEventConverter.fromMeetingEventItems(eventItems)
+                IngestionEventConverter.fromMeetingEventItems(eventItems, ingestionConfiguration)
 
             val idsToRemove = eventItems.map { it.id }.toList()
 
@@ -142,7 +142,7 @@ class DefaultMeetingEventBuffer @JvmOverloads constructor(
             var dirtyEvents =
                 dirtyEventDao.listDirtyMeetingEventItems(ingestionConfiguration.flushSize)
             var ingestionRecord =
-                IngestionEventConverter.fromDirtyMeetingEventItems(dirtyEvents)
+                IngestionEventConverter.fromDirtyMeetingEventItems(dirtyEvents, ingestionConfiguration)
 
             var isSentSuccessful = true
             try {
@@ -161,7 +161,7 @@ class DefaultMeetingEventBuffer @JvmOverloads constructor(
                     )
                     ingestionRecord =
                         IngestionEventConverter.fromDirtyMeetingEventItems(
-                            dirtyEvents
+                            dirtyEvents, ingestionConfiguration
                         )
                 }
             } catch (exception: Exception) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -150,6 +150,7 @@ class DefaultAudioClientController(
             DEFAULT_PORT
         }
         setUpAudioConfiguration(audioMode)
+        meetingStatsCollector.updateMeetingStartConnectingTimeMs()
         eventAnalyticsController.publishEvent(EventName.meetingStartRequested)
         audioClientObserver.notifyAudioClientObserver { observer ->
             observer.onAudioSessionStartedConnecting(

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -13,7 +13,6 @@ import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionEvent
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionMetadata
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionPayload
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionRecord
-import com.amazonaws.services.chime.sdk.meetings.ingestion.MeetingEventClientConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
 
 object IngestionEventConverter {
@@ -66,17 +65,7 @@ object IngestionEventConverter {
                 })
         }
 
-        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
-        when (ingestionConfiguration.clientConfiguration) {
-            is MeetingEventClientConfiguration -> {
-                rootMetadata.putAll(
-                    mutableMapOf(
-                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
-                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
-                    )
-                )
-            }
-        }
+        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes(ingestionConfiguration)
 
         return IngestionRecord(rootMetadata, ingestionEvents)
     }
@@ -120,17 +109,7 @@ object IngestionEventConverter {
                 })
         }
 
-        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
-        when (ingestionConfiguration.clientConfiguration) {
-            is MeetingEventClientConfiguration -> {
-                rootMetadata.putAll(
-                    mutableMapOf(
-                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
-                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
-                    )
-                )
-            }
-        }
+        val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes(ingestionConfiguration)
         return IngestionRecord(rootMetadata, ingestionEvents)
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -7,11 +7,11 @@ package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
 
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionEvent
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionMetadata
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionPayload
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionRecord
-import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
 
 object IngestionEventConverter {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -7,11 +7,11 @@ package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
 
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
-import com.amazonaws.services.chime.sdk.meetings.ingestion.EventClientType
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionEvent
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionMetadata
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionPayload
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionRecord
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
 
 object IngestionEventConverter {
@@ -25,7 +25,7 @@ object IngestionEventConverter {
     private val eventMetadataAttributeNames =
         listOf(EventAttributeName.meetingId, EventAttributeName.attendeeId)
 
-    fun fromDirtyMeetingEventItems(items: List<DirtyMeetingEventItem>): IngestionRecord {
+    fun fromDirtyMeetingEventItems(items: List<DirtyMeetingEventItem>, ingestionConfiguration: IngestionConfiguration): IngestionRecord {
         if (items.isEmpty()) {
             return IngestionRecord(mutableMapOf(), listOf())
         }
@@ -65,12 +65,22 @@ object IngestionEventConverter {
         }
 
         val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
+        when (ingestionConfiguration.clientConfiguration) {
+            is MeetingEventClientConfiguration -> {
+                rootMetadata.putAll(
+                    mutableMapOf(
+                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
+                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
+                    )
+                )
+            }
+        }
 
         return IngestionRecord(rootMetadata, ingestionEvents)
     }
 
     // Need to have different name due to Kotlin name collision on List
-    fun fromMeetingEventItems(items: List<MeetingEventItem>): IngestionRecord {
+    fun fromMeetingEventItems(items: List<MeetingEventItem>, ingestionConfiguration: IngestionConfiguration): IngestionRecord {
         if (items.isEmpty()) {
             return IngestionRecord(mutableMapOf(), listOf())
         }
@@ -109,7 +119,16 @@ object IngestionEventConverter {
         }
 
         val rootMetadata: IngestionMetadata = EventAttributesUtils.getCommonAttributes()
-
+        when (ingestionConfiguration.clientConfiguration) {
+            is MeetingEventClientConfiguration -> {
+                rootMetadata.putAll(
+                    mutableMapOf(
+                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
+                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
+                    )
+                )
+            }
+        }
         return IngestionRecord(rootMetadata, ingestionEvents)
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -7,11 +7,13 @@ package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
 
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.ingestion.EventClientType
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionEvent
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionMetadata
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionPayload
 import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionRecord
+import com.amazonaws.services.chime.sdk.meetings.ingestion.MeetingEventClientConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
 
 object IngestionEventConverter {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/EventAttributesUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/EventAttributesUtils.kt
@@ -7,9 +7,28 @@ package com.amazonaws.services.chime.sdk.meetings.internal.utils
 
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.ingestion.IngestionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.ingestion.MeetingEventClientConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 
 object EventAttributesUtils {
+    fun getCommonAttributes(ingestionConfiguration: IngestionConfiguration): EventAttributes {
+        val attributes = getCommonAttributes()
+
+        when (ingestionConfiguration.clientConfiguration) {
+            is MeetingEventClientConfiguration -> {
+                attributes.putAll(
+                    mutableMapOf(
+                        EventAttributeName.meetingId to ingestionConfiguration.clientConfiguration.meetingId,
+                        EventAttributeName.attendeeId to ingestionConfiguration.clientConfiguration.attendeeId
+                    )
+                )
+            }
+        }
+
+        return attributes
+    }
+
     fun getCommonAttributes(meetingSessionConfiguration: MeetingSessionConfiguration): EventAttributes {
         val attributes = getCommonAttributes()
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBufferTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBufferTests.kt
@@ -107,7 +107,7 @@ class DefaultMeetingEventBufferTests {
         val ttl = 100L
         coEvery { eventSender.sendRecord(any()) } returns false
         every { calendar.timeInMillis } returns 101L
-        every { IngestionEventConverter.fromDirtyMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromDirtyMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
         every { dirtyEventDao.listDirtyMeetingEventItems(any()) } returns listOf(
@@ -139,7 +139,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `add should send immediately if it is meeting failed`() {
         coEvery { eventSender.sendRecord(any()) } returns true
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
 
@@ -159,7 +159,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `add should not send immediately if it is not meeting failed`() {
         coEvery { eventSender.sendRecord(any()) } returns true
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
 
@@ -189,7 +189,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `process should invoke eventSender sendRecord when there is stored events`() {
         every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
         coEvery { eventSender.sendRecord(any()) } returns true
@@ -206,7 +206,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `process should remove processed ids when sent succeeded`() {
         every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
         coEvery { eventSender.sendRecord(any()) } returns true
@@ -221,7 +221,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `process should remove processed ids when sent failed`() {
         every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
         coEvery { eventSender.sendRecord(any()) } returns false
@@ -236,7 +236,7 @@ class DefaultMeetingEventBufferTests {
     @Test
     fun `process should insert events as dirtyEvents when failed to send`() {
         every { eventDao.listMeetingEventItems(any()) } returns listOf(meetingEventItem)
-        every { IngestionEventConverter.fromMeetingEventItems(any()) }.returns(
+        every { IngestionEventConverter.fromMeetingEventItems(any(), any()) }.returns(
             ingestionRecord
         )
         coEvery { eventSender.sendRecord(any()) } returns false


### PR DESCRIPTION
### Issue #, if available:
https://issues.amazon.com/issues/Chime-41485
### Description of changes:
Just like JS SDK we need an event meetingStartDurationMs - the time that elapsed between the start request audioVideo.start and the beginning of the meeting AudioVideoObserver.audioVideoDidStart.

*Add an attribute `meetingStartDurationMs` in Payload.
*Include `meetingId` and `attendeeId` in the top level metadata, which could enable the metrics.
*Update test.

### Testing done:
Sanity Test done.
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
