### PR TITLE
Revert "Add gradle tasks to publish amazon-chime-sdk-machine-learning (#432)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,10 +28,8 @@ kotlin.code.style=official
 GROUP=software.aws.chimesdk
 ARTIFACT_ID_SDK=amazon-chime-sdk
 ARTIFACT_ID_SDK_MEDIA=amazon-chime-sdk-media
-ARTIFACT_ID_SDK_MACHINE_LEARNING=amazon-chime-sdk-machine-learning
 POM_SDK_NAME=Amazon Chime SDK
 POM_SDK_MEDIA_NAME=Amazon Chime SDK Media
-POM_SDK_MACHINE_LEARNING_NAME=Amazon Chime SDK Machine Learning
 
 POM_URL=https://github.com/aws/amazon-chime-sdk-android
 POM_SCM_URL=https://github.com/aws/amazon-chime-sdk-android
@@ -48,4 +46,3 @@ POM_DEVELOPER_ORGANIZATION_URL=http://aws.amazon.com
 
 POM_DESCRIPTION_SDK=Amazon Chime Android SDK
 POM_DESCRIPTION_SDK_MEDIA=Amazon Chime Android SDK Media
-POM_DESCRIPTION_SDK_MACHINE_LEARNING=Amazon Chime Android SDK Machine Learning

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -19,7 +19,6 @@ if (versionFile.exists()) {
 }
 version = versionProperties.getProperty('VERSION')
 def media_version = versionProperties.getProperty('MEDIA_VERSION')
-def machineLearningVersion = versionProperties.getProperty('MACHINE_LEARNING_VERSION')
 
 signing {
     if (!project.hasProperty('signing.key') || !project.hasProperty('signing.password') || !project.hasProperty('signing.keyId')) {
@@ -100,38 +99,6 @@ project.afterEvaluate {
                     }
                 }
             }
-            publishChimeSDKMachineLearning(MavenPublication) {
-                groupId = GROUP
-                version = machineLearningVersion
-                artifactId = ARTIFACT_ID_SDK_MACHINE_LEARNING
-                artifact("$buildDir/../libs/amazon-chime-sdk-machine-learning.aar")
-
-                pom {
-                    name = POM_SDK_MACHINE_LEARNING_NAME
-                    description = POM_DESCRIPTION_SDK_MACHINE_LEARNING
-                    url = POM_URL
-                    licenses {
-                        license {
-                            name = POM_LICENCE_NAME
-                            url = POM_LICENCE_URL
-                            distribution = POM_LICENCE_DIST
-                        }
-                    }
-                    scm {
-                        url = POM_SCM_URL
-                        connection = POM_SCM_CONNECTION
-                        developerConnection = POM_SCM_DEV_CONNECTION
-                    }
-                    developers {
-                        developer {
-                            id = POM_DEVELOPER_ID
-                            organization = POM_DEVELOPER_ORGANIZATION
-                            organizationUrl = POM_DEVELOPER_ORGANIZATION_URL
-                        }
-                    }
-                }
-            }
-
         }
 
         repositories {


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
Revert changes to add gradle tasks to publish `amazon-chime-sdk-machine-learning`. The feature will be punted to next release.

### Testing done:
N/A

#### Unit test coverage
* Class coverage: N/A
* Line coverage: N/A

#### Manual test cases (add more as needed):
* [x] Join meeting
* [x] Leave meeting
* [x] Rejoin meeting
* [x] Send audio
* [x] Receive audio
* [x] See active speaker indicator when speaking
* [x] Mute/Unmute self
* [x] See local mute indicator when muted
* [x] See remote mute indicator when other is muted
* [x] See audio video events
* [x] See signal strength changes
* [x] See media metrics received
* [x] See roster updates when remote attendees join / leave the meeting
* [x] Enable local video
* [x] See local video tile
* [x] See remote video tile
* [x] Switch camera
* [x] See remote screen sharing content with attendee name
* [x] Pause remote video tile
* [x] Resume remote video tile
* [x] First time audio permissions
* [x] First time video permissions

#### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
