### PR TITLE
Fix failed code coverage tests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,18 +14,13 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-18.04
+    runs-on: macos-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-      - uses: uraimo/run-on-arch-action@v2
-        name: Build artifact
-        id: build
-        with:
-          arch: aarch64
-          distro: ubuntu18.04
+
       # Download amazon-chime-sdk-media binary from AWS S3
       - name: Get Media binary from AWS S3
         run: |
@@ -67,13 +62,13 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-30
+          key: avd-27
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
-          api-level: 30
+          api-level: 27
           target: google_apis
           arch: arm64-v8a
           force-avd-creation: false
@@ -87,7 +82,7 @@ jobs:
         with:
           target: google_apis
           arch: arm64-v8a
-          api-level: 30
+          api-level: 27
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -62,15 +62,15 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-27
+          key: avd-30
 
       - name: Create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
-          api-level: 27
+          api-level: 30
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
@@ -81,8 +81,8 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           target: google_apis
-          arch: arm64-v8a
-          api-level: 27
+          arch: x86_64
+          api-level: 30
           emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/161#issuecomment-868614089
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -56,7 +56,9 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           target: google_apis
-          api-level: 27 # Using lower api level due to mockk bug https://github.com/mockk/mockk/issues/297
+          arch: arm64-v8a
+          # TODO: Using lower api level 27 due to mockk bug https://github.com/mockk/mockk/issues/297
+          api-level: 30
           script: ./gradlew jacocoTestReport --stacktrace
 
       # Upload code coverage report to codecov to process data

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,13 +14,18 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: ubuntu-18.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
+      - uses: uraimo/run-on-arch-action@v2
+        name: Build artifact
+        id: build
+        with:
+          arch: aarch64
+          distro: ubuntu18.04
       # Download amazon-chime-sdk-media binary from AWS S3
       - name: Get Media binary from AWS S3
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -51,14 +51,39 @@ jobs:
           mkdir -p ./amazon-chime-sdk/libs
           mv amazon-chime-sdk-machine-learning.aar ./amazon-chime-sdk/libs
 
+      # Setup gradle caching to reduce AVD start-up time
+      - name: Gradle cache
+        uses: gradle/gradle-build-action@v2
+
+      - name: AVD cache
+        uses: actions/cache@v3
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-30
+
+      - name: Create AVD and generate snapshot for caching
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: ReactiveCircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: false
+          script: echo "Generated AVD snapshot for caching."
+
       # Execute unit tests
       - name: Unit Test with Android Emulator Runner
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           target: google_apis
           arch: arm64-v8a
-          # TODO: Using lower api level 27 due to mockk bug https://github.com/mockk/mockk/issues/297
           api-level: 30
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
           script: ./gradlew jacocoTestReport --stacktrace
 
       # Upload code coverage report to codecov to process data

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -69,9 +69,11 @@ jobs:
         uses: ReactiveCircus/android-emulator-runner@v2
         with:
           api-level: 30
+          target: google_apis
+          arch: arm64-v8a
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
+          disable-animations: true
           script: echo "Generated AVD snapshot for caching."
 
       # Execute unit tests

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -83,6 +83,7 @@ jobs:
           target: google_apis
           arch: arm64-v8a
           api-level: 27
+          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/161#issuecomment-868614089
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,6 +21,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Modify build.gradle file to build for x86_64
+      - name: Add x86_64 in gradle build
+        run: |
+          sed -i '' "s/abiFilters 'armeabi-v7a', 'arm64-v8a'/abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'/" $GITHUB_WORKSPACE/amazon-chime-sdk/build.gradle
+
       # Download amazon-chime-sdk-media binary from AWS S3
       - name: Get Media binary from AWS S3
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -88,7 +88,6 @@ jobs:
           target: google_apis
           arch: x86_64
           api-level: 30
-          emulator-build: 7425822 # https://github.com/ReactiveCircus/android-emulator-runner/issues/161#issuecomment-868614089
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true

--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -35,7 +35,7 @@ android {
         renderscriptTargetApi 21
         renderscriptSupportModeEnabled true
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a'
+            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
         }
     }
 

--- a/amazon-chime-sdk/build.gradle
+++ b/amazon-chime-sdk/build.gradle
@@ -35,7 +35,7 @@ android {
         renderscriptTargetApi 21
         renderscriptSupportModeEnabled true
         ndk {
-            abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86_64'
+            abiFilters 'armeabi-v7a', 'arm64-v8a'
         }
     }
 


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

Fix failed code coverage tests. Currently github workflow runs on non-ARM virtual machines. Since Chime SDK builds only for abiFilters 'armeabi-v7a' and 'arm64-v8a', I've added support to build for 'x86_64' when running git workflow actions only.

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Cannot test this locally. Github code coverage workflow passed in this commit.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
