### PR TITLE
Fix for Mobile Sdk gamma canary failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-## Unreleased
+## [Unreleased]
 
 ### Fixed
 * Catch and ignore the exception from rendering one video frame and move on to the next. This helps workaround a openGL error on some Android 12 devices at initial rendering phase.
+
+### Added
+* [Demo] Added overridden endpoint url capability to live transcription API.
 
 ## [0.15.0] - 2022-02-24
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -67,6 +67,7 @@ class HomeActivity : AppCompatActivity() {
         const val MEETING_RESPONSE_KEY = "MEETING_RESPONSE"
         const val MEETING_ID_KEY = "MEETING_ID"
         const val NAME_KEY = "NAME"
+        const val MEETING_ENDPOINT_KEY = "MEETING_ENDPOINT_URL"
         const val AUDIO_MODE_KEY = "AUDIO_MODE"
     }
 
@@ -176,6 +177,7 @@ class HomeActivity : AppCompatActivity() {
                                 MEETING_RESPONSE_KEY to meetingResponseJson,
                                 MEETING_ID_KEY to meetingId,
                                 NAME_KEY to attendeeName,
+                                MEETING_ENDPOINT_KEY to meetingUrl,
                                 AUDIO_MODE_KEY to audioVideoConfig.audioMode.value
                             )
                         )

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -45,6 +45,7 @@ class MeetingActivity : AppCompatActivity(),
     private lateinit var meetingId: String
     private lateinit var name: String
     private lateinit var audioVideoConfig: AudioVideoConfiguration
+    private lateinit var meetingEndpointUrl: String
 
     private var cachedDevice: MediaDevice? = null
 
@@ -59,6 +60,7 @@ class MeetingActivity : AppCompatActivity(),
             AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
         } ?: AudioMode.Stereo48K
         audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode)
+        meetingEndpointUrl = intent.extras?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String
 
         if (savedInstanceState == null) {
             val meetingResponseJson =
@@ -107,7 +109,7 @@ class MeetingActivity : AppCompatActivity(),
     }
 
     override fun onJoinMeetingClicked() {
-        val rosterViewFragment = MeetingFragment.newInstance(meetingId, audioVideoConfig)
+        val rosterViewFragment = MeetingFragment.newInstance(meetingId, audioVideoConfig, meetingEndpointUrl)
         supportFragmentManager
             .beginTransaction()
             .replace(R.id.root_layout, rosterViewFragment, "rosterViewFragment")

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/TranscriptionConfigActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/TranscriptionConfigActivity.kt
@@ -35,11 +35,13 @@ class TranscriptionConfigActivity : AppCompatActivity(),
 
     private val TAG = "TranscriptionConfigActivity"
 
+    private lateinit var meetingEndpointUrl: String
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_transcription_config)
         meetingId = intent.getStringExtra(HomeActivity.MEETING_ID_KEY) as String
-
+        meetingEndpointUrl = intent.getStringExtra(HomeActivity.MEETING_ENDPOINT_KEY) as String
         if (savedInstanceState == null) {
             val transcriptionConfigFragment = TranscriptionConfigFragment.newInstance(meetingId)
             supportFragmentManager
@@ -83,7 +85,7 @@ class TranscriptionConfigActivity : AppCompatActivity(),
         transcriptionLanguage: String?,
         transcriptionRegion: String?
     ): String? {
-        val meetingUrl = if (getString(R.string.test_url).endsWith("/")) getString(R.string.test_url) else "${getString(R.string.test_url)}/"
+        val meetingUrl = if (meetingEndpointUrl.endsWith("/")) meetingEndpointUrl else meetingEndpointUrl.plus("/")
         val url = "${meetingUrl}start_transcription?title=${encodeURLParam(meetingId)}" +
                 "&language=${encodeURLParam(transcriptionLanguage)}" +
                 "&region=${encodeURLParam(transcriptionRegion)}" +


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Mobile SDK Gamma Canary were failing with 100% failure rate in saucelabs. The issue was in the demo app not handling the scenario when meeting endpoint url is overridden. This change adds the logic to consider the url's based on whether it is overridden or not in the demo app.
### Testing done:
Yes. The demo app was tested in local using physical device.
Test Case 1: With overridden endpoint
Join a meeting by overriding meeting endpoint url.
Enable Live Transcription.
Captions are showing transcriptions message.
Stop Live Transcription.
Live Transcription is stopped successfully.

Test Case 2: Without overriding endpoint URL.
Add test_url in strings.xml file
Join meeting
Start Live Transcriptions
Captions are showing transcripted statements
Stop Live Transcription.
#### Unit test coverage
* Class coverage: na
* Line coverage: na

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
