### PR TITLE
Fix 25 video tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+* [Demo] Fixed local video turning off when it reaches the limit.
+
 ## [0.17.0] - 2022-05-18
 
 ### Added

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1535,7 +1535,6 @@ class MeetingFragment : Fragment(),
         when (sessionStatus.statusCode) {
             MeetingSessionStatusCode.VideoAtCapacityViewOnly -> {
                 notifyHandler("Currently cannot enable video in meeting")
-                stopLocalVideo()
                 meetingModel.isCameraOn = !meetingModel.isCameraOn
                 refreshNoVideosOrScreenShareAvailableText()
             }


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

There was issue when we reach 25 video tiles, the local video seems to turn off, which shouldn't be expected behavior.

### Issue #, if available
Chime-50639

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

Added 25 video tiles and see that local video does not turn off.

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
