### PR TITLE
Music stream support added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* Added `audioStreamType` in `AudioVideoConfiguration` for supporting audio stream configuration.
+
 ## [0.15.4] - 2022-04-21
 
 ## [0.15.3] - 2022-04-07

--- a/README.md
+++ b/README.md
@@ -151,15 +151,26 @@ If you discover a potential security issue in this project we ask that you notif
 
 You need to start the meeting session to start sending and receiving audio. Make sure that the user has granted audio permission first.
 
+Start a session with default configurations:
 ```kotlin
 meetingSession.audioVideo.start()
 ```
 
-The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
+Start a session with custom configurations:
 
 ```kotlin
 meetingSession.audioVideo.start(audioVideoConfiguration)
 ```
+
+There are 2 configurations available in `audioVideoConfiguration`: `audioMode` and `audioStream`.
+
+AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
+
+AudioStream: The default audio stream is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
+
+> Note: Even though there are more available stream options in Android, currently only *STREAM_VOICE_CALL* and *STREAM_MUSIC* are supported in Chime Android SDK.
+
+
 
 #### Use case 2. Add an observer to receive audio and video session life cycle events.
 
@@ -275,10 +286,13 @@ override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
 
 #### Use case 8. Choose the audio configuration.
 
-> When joining a meeting, *Mono/16KHz*, *Mono/48KHz* and *Stereo/48KHz* are supported. *Stereo/48KHz* will be set as the default audio mode if not explicitly specified when starting the audio session.
+> When joining a meeting, *Stereo/48KHz* and *VoiceCall* will be set as the default audio mode and stream if not explicitly specified when starting the audio session.
+> 
+> Supported AudioMode options: *Mono/16KHz*, *Mono/48KHz*, and *Stereo/48KHz*.
+> Supproted AudioStream options: *VoiceCall* and *Music*.
 
 ```kotlin
-meetingSession.audioVideo.start() // starts the audio video session with Stereo/48KHz audio
+meetingSession.audioVideo.start() // starts the audio video session with Stereo/48KHz and VoiceCall
 
 meetingSession.audioVideo.start(audioVideoConfiguration) // starts the audio video session with the specified [AudioVideoConfiguration]
 ```

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz 
 
 AudioStreamType: The default value is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
 
-> Note: Even though there are more available stream options in Android, currently only *STREAM_VOICE_CALL* and *STREAM_MUSIC* are supported in Chime Android SDK.
+> Note: Even though there are more available stream options in Android, currently only *STREAM_VOICE_CALL* and *STREAM_MUSIC* are supported in Amazon Chime SDK for Android.
 
 
 

--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ meetingSession.audioVideo.start(audioVideoConfiguration)
 
 There are 2 configurations available in `audioVideoConfiguration`: 
 - `audioMode`
-- `audioStream`
+- `audioStreamType`
 
 AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
 
-AudioStream: The default audio stream is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
+AudioStreamType: The default value is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
 
 > Note: Even though there are more available stream options in Android, currently only *STREAM_VOICE_CALL* and *STREAM_MUSIC* are supported in Chime Android SDK.
 
@@ -291,7 +291,7 @@ override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
 > When joining a meeting, *Stereo/48KHz* and *VoiceCall* will be set as the default audio mode and stream if not explicitly specified when starting the audio session.
 > 
 > Supported AudioMode options: *Mono/16KHz*, *Mono/48KHz*, and *Stereo/48KHz*.
-> Supproted AudioStream options: *VoiceCall* and *Music*.
+> Supported AudioStreamType options: *VoiceCall* and *Music*.
 
 ```kotlin
 meetingSession.audioVideo.start() // starts the audio video session with Stereo/48KHz and VoiceCall

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ Start a session with custom configurations:
 meetingSession.audioVideo.start(audioVideoConfiguration)
 ```
 
-There are 2 configurations available in `audioVideoConfiguration`: `audioMode` and `audioStream`.
+There are 2 configurations available in `audioVideoConfiguration`: 
+- `audioMode`
+- `audioStream`
 
 AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
 
 /**
  * [AudioVideoConfiguration] represents the configuration to be used for audio and video during a
@@ -13,7 +14,11 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
  *
  * @property audioMode: AudioMode - the audio mode in which the audio client should operate during
  * a meeting session.
+ *
+ * @property audioStream: AudioStream - the audio stream in which the audio client should operate
+ * during a meeting session.
  */
 data class AudioVideoConfiguration @JvmOverloads constructor(
-    val audioMode: AudioMode = AudioMode.Stereo48K
+    val audioMode: AudioMode = AudioMode.Stereo48K,
+    val audioStream: AudioStream = AudioStream.VoiceCall
 )

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
@@ -6,7 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 
 /**
  * [AudioVideoConfiguration] represents the configuration to be used for audio and video during a
@@ -15,10 +15,10 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
  * @property audioMode: AudioMode - the audio mode in which the audio client should operate during
  * a meeting session.
  *
- * @property audioStream: AudioStream - the audio stream in which the audio client should operate
- * during a meeting session.
+ * @property audioStreamType: AudioStreamType - the audio stream type in which the audio client
+ * should operate during a meeting session.
  */
 data class AudioVideoConfiguration @JvmOverloads constructor(
     val audioMode: AudioMode = AudioMode.Stereo48K,
-    val audioStream: AudioStream = AudioStream.VoiceCall
+    val audioStreamType: AudioStreamType = AudioStreamType.VoiceCall
 )

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -50,7 +50,8 @@ class DefaultAudioVideoController(
             meetingId = configuration.meetingId,
             attendeeId = configuration.credentials.attendeeId,
             joinToken = configuration.credentials.joinToken,
-            audioMode = audioVideoConfiguration.audioMode
+            audioMode = audioVideoConfiguration.audioMode,
+            audioStream = audioVideoConfiguration.audioStream
         )
         videoClientController.start()
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -51,7 +51,7 @@ class DefaultAudioVideoController(
             attendeeId = configuration.credentials.attendeeId,
             joinToken = configuration.credentials.joinToken,
             audioMode = audioVideoConfiguration.audioMode,
-            audioStream = audioVideoConfiguration.audioStream
+            audioStreamType = audioVideoConfiguration.audioStreamType
         )
         videoClientController.start()
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStream.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStream.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
+
+/**
+ * [AudioStream] describes the audio stream in which the audio client should operate during a meeting session.
+ */
+enum class AudioStream {
+
+    /**
+     * Equivalent of AudioManager.STREAM_VOICE_CALL
+     * https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL
+     */
+    VoiceCall,
+
+    /**
+     * Equivalent of AudioManager.STREAM_MUSIC
+     * https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC
+     * Not that the meeting session volume cannot be adjusted by the volume button with [Music]
+     * except for Oculus Quest 2.
+     */
+    Music
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStream.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStream.kt
@@ -19,7 +19,7 @@ enum class AudioStream {
     /**
      * Equivalent of AudioManager.STREAM_MUSIC
      * https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC
-     * Not that the meeting session volume cannot be adjusted by the volume button with [Music]
+     * Note that the meeting session volume cannot be adjusted by the volume button with [Music]
      * except for Oculus Quest 2.
      */
     Music

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStreamType.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioStreamType.kt
@@ -6,9 +6,10 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
 
 /**
- * [AudioStream] describes the audio stream in which the audio client should operate during a meeting session.
+ * [AudioStreamType] describes the audio stream type in which the audio client should operate
+ * during a meeting session.
  */
-enum class AudioStream {
+enum class AudioStreamType {
 
     /**
      * Equivalent of AudioManager.STREAM_VOICE_CALL

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
 
 /**
@@ -25,7 +26,8 @@ interface AudioClientController {
         meetingId: String,
         attendeeId: String,
         joinToken: String,
-        audioMode: AudioMode
+        audioMode: AudioMode,
+        audioStream: AudioStream
     )
 
     fun stop()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
@@ -7,7 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
 
 /**
@@ -27,7 +27,7 @@ interface AudioClientController {
         attendeeId: String,
         joinToken: String,
         audioMode: AudioMode,
-        audioStream: AudioStream
+        audioStreamType: AudioStreamType
     )
 
     fun stop()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -177,25 +177,27 @@ class DefaultAudioClientController(
             }
 
             var audioStreamType = when (audioStream) {
-                AudioStream.VoiceCall -> AudioClient.AudioStream.VOICE_CALL
-                AudioStream.Music -> AudioClient.AudioStream.MUSIC
+                AudioStream.VoiceCall -> AudioClient.AudioStreamType.VOICE_CALL
+                AudioStream.Music -> AudioClient.AudioStreamType.MUSIC
             }
 
-            val config = AudioClientConfig(
-                    AudioClient.XTL_DEFAULT_TRANSPORT,
-                    host,
-                    port,
-                    joinToken,
-                    meetingId,
-                    attendeeId,
-                    muteMicAndSpeaker,
-                    muteMicAndSpeaker,
-                    DEFAULT_PRESENTER,
-                    audioFallbackUrl,
-                    null,
-                    appInfo,
-                    audioModeInternal,
-                    audioStreamType)
+            var config = AudioClientConfig.Builder(
+                host,
+                port,
+                joinToken,
+                meetingId,
+                attendeeId,
+                audioFallbackUrl,
+                appInfo,
+                audioModeInternal,
+                audioStreamType
+            ).withTransportMode(AudioClient.XTL_DEFAULT_TRANSPORT)
+                .withMicMute(muteMicAndSpeaker)
+                .withSpkMute(muteMicAndSpeaker)
+                .withPresenter(DEFAULT_PRESENTER)
+                .withProxyConfig(null)
+                .build()
+
             val res = audioClient.startSession(config)
 
             if (res != AUDIO_CLIENT_RESULT_SUCCESS) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -16,7 +16,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
@@ -125,7 +125,7 @@ class DefaultAudioClientController(
         attendeeId: String,
         joinToken: String,
         audioMode: AudioMode,
-        audioStream: AudioStream
+        audioStreamType: AudioStreamType
     ) {
         // Validate audio client state
         if (audioClientState != AudioClientState.INITIALIZED &&
@@ -176,9 +176,9 @@ class DefaultAudioClientController(
                 AudioMode.NoDevice -> AudioModeInternal.NO_DEVICE
             }
 
-            var audioStreamType = when (audioStream) {
-                AudioStream.VoiceCall -> AudioClient.AudioStreamType.VOICE_CALL
-                AudioStream.Music -> AudioClient.AudioStreamType.MUSIC
+            var audioStreamTypeInternal = when (audioStreamType) {
+                AudioStreamType.VoiceCall -> AudioClient.AudioStreamType.VOICE_CALL
+                AudioStreamType.Music -> AudioClient.AudioStreamType.MUSIC
             }
 
             var config = AudioClientConfig.Builder(
@@ -190,7 +190,7 @@ class DefaultAudioClientController(
                 audioFallbackUrl,
                 appInfo,
                 audioModeInternal,
-                audioStreamType
+                audioStreamTypeInternal
             ).withTransportMode(AudioClient.XTL_DEFAULT_TRANSPORT)
                 .withMicMute(muteMicAndSpeaker)
                 .withSpkMute(muteMicAndSpeaker)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -24,7 +24,7 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCod
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
 import com.xodee.client.audio.audioclient.AudioClient.AudioModeInternal
-import com.xodee.client.audio.audioclient.AudioClientConfig
+import com.xodee.client.audio.audioclient.AudioClientSessionConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
@@ -181,7 +181,7 @@ class DefaultAudioClientController(
                 AudioStreamType.Music -> AudioClient.AudioStreamType.MUSIC
             }
 
-            var config = AudioClientConfig.Builder(
+            var config = AudioClientSessionConfig.Builder(
                 host,
                 port,
                 joinToken,

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientObserver
@@ -111,7 +112,8 @@ class DefaultAudioVideoControllerTest {
                 meetingId,
                 attendeeId,
                 joinToken,
-                AudioMode.Stereo48K
+                AudioMode.Stereo48K,
+                AudioStream.VoiceCall
             )
         }
     }
@@ -127,7 +129,8 @@ class DefaultAudioVideoControllerTest {
                     meetingId,
                     attendeeId,
                     joinToken,
-                    AudioMode.Mono16K
+                    AudioMode.Mono16K,
+                    AudioStream.VoiceCall
             )
         }
     }
@@ -143,7 +146,8 @@ class DefaultAudioVideoControllerTest {
                     meetingId,
                     attendeeId,
                     joinToken,
-                    AudioMode.Mono48K
+                    AudioMode.Mono48K,
+                    AudioStream.VoiceCall
             )
         }
     }
@@ -159,7 +163,42 @@ class DefaultAudioVideoControllerTest {
                     meetingId,
                     attendeeId,
                     joinToken,
-                    AudioMode.Stereo48K
+                    AudioMode.Stereo48K,
+                    AudioStream.VoiceCall
+            )
+        }
+    }
+
+    @Test
+    fun `start() with voice call stream should call audioClientController start() with AudioStream VoiceCall`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStream = AudioStream.VoiceCall)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                audioFallbackURL,
+                audioHostURL,
+                meetingId,
+                attendeeId,
+                joinToken,
+                AudioMode.Stereo48K,
+                AudioStream.VoiceCall
+            )
+        }
+    }
+
+    @Test
+    fun `start() with music stream should call audioClientController start() with AudioStream Music`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStream = AudioStream.Music)
+        audioVideoController.start(testAudioVideoConfiguration)
+        verify {
+            audioClientController.start(
+                audioFallbackURL,
+                audioHostURL,
+                meetingId,
+                attendeeId,
+                joinToken,
+                AudioMode.Stereo48K,
+                AudioStream.Music
             )
         }
     }
@@ -175,7 +214,8 @@ class DefaultAudioVideoControllerTest {
                 meetingId,
                 attendeeId,
                 joinToken,
-                AudioMode.NoDevice
+                AudioMode.NoDevice,
+                AudioStream.VoiceCall
             )
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -6,7 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientObserver
@@ -113,7 +113,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
             )
         }
     }
@@ -130,7 +130,7 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Mono16K,
-                    AudioStream.VoiceCall
+                    AudioStreamType.VoiceCall
             )
         }
     }
@@ -147,7 +147,7 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Mono48K,
-                    AudioStream.VoiceCall
+                    AudioStreamType.VoiceCall
             )
         }
     }
@@ -164,14 +164,14 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Stereo48K,
-                    AudioStream.VoiceCall
+                    AudioStreamType.VoiceCall
             )
         }
     }
 
     @Test
-    fun `start() with voice call stream should call audioClientController start() with AudioStream VoiceCall`() {
-        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStream = AudioStream.VoiceCall)
+    fun `start() with voice call stream should call audioClientController start() with AudioStreamType VoiceCall`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStreamType = AudioStreamType.VoiceCall)
         audioVideoController.start(testAudioVideoConfiguration)
         verify {
             audioClientController.start(
@@ -181,14 +181,14 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
             )
         }
     }
 
     @Test
-    fun `start() with music stream should call audioClientController start() with AudioStream Music`() {
-        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStream = AudioStream.Music)
+    fun `start() with music stream should call audioClientController start() with AudioStreamType Music`() {
+        val testAudioVideoConfiguration = AudioVideoConfiguration(audioStreamType = AudioStreamType.Music)
         audioVideoController.start(testAudioVideoConfiguration)
         verify {
             audioClientController.start(
@@ -198,7 +198,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
-                AudioStream.Music
+                AudioStreamType.Music
             )
         }
     }
@@ -215,7 +215,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.NoDevice,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
             )
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -16,6 +16,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AppInfo
@@ -36,6 +37,7 @@ import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -126,21 +128,7 @@ class DefaultAudioClientControllerTest {
     private fun setupStartTests() {
         every { mockAudioClient.sendMessage(any(), any()) } returns testAudioClientSuccessCode
         every {
-            mockAudioClient.startSessionV2(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any()
-            )
+            mockAudioClient.startSession(any())
         } returns testAudioClientSuccessCode
         every { mockAudioClient.setVoiceFocusNoiseSuppression(any()) } returns AudioClient.AUDIO_CLIENT_OK
         every { mockAudioClient.getVoiceFocusNoiseSuppression() } returns true
@@ -285,7 +273,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start with Stereo 48KHz should call AudioClient startSessionV2 with Stereo 48KHz and mute mic and speaker as false`() {
+    fun `start with Stereo 48KHz should call AudioClient startSession with Stereo 48KHz and mute mic and speaker as false`() {
         setupStartTests()
 
         audioClientController.start(
@@ -294,25 +282,14 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
 
         verify {
-            mockAudioClient.startSessionV2(
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                false,
-                false,
-                any(),
-                any(),
-                any(),
-                any(),
-                AudioModeInternal.STEREO_48K
-            )
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioModeInternal.STEREO_48K, it.audioMode)
+            })
         }
     }
 
@@ -326,30 +303,21 @@ class DefaultAudioClientControllerTest {
                 testMeetingId,
                 testAttendeeId,
                 testJoinToken,
-                AudioMode.Mono16K
+                AudioMode.Mono16K,
+                AudioStream.VoiceCall
         )
 
         verify {
-            mockAudioClient.startSessionV2(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    false,
-                    false,
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    AudioModeInternal.MONO_16K
-            )
+            mockAudioClient.startSession(withArg {
+                assertFalse(it.micMute)
+                assertFalse(it.spkMute)
+                assertEquals(AudioModeInternal.MONO_16K, it.audioMode)
+            })
         }
     }
 
     @Test
-    fun `start with Mono 48KHz should call AudioClient startSessionV2 with Mono 48KHz and mute mic and speaker as false`() {
+    fun `start with Mono 48KHz should call AudioClient startSession with Mono 48KHz and mute mic and speaker as false`() {
         setupStartTests()
 
         audioClientController.start(
@@ -358,25 +326,58 @@ class DefaultAudioClientControllerTest {
                 testMeetingId,
                 testAttendeeId,
                 testJoinToken,
-                AudioMode.Mono48K
+                AudioMode.Mono48K,
+                AudioStream.VoiceCall
         )
 
         verify {
-            mockAudioClient.startSessionV2(
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    false,
-                    false,
-                    any(),
-                    any(),
-                    any(),
-                    any(),
-                    AudioModeInternal.MONO_48K
-            )
+            mockAudioClient.startSession(withArg {
+                assertFalse(it.micMute)
+                assertFalse(it.spkMute)
+                assertEquals(AudioModeInternal.MONO_48K, it.audioMode)
+            })
+        }
+    }
+
+    @Test
+    fun `start() with voice call stream should call startSession(AudioClientConfig) with AudioStream VOICE_CALL`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Mono48K,
+            AudioStream.VoiceCall
+        )
+
+        verify {
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioClient.AudioStream.VOICE_CALL, it.audioStream)
+            })
+        }
+    }
+
+    @Test
+    fun `start() with music stream should call startSession(AudioClientConfig) with AudioStream MUSIC`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Mono48K,
+            AudioStream.Music
+        )
+
+        verify {
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioClient.AudioStream.MUSIC, it.audioStream)
+            })
         }
     }
 
@@ -390,7 +391,8 @@ class DefaultAudioClientControllerTest {
                 testMeetingId,
                 testAttendeeId,
                 testJoinToken,
-                AudioMode.Stereo48K
+                AudioMode.Stereo48K,
+                AudioStream.VoiceCall
         )
 
         verify {
@@ -408,7 +410,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
 
         verify(exactly = 1) { mockAudioClientObserver.notifyAudioClientObserver(any()) }
@@ -423,7 +426,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
 
         verify(exactly = 1) { mockEventAnalyticsController.publishEvent(EventName.meetingStartRequested, any()) }
@@ -448,7 +452,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -466,7 +471,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -488,7 +494,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
 
         val enableOutput: Boolean = audioClientController.setVoiceFocusEnabled(true)
@@ -522,7 +529,8 @@ class DefaultAudioClientControllerTest {
             testMeetingId,
             testAttendeeId,
             testJoinToken,
-            AudioMode.Stereo48K
+            AudioMode.Stereo48K,
+            AudioStream.VoiceCall
         )
 
         audioClientController.isVoiceFocusEnabled()

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -340,7 +340,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start() with voice call stream should call startSession(AudioClientConfig) with AudioStreamType VOICE_CALL`() {
+    fun `start() with voice call stream should call startSession(AudioClientSessionConfig) with AudioStreamType VOICE_CALL`() {
         setupStartTests()
 
         audioClientController.start(
@@ -361,7 +361,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start() with music stream should call startSession(AudioClientConfig) with AudioStreamType MUSIC`() {
+    fun `start() with music stream should call startSession(AudioClientSessionConfig) with AudioStreamType MUSIC`() {
         setupStartTests()
 
         audioClientController.start(

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -340,7 +340,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start() with voice call stream should call startSession(AudioClientConfig) with AudioStream VOICE_CALL`() {
+    fun `start() with voice call stream should call startSession(AudioClientConfig) with AudioStreamType VOICE_CALL`() {
         setupStartTests()
 
         audioClientController.start(
@@ -355,13 +355,13 @@ class DefaultAudioClientControllerTest {
 
         verify {
             mockAudioClient.startSession(withArg {
-                assertEquals(AudioClient.AudioStream.VOICE_CALL, it.audioStream)
+                assertEquals(AudioClient.AudioStreamType.VOICE_CALL, it.audioStreamType)
             })
         }
     }
 
     @Test
-    fun `start() with music stream should call startSession(AudioClientConfig) with AudioStream MUSIC`() {
+    fun `start() with music stream should call startSession(AudioClientConfig) with AudioStreamType MUSIC`() {
         setupStartTests()
 
         audioClientController.start(
@@ -376,7 +376,7 @@ class DefaultAudioClientControllerTest {
 
         verify {
             mockAudioClient.startSession(withArg {
-                assertEquals(AudioClient.AudioStream.MUSIC, it.audioStream)
+                assertEquals(AudioClient.AudioStreamType.MUSIC, it.audioStreamType)
             })
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -294,7 +294,7 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
-    fun `start with Mono 16KHz should call AudioClient startSessionV2 with Mono 16KHz and mute mic and speaker as false`() {
+    fun `start with Mono 16KHz should call AudioClient startSession with Mono 16KHz and mute mic and speaker as false`() {
         setupStartTests()
 
         audioClientController.start(

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -16,7 +16,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStream
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AppInfo
@@ -283,7 +283,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         verify {
@@ -304,7 +304,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
         )
 
         verify {
@@ -327,7 +327,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono48K,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
         )
 
         verify {
@@ -350,7 +350,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         verify {
@@ -371,7 +371,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono48K,
-            AudioStream.Music
+            AudioStreamType.Music
         )
 
         verify {
@@ -392,7 +392,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Stereo48K,
-                AudioStream.VoiceCall
+                AudioStreamType.VoiceCall
         )
 
         verify {
@@ -411,7 +411,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         verify(exactly = 1) { mockAudioClientObserver.notifyAudioClientObserver(any()) }
@@ -427,7 +427,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         verify(exactly = 1) { mockEventAnalyticsController.publishEvent(EventName.meetingStartRequested, any()) }
@@ -453,7 +453,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -472,7 +472,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -495,7 +495,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         val enableOutput: Boolean = audioClientController.setVoiceFocusEnabled(true)
@@ -530,7 +530,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
-            AudioStream.VoiceCall
+            AudioStreamType.VoiceCall
         )
 
         audioClientController.isVoiceFocusEnabled()


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Support music stream for fixing volume issue on Oculus Quest 2

### Testing done:
#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
