### PR TITLE
Nodev

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -23,7 +23,9 @@ enum class AudioMode(val value: Int) {
      * The stereo audio mode with two audio channels for speaker, and single audio channel for microphone,
      * both with 48KHz sampling rate.
      */
-    Stereo48K(3);
+    Stereo48K(3),
+
+    NoDevice(4);
 
     companion object {
         fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -63,6 +63,7 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> 16000
             AudioMode.Mono48K -> 48000
             AudioMode.Stereo48K -> 48000
+            AudioMode.NoDevice -> 16000
         }
         audioClient.sendMessage(
             AudioClient.MESS_SET_IO_SAMPLE_RATE,
@@ -74,6 +75,7 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Mono48K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Stereo48K -> AudioFormat.CHANNEL_OUT_STEREO
+            AudioMode.NoDevice -> AudioFormat.CHANNEL_OUT_MONO
         }
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
@@ -166,6 +168,7 @@ class DefaultAudioClientController(
                 AudioMode.Mono16K -> AudioModeInternal.MONO_16K
                 AudioMode.Mono48K -> AudioModeInternal.MONO_48K
                 AudioMode.Stereo48K -> AudioModeInternal.STEREO_48K
+                AudioMode.NoDevice -> AudioModeInternal.NO_DEVICE
             }
             val res = audioClient.startSessionV2(
                 AudioClient.XTL_DEFAULT_TRANSPORT,

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -140,6 +140,22 @@ class DefaultAudioVideoControllerTest {
     }
 
     @Test
+    fun `start with no_device should call audioClientController start with the parameters in configuration and no device`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.NoDevice)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                audioFallbackURL,
+                audioHostURL,
+                meetingId,
+                attendeeId,
+                joinToken,
+                AudioMode.NoDevice
+            )
+        }
+    }
+
+    @Test
     fun `start should call videoClientController start with the parameters in configuration`() {
         audioVideoController.start()
         verify {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
@@ -9,6 +9,7 @@ class AudioModeTest {
         Assert.assertEquals(AudioMode.from(1), AudioMode.Mono16K)
         Assert.assertEquals(AudioMode.from(2), AudioMode.Mono48K)
         Assert.assertEquals(AudioMode.from(3), AudioMode.Stereo48K)
+        Assert.assertEquals(AudioMode.from(4), AudioMode.NoDevice)
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:
V517073723
Add NoDevice support for Android.

### Description of changes:

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
