### PR TITLE
Skip permission check if AudioMode is NoDevice

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -15,6 +15,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsObserver
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEvent
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerpolicy.ActiveSpeakerPolicy
@@ -57,23 +58,23 @@ class DefaultAudioVideoFacade(
     }
 
     override fun start(audioVideoConfiguration: AudioVideoConfiguration) {
-        val hasPermission: Boolean = permissions.all {
-            ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+        if (audioVideoConfiguration.audioMode != AudioMode.NoDevice) {
+            val hasPermission: Boolean = permissions.all {
+                ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED
+            }
+            if (!hasPermission) {
+                throw SecurityException(
+                    "Missing necessary permissions for WebRTC: ${
+                        permissions.joinToString(
+                            separator = ", ",
+                            prefix = "",
+                            postfix = ""
+                        )
+                    }"
+                )
+            }
         }
-
-        if (hasPermission) {
-            audioVideoController.start(audioVideoConfiguration)
-        } else {
-            throw SecurityException(
-                "Missing necessary permissions for WebRTC: ${
-                    permissions.joinToString(
-                        separator = ", ",
-                        prefix = "",
-                        postfix = ""
-                    )
-                }"
-            )
-        }
+        audioVideoController.start(audioVideoConfiguration)
     }
 
     override fun addAudioVideoObserver(observer: AudioVideoObserver) {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import androidx.core.content.ContextCompat
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerDetectorFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
@@ -103,10 +104,17 @@ class DefaultAudioVideoFacadeTest {
     fun setup() = MockKAnnotations.init(this, relaxUnitFun = true)
 
     @Test(expected = SecurityException::class)
-    fun `start should throw exception when the required permissions are not granted`() {
+    fun `start should throw exception when the required permissions are not granted with default AudioMode`() {
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns 1
         audioVideoFacade.start()
+    }
+
+    @Test
+    fun `start should not check permissions if AudioMode is NoDevice`() {
+        mockkStatic(ContextCompat::class)
+        audioVideoFacade.start(AudioVideoConfiguration(audioMode = AudioMode.NoDevice))
+        verify(exactly = 0) { ContextCompat.checkSelfPermission(any(), any()) }
     }
 
     @Test


### PR DESCRIPTION
### Issue #, if available:
- Chime-48007

### Description of changes:

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
