### PR TITLE
Workaround android 12 openGL crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Catch and ignore the exception from rendering one video frame and move on to the next. This helps workaround a openGL error on some Android 12 devices at initial rendering phase.
+
 ## [0.15.0] - 2022-02-24
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -151,6 +151,10 @@ class DefaultVideoTileController(
         logger.info(TAG, "Binding VideoView to Tile with tileId = $tileId")
 
         renderViewToBoundVideoTileMap[videoView]?.let {
+            if (it.state.tileId == tileId) {
+                logger.info(TAG, "Already binding with the tile Id $tileId, ignore...")
+                return
+            }
             logger.warn(TAG, "Override the binding from ${it.state.tileId} to $tileId")
             removeRenderViewFromBoundVideoTileMap(it.state.tileId)
         }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -223,9 +223,13 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
                 EGL14.EGL_HEIGHT, heightArray, 0
         )
 
-        // Draw frame and swap buffers, which will make it visible
-        frameDrawer.drawFrame(frame, 0, 0, widthArray[0], heightArray[0], drawMatrix)
-        EGL14.eglSwapBuffers(eglCore?.eglDisplay, eglCore?.eglSurface)
+        try {
+            // Draw frame and swap buffers, which will make it visible
+            frameDrawer.drawFrame(frame, 0, 0, widthArray[0], heightArray[0], drawMatrix)
+            EGL14.eglSwapBuffers(eglCore?.eglDisplay, eglCore?.eglSurface)
+        } catch (e: Throwable) {
+            logger.verbose(TAG, "Failed to draw frame, ignore...")
+        }
 
         frame.release()
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileControllerTest.kt
@@ -528,6 +528,24 @@ class DefaultVideoTileControllerTest {
     }
 
     @Test
+    fun `bind should not rebind the view when already bound with the same tile`() {
+        runBlockingTest {
+            videoTileController.onReceiveFrame(
+                mockVideoFrame,
+                tileId,
+                attendeeId,
+                VideoPauseState.Unpaused
+            )
+        }
+
+        videoTileController.bindVideoView(mockVideoRenderView, tileId)
+        videoTileController.bindVideoView(mockVideoRenderView, tileId)
+
+        verify(exactly = 1) { mockVideoTile.bind(any()) }
+        verify(exactly = 0) { mockVideoTile.unbind() }
+    }
+
+    @Test
     fun `bind should NOT call unbind on the first view when not bound`() {
         val mockVideoTile2: VideoTile = mockk(relaxUnitFun = true)
         val mockVideoRenderView2: VideoRenderView = mockk(relaxUnitFun = true)


### PR DESCRIPTION
### Issue #, if available:
Chime-45065

### Description of changes:
1. Make rebind same tile to the same view as no-opt
2. Catch and ignore the exception when rendering one video frame, move on to handle the next one. This is because some Android 12 device has temporary error with openGL API

### Testing done:
* Private drop has been verified working with reported builder.
* Sanity test on both Android 12 and non Android 12 devices.

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [ ] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
