### PR TITLE
Fix primary join using inputed URL

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -153,7 +153,6 @@ class MeetingFragment : Fragment(),
     private lateinit var gpuVideoProcessor: GpuVideoProcessor
     private lateinit var cpuVideoProcessor: CpuVideoProcessor
     private lateinit var eglCoreFactory: EglCoreFactory
-    private lateinit var demoUrl: String
     private lateinit var listener: RosterViewEventListener
     private lateinit var postLogger: PostLogger
 
@@ -261,12 +260,12 @@ class MeetingFragment : Fragment(),
         cpuVideoProcessor = activity.getCpuVideoProcessor()
         screenShareManager = activity.getScreenShareManager()
         audioDeviceManager = AudioDeviceManager(audioVideo)
-        demoUrl = if (getString(R.string.test_url).endsWith("/")) getString(R.string.test_url) else "${getString(R.string.test_url)}/"
 
+        val meetingEndpointUrl = arguments?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String
         postLogger = PostLogger(
             appName,
             activity.getMeetingSessionConfiguration(),
-            "${demoUrl}log_meeting_event",
+            "${meetingEndpointUrl}log_meeting_event",
             LogLevel.INFO
         )
 
@@ -632,7 +631,8 @@ class MeetingFragment : Fragment(),
     }
 
     private suspend fun getJoinResponseForPrimaryMeeting(): MeetingSessionCredentials? {
-        var url = if (demoUrl.endsWith("/")) demoUrl else "$demoUrl/"
+        val meetingEndpointUrl = arguments?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String
+        var url = if (meetingEndpointUrl.endsWith("/")) meetingEndpointUrl else "$meetingEndpointUrl/"
         val attendeeName = getAttendeeName(credentials.attendeeId, credentials.externalUserId)
         url = "${url}join?title=${encodeURLParam(primaryExternalMeetingId)}&name=promoted-${encodeURLParam(attendeeName)}"
         url += "&region=region"


### PR DESCRIPTION
### Issue #, if available: None

### Description of changes: title

### Testing done:
Promotion demotion smoke tests

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
