### PR TITLE
Unify code coverage for instrumented tests and unit tests

### DIFF
--- a/amazon-chime-sdk/.gitignore
+++ b/amazon-chime-sdk/.gitignore
@@ -1,2 +1,3 @@
 /build
 /libs
+jacoco.exec

--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -46,8 +46,7 @@ android {
         debug {
             buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
             buildConfigField("String", "VERSION_NAME", "\"${defaultConfig.versionName}\"")
-            // Note: We had seen this problem from other engineers as well - setting this to true will somehow discard the coverage, instead setting to false will get the right coverage number.
-            testCoverageEnabled false
+            testCoverageEnabled true
         }
         release {
             buildConfigField("long", "VERSION_CODE", "${defaultConfig.versionCode}")
@@ -103,7 +102,9 @@ tasks.withType(Test) {
     }
 }
 
-task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest','createDebugCoverageReport']) {
+    group = "Reporting"
+    description = "Generate Jacoco coverage reports after running tests."
 
     reports {
         xml.enabled = true
@@ -116,7 +117,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
 
     sourceDirectories.setFrom(files([mainSrc]))
     classDirectories.setFrom(files([kotlinTree]))
-    executionData.setFrom(fileTree(dir: "$buildDir", includes: ["jacoco/testDebugUnitTest.exec"]))
+    executionData.setFrom(files([fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code_coverage/debugAndroidTest/connected/**ec"]), "jacoco.exec"]))
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
To unify code coverage report for unit tests and instrumented tests. We used to have only unit tests coverage.

### Testing done:
Ran the code coverage report gradle task, verified both tests are covered.
<img width="1296" alt="Screen Shot 2022-04-28 at 5 46 33 PM" src="https://user-images.githubusercontent.com/55719628/165869701-d38de0ec-6990-451a-8ec4-a7949926d359.png">

#### Unit test coverage
* Class coverage: 
* Line coverage: 

#### Manual test cases (add more as needed):
* [ ] Join meeting
* [ ] Leave meeting
* [ ] Rejoin meeting
* [ ] Send audio
* [ ] Receive audio
* [ ] See active speaker indicator when speaking
* [ ] Mute/Unmute self
* [ ] See local mute indicator when muted
* [ ] See remote mute indicator when other is muted
* [ ] See audio video events
* [ ] See signal strength changes
* [ ] See media metrics received
* [ ] See roster updates when remote attendees join / leave the meeting
* [ ] Enable local video
* [ ] See local video tile
* [ ] See remote video tile
* [ ] Switch camera
* [ ] See remote screen sharing content with attendee name
* [ ] Pause remote video tile
* [ ] Resume remote video tile
* [ ] First time audio permissions
* [ ] First time video permissions

#### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
