### PR TITLE
Fix video subscription issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 * Fixed crash from openGL due to potential race condition.
 * [Demo] Fixed videos paused when change from other tabs to video tab and reopen app from background
 * [Demo] Fixed screen sharing is unavailable to present videos
+* [Demo] Fixed demo application not subscribing remote videos properly
 
 ## [0.17.1] - 2022-06-03
-
 
 ## [0.17.0] - 2022-05-18
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -216,7 +216,7 @@ class VideoHolder(
 
             val updatedSource = mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
             for (source in meetingModel.remoteVideoSourceConfigurations) {
-                if (source.key?.attendeeId == attendeeId) {
+                if (source.key.attendeeId == attendeeId) {
                     val resolution: VideoResolution = source.value.targetResolution
                     source.setValue(VideoSubscriptionConfiguration(priority, resolution))
                     updatedSource[source.key] = source.value
@@ -235,7 +235,7 @@ class VideoHolder(
         val popup = PopupMenu(context, view)
         popup.inflate(R.menu.resolution_popup_menu)
         popup.setOnMenuItemClickListener { item: MenuItem? ->
-            var resolution = when (item?.itemId) {
+            val resolution = when (item?.itemId) {
                 R.id.high -> {
                     VideoResolution.High
                 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1260,7 +1260,7 @@ class MeetingFragment : Fragment(),
         val updatedSources: MutableMap<RemoteVideoSource, VideoSubscriptionConfiguration> =
             mutableMapOf()
         for (videoState in newList) {
-            // TODO: This seems to be needed for demo application to show all tiles.
+            // This seems to be needed for demo application to show all tiles. Sometimes, it gets paused
             audioVideo.resumeRemoteVideoTile(videoState.videoTileState.tileId)
             for ((key, value) in meetingModel.remoteVideoSourceConfigurations) {
                 if (videoState.videoTileState.attendeeId == key.attendeeId) {
@@ -1269,7 +1269,8 @@ class MeetingFragment : Fragment(),
             }
         }
 
-        // This is to handle case where we are on same page and page updates.
+        // This is to handle case where this function is called without page changes
+        // which could lead to having same removed and updated.
         val removedList = mutableListOf<RemoteVideoSource>()
         for (removed in potentialRemovedList) {
             if (!updatedSources.containsKey(removed)) {
@@ -1280,11 +1281,10 @@ class MeetingFragment : Fragment(),
         val videoDiffCallback = VideoDiffCallback(oldList, newList)
         val videoDiffResult: DiffUtil.DiffResult = DiffUtil.calculateDiff(videoDiffCallback)
 
-        audioVideo.updateVideoSourceSubscriptions(updatedSources, removedList.toTypedArray())
-
         videoDiffResult.dispatchUpdatesTo(videoTileAdapter)
 
         // subscribe to updated sources with highest priority and unsubscribed sources in prev page
+        audioVideo.updateVideoSourceSubscriptions(updatedSources, removedList.toTypedArray())
 
         // update video pagination control buttons states
         prevVideoPageButton.isEnabled = meetingModel.canGoToPrevVideoPage()


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

There was issue where video tiles are paused even when the network is very nice. It looks like we add and remove the same video sources, which caused it to be not subscribed.

### Issue #, if available


### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
I tested on S9 device and confirmed that no more Network Connection issue strings, but actual tile.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

I had 14 video tiles transmitting.


## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
