### PR TITLE
Add support to set maxBitRateKbps for local video and content share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## unreleased
 
+### Added
+* Added support to set max bit rate for local video and content share
+* [Demo] Add video configuration options to set max bit rate for local video in meeting
+
 ### Fixed
 * Use thread safe mutableSet for observers
 

--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ meetingSession.audioVideo.startLocalVideo(localVideoConfig)
 // You can switch camera to change the video input device
 meetingSession.audioVideo.switchCamera()
 
-// Or you can inject custom video source for local video, see [custom video guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md)
+// Or you can inject custom video source for local video, see custom video guide
 ```
 
 #### Use case 16. Stop sharing your video.

--- a/README.md
+++ b/README.md
@@ -451,12 +451,18 @@ For more advanced video tile management, take a look at [Video Pagination](https
 
 ```kotlin
 // Use internal camera capture for the local video
- meetingSession.audioVideo.startLocalVideo()
+meetingSession.audioVideo.startLocalVideo()
+
+// Use internal camera capture and set configuration for the video, e.g. maxBitRateKbps
+// If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+// This can be called multiple times to dynamically adjust video configuration
+val localVideoConfig = LocalVideoConfiguration(600)
+meetingSession.audioVideo.startLocalVideo(localVideoConfig)
 
 // You can switch camera to change the video input device
 meetingSession.audioVideo.switchCamera()
 
-// Or you can inject custom video source for local video, see custom video guide
+// Or you can inject custom video source for local video, see [custom video guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md)
 ```
 
 #### Use case 16. Stop sharing your video.
@@ -513,6 +519,12 @@ meetingSession.audioVideo.addContentShareObserver(observer)
 val contentShareSource = /* a ContentShareSource object, can use DefaultScreenCaptureSource for screen share or any subclass with custom video source */
 // ContentShareSource object is not managed by SDK, builders need to start, stop, release accordingly
 meetingSession.audioVideo.startContentShare(contentShareSource)
+```
+
+You can set configuration for content share, e.g. maxBitRateKbps. Actual quality achieved may vary throughout the call depending on what system and network can provide.
+```kotlin
+val contentShareConfig = LocalVideoConfiguration(200)
+meetingSession.audioVideo.startContentShare(contentShareSource, contentShareConfig)
 ```
 
 See [Content Share](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/content_share.md) for more details.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
@@ -76,6 +77,20 @@ interface AudioVideoControllerFacade {
     fun startLocalVideo()
 
     /**
+     * Start local video with configuration and begin transmitting frames from an internally held [DefaultCameraCaptureSource].
+     * [stopLocalVideo] will stop the internal capture source if being used.
+     *
+     * Calling this after passing in a custom [VideoSource] will replace it with the internal capture source.
+     *
+     * This function will only have effect if [start] has already been called.
+     * Calling this function repeatedly will update configuration of local video.
+     * If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+     *
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startLocalVideo(config: LocalVideoConfiguration)
+
+    /**
      * Start local video with a provided custom [VideoSource] which can be used to provide custom
      * [VideoFrame] objects to be transmitted to remote clients
      *
@@ -88,6 +103,22 @@ interface AudioVideoControllerFacade {
      * @param source: [VideoSource] - The source of video frames to be sent to other clients
      */
     fun startLocalVideo(source: VideoSource)
+
+    /**
+     * Start local video with with configuration and a provided custom [VideoSource] which can be used to provide custom
+     * [VideoFrame] objects to be transmitted to remote clients
+     *
+     * Calling this function repeatedly will replace the previous [VideoSource] as the one being
+     * transmitted. It will update configuration of local video. It will also stop and replace the internal capture source
+     * if [startLocalVideo] was called with no arguments.
+     * If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+     *
+     * Read [custom video guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md) for details.
+     *
+     * @param source: [VideoSource] - The source of video frames to be sent to other clients
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startLocalVideo(source: VideoSource, config: LocalVideoConfiguration)
 
     /**
      * Stops sending video for local attendee. This will additionally stop the internal capture source if being used.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -66,8 +67,16 @@ class DefaultAudioVideoController(
         videoClientController.startLocalVideo()
     }
 
+    override fun startLocalVideo(config: LocalVideoConfiguration) {
+        videoClientController.startLocalVideo(config)
+    }
+
     override fun startLocalVideo(source: VideoSource) {
         videoClientController.startLocalVideo(source)
+    }
+
+    override fun startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
+        videoClientController.startLocalVideo(source, config)
     }
 
     override fun stopLocalVideo() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -23,6 +23,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
@@ -102,8 +103,16 @@ class DefaultAudioVideoFacade(
         audioVideoController.startLocalVideo()
     }
 
+    override fun startLocalVideo(config: LocalVideoConfiguration) {
+        audioVideoController.startLocalVideo(config)
+    }
+
     override fun startLocalVideo(source: VideoSource) {
         audioVideoController.startLocalVideo(source)
+    }
+
+    override fun startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
+        audioVideoController.startLocalVideo(source, config)
     }
 
     override fun stopLocalVideo() {
@@ -239,6 +248,10 @@ class DefaultAudioVideoFacade(
 
     override fun startContentShare(source: ContentShareSource) {
         contentShareController.startContentShare(source)
+    }
+
+    override fun startContentShare(source: ContentShareSource, config: LocalVideoConfiguration) {
+        contentShareController.startContentShare(source, config)
     }
 
     override fun stopContentShare() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/ContentShareController.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
 
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 
 /**
@@ -30,6 +31,24 @@ interface ContentShareController {
      * @param source: [ContentShareSource] - The source of content to be shared.
      */
     fun startContentShare(source: ContentShareSource)
+
+    /**
+     * Start sharing the content of a given [ContentShareSource] with configuration.
+     *
+     * Once sharing has started successfully, [ContentShareObserver.onContentShareStarted] will
+     * be invoked. If sharing fails or stops, [ContentShareObserver.onContentShareStopped]
+     * will be invoked with [ContentShareStatus] as the cause.
+     *
+     * This will call [VideoSource.addVideoSink] on the provided source
+     * and [VideoSource.removeVideoSink] on the previously provided source.
+     *
+     * Calling this function repeatedly will replace the previous [ContentShareSource] as the one being
+     * transmitted, will update the content share configuration, e.g. maxBitRateKbps.
+     *
+     * @param source: [ContentShareSource] - The source of content to be shared.
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startContentShare(source: ContentShareSource, config: LocalVideoConfiguration)
 
     /**
      * Stop sharing the content of a [ContentShareSource] that previously started.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/contentshare/DefaultContentShareController.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare
 
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.contentshare.ContentShareVideoClientController
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 
@@ -18,6 +19,12 @@ class DefaultContentShareController(
     override fun startContentShare(source: ContentShareSource) {
         source.videoSource?.let {
             contentShareVideoClientController.startVideoShare(it)
+        }
+    }
+
+    override fun startContentShare(source: ContentShareSource, config: LocalVideoConfiguration) {
+        source.videoSource?.let {
+            contentShareVideoClientController.startVideoShare(it, config)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/LocalVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/LocalVideoConfiguration.kt
@@ -3,9 +3,12 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 /**
  * Contains configuration for a local video or content share to be sent
  *
- * @property maxBitRateKbps: UInt - The max bit rate for video encoding, should be greater than 0
+ * @property maxBitRateKbps: Int - The max bit rate for video encoding, should be greater than 0
  * Actual quality achieved may vary throughout the call depending on what system and network can provide
  */
-data class LocalVideoConfiguration(
-    val maxBitRateKbps: UInt = 0U
-)
+data class LocalVideoConfiguration @JvmOverloads constructor(
+    private val maxBitRateKbps: Int = 0
+) {
+    val safeMaxBitRateKbps: Int
+    get() = if (maxBitRateKbps < 0) 0 else maxBitRateKbps
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/LocalVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/LocalVideoConfiguration.kt
@@ -1,0 +1,11 @@
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
+
+/**
+ * Contains configuration for a local video or content share to be sent
+ *
+ * @property maxBitRateKbps: UInt - The max bit rate for video encoding, should be greater than 0
+ * Actual quality achieved may vary throughout the call depending on what system and network can provide
+ */
+data class LocalVideoConfiguration(
+    val maxBitRateKbps: UInt = 0U
+)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/ContentShareVideoClientController.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.contentshare
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 
@@ -25,6 +26,20 @@ interface ContentShareVideoClientController {
      * @param videoSource: [VideoSource] - The source of video frames to be sent to other clients.
      */
     fun startVideoShare(videoSource: VideoSource)
+
+    /**
+     * Start to share video with configuration and a provided custom [VideoSource] which can be
+     * used to provide custom [VideoFrame]s to be transmitted to remote clients.
+     * This will call [VideoSource.addVideoSink] on the provided source
+     * and [VideoSource.removeVideoSink] on the previously provided source.
+     *
+     * Calling this function repeatedly will replace the previous [VideoSource] as the one being
+     * transmitted, will update the content share configuration, e.g. maxBitRateKbps.
+     *
+     * @param videoSource: [VideoSource] - The source of video frames to be sent to other clients.
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startVideoShare(videoSource: VideoSource, config: LocalVideoConfiguration)
 
     /**
      * Stop sending video to remote clients.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
@@ -48,6 +49,11 @@ class DefaultContentShareVideoClientController(
     private val VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS = 1 shl 26
 
     override fun startVideoShare(videoSource: VideoSource) {
+        val localVideoConfig = LocalVideoConfiguration()
+        startVideoShare(videoSource, localVideoConfig)
+    }
+
+    override fun startVideoShare(videoSource: VideoSource, config: LocalVideoConfiguration) {
         // Start the given content share source
         if (eglCore == null) {
             logger.debug(TAG, "Creating EGL core")
@@ -78,6 +84,9 @@ class DefaultContentShareVideoClientController(
         logger.debug(TAG, "Setting sending to true")
         videoClient?.setSending(true)
         isSharing = true
+        config.maxBitRateKbps.toInt().let {
+            if (it > 0) videoClient?.setMaxBitRateKbps(it)
+        }
     }
 
     private fun initializeVideoClient() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -49,8 +49,7 @@ class DefaultContentShareVideoClientController(
     private val VIDEO_CLIENT_FLAG_ENABLE_INBAND_TURN_CREDS = 1 shl 26
 
     override fun startVideoShare(videoSource: VideoSource) {
-        val localVideoConfig = LocalVideoConfiguration()
-        startVideoShare(videoSource, localVideoConfig)
+        startVideoShare(videoSource, LocalVideoConfiguration())
     }
 
     override fun startVideoShare(videoSource: VideoSource, config: LocalVideoConfiguration) {
@@ -84,7 +83,7 @@ class DefaultContentShareVideoClientController(
         logger.debug(TAG, "Setting sending to true")
         videoClient?.setSending(true)
         isSharing = true
-        config.maxBitRateKbps.toInt().let {
+        config.safeMaxBitRateKbps.let {
             if (it > 0) videoClient?.setMaxBitRateKbps(it)
         }
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.video
 import android.content.Context
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -105,6 +106,11 @@ class DefaultVideoClientController(
     }
 
     override fun startLocalVideo() {
+        val config = LocalVideoConfiguration()
+        startLocalVideo(config)
+    }
+
+    override fun startLocalVideo(config: LocalVideoConfiguration) {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
         videoSourceAdapter.source = cameraCaptureSource
@@ -114,9 +120,17 @@ class DefaultVideoClientController(
 
         cameraCaptureSource.start()
         isUsingInternalCaptureSource = true
+        config.maxBitRateKbps.toInt().let {
+            if (it > 0) videoClient?.setMaxBitRateKbps(it)
+        }
     }
 
     override fun startLocalVideo(source: VideoSource) {
+        val config = LocalVideoConfiguration()
+        startLocalVideo(source, config)
+    }
+
+    override fun startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
         if (!videoClientStateController.canAct(VideoClientState.INITIALIZED)) return
 
         stopInternalCaptureSourceIfRunning()
@@ -125,6 +139,9 @@ class DefaultVideoClientController(
         logger.info(TAG, "Setting external video source in media client to custom source")
         videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
         videoClient?.setSending(true)
+        config.maxBitRateKbps.toInt().let {
+            if (it > 0) videoClient?.setMaxBitRateKbps(it)
+        }
     }
 
     override fun stopLocalVideo() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -120,7 +120,7 @@ class DefaultVideoClientController(
 
         cameraCaptureSource.start()
         isUsingInternalCaptureSource = true
-        config.maxBitRateKbps.toInt().let {
+        config.safeMaxBitRateKbps.let {
             if (it > 0) videoClient?.setMaxBitRateKbps(it)
         }
     }
@@ -139,7 +139,7 @@ class DefaultVideoClientController(
         logger.info(TAG, "Setting external video source in media client to custom source")
         videoClient?.setExternalVideoSource(videoSourceAdapter, eglCore?.eglContext)
         videoClient?.setSending(true)
-        config.maxBitRateKbps.toInt().let {
+        config.safeMaxBitRateKbps.let {
             if (it > 0) videoClient?.setMaxBitRateKbps(it)
         }
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientController.kt
@@ -6,9 +6,12 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.video
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.DefaultCameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentials
@@ -39,6 +42,20 @@ interface VideoClientController {
     fun startLocalVideo()
 
     /**
+     * Start local video with configuration and begin transmitting frames from an internally held [DefaultCameraCaptureSource].
+     * [stopLocalVideo] will stop the internal capture source if being used.
+     *
+     * Calling this after passing in a custom [VideoSource] will replace it with the internal capture source.
+     *
+     * This function will only have effect if [start] has already been called.
+     * Calling this function repeatedly will update configuration of local video.
+     * If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+     *
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startLocalVideo(config: LocalVideoConfiguration)
+
+    /**
      * Start local video with a provided custom [VideoSource] which can be used to provide custom
      * [VideoFrame]s to be transmitted to remote clients. This will call [VideoSource.addVideoSink]
      * on the provided source.
@@ -52,6 +69,22 @@ interface VideoClientController {
      * @param source: [VideoSource] - The source of video frames to be sent to other clients
      */
     fun startLocalVideo(source: VideoSource)
+
+    /**
+     * Start local video with with configuration and a provided custom [VideoSource] which can be used to provide custom
+     * [VideoFrame] objects to be transmitted to remote clients
+     *
+     * Calling this function repeatedly will replace the previous [VideoSource] as the one being
+     * transmitted. It will update configuration of local video. It will also stop and replace the internal capture source
+     * if [startLocalVideo] was called with no arguments.
+     * If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+     *
+     * Read [custom video guide](https://github.com/aws/amazon-chime-sdk-android/blob/master/guides/custom_video.md) for details.
+     *
+     * @param source: [VideoSource] - The source of video frames to be sent to other clients
+     * @param config: [LocalVideoConfiguration] - The configuration of emitted video stream, e.g. maxBitRateKbps
+     */
+    fun startLocalVideo(source: VideoSource, config: LocalVideoConfiguration)
 
     /**
      * Stops sending video for local attendee. This will additionally stop the internal capture source if being used.

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -9,6 +9,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -60,6 +61,7 @@ class DefaultAudioVideoControllerTest {
         MeetingSessionCredentials(attendeeId, externalUserId, joinToken),
         MeetingSessionURLs(audioFallbackURL, audioHostURL, turnControlURL, signalingURL, ::defaultUrlRewriter)
     )
+    private val localVideoConfig = LocalVideoConfiguration()
 
     @MockK
     private lateinit var audioClientObserver: AudioClientObserver
@@ -88,7 +90,7 @@ class DefaultAudioVideoControllerTest {
     private lateinit var mockTimer: Timer
 
     @MockK
-    private lateinit var videoSource: VideoSource
+    private lateinit var mockVideoSource: VideoSource
 
     @ExperimentalCoroutinesApi
     private val testDispatcher = TestCoroutineDispatcher()
@@ -306,10 +308,24 @@ class DefaultAudioVideoControllerTest {
     }
 
     @Test
-    fun `startLocalVideo should call videoClientController startLocalVideo with given video source`() {
-        audioVideoController.startLocalVideo(videoSource)
+    fun `startLocalVideo should call videoClientController startLocalVideo with given video config)`() {
+        audioVideoController.startLocalVideo(localVideoConfig)
 
-        verify { videoClientController.startLocalVideo(videoSource) }
+        verify { videoClientController.startLocalVideo(localVideoConfig) }
+    }
+
+    @Test
+    fun `startLocalVideo should call videoClientController startLocalVideo with given video source`() {
+        audioVideoController.startLocalVideo(mockVideoSource)
+
+        verify { videoClientController.startLocalVideo(mockVideoSource) }
+    }
+
+    @Test
+    fun `startLocalVideo should call videoClientController startLocalVideo with given video source and config)`() {
+        audioVideoController.startLocalVideo(mockVideoSource, localVideoConfig)
+
+        verify { videoClientController.startLocalVideo(mockVideoSource, localVideoConfig) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -15,6 +15,8 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoTileController
 import com.amazonaws.services.chime.sdk.meetings.device.DeviceChangeObserver
 import com.amazonaws.services.chime.sdk.meetings.device.DeviceController
@@ -48,6 +50,7 @@ class DefaultAudioVideoFacadeTest {
     private val messageTopic = "topic"
     private val messageData = "data"
     private val messageLifetimeMs = 3000
+    private val localVideoConfig = LocalVideoConfiguration()
 
     @MockK
     private lateinit var mockAudioVideoObserver: AudioVideoObserver
@@ -96,6 +99,9 @@ class DefaultAudioVideoFacadeTest {
 
     @MockK
     private lateinit var contentShareController: ContentShareController
+
+    @MockK
+    private lateinit var mockVideoSource: VideoSource
 
     @InjectMockKs
     private lateinit var audioVideoFacade: DefaultAudioVideoFacade
@@ -294,6 +300,24 @@ class DefaultAudioVideoFacadeTest {
     fun `startLocalVideo should call audioVideoController startLocalVideo`() {
         audioVideoFacade.startLocalVideo()
         verify { audioVideoController.startLocalVideo() }
+    }
+
+    @Test
+    fun `startLocalVideo should call audioVideoController startLocalVideo with given video config`() {
+        audioVideoFacade.startLocalVideo(localVideoConfig)
+        verify { audioVideoController.startLocalVideo(localVideoConfig) }
+    }
+
+    @Test
+    fun `startLocalVideo should call audioVideoController startLocalVideo with given video source`() {
+        audioVideoFacade.startLocalVideo(mockVideoSource)
+        verify { audioVideoController.startLocalVideo(mockVideoSource) }
+    }
+
+    @Test
+    fun `startLocalVideo should call audioVideoController startLocalVideo with given video source and config)`() {
+        audioVideoFacade.startLocalVideo(mockVideoSource, localVideoConfig)
+        verify { audioVideoController.startLocalVideo(mockVideoSource, localVideoConfig) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
@@ -14,6 +14,7 @@ import android.os.Looper
 import android.util.Log
 import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.DefaultCameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
@@ -136,7 +137,7 @@ class DefaultVideoClientControllerTest {
     }
 
     @Test
-    fun `startLocalVideo without source should start camera capture and then video client`() {
+    fun `startLocalVideo should start camera capture and then video client`() {
         every { mockVideoClientStateController.canAct(any()) } returns true
 
         testVideoClientController.startLocalVideo()
@@ -147,7 +148,20 @@ class DefaultVideoClientControllerTest {
     }
 
     @Test
-    fun `startLocalVideo with source should not start camera capture and then video client`() {
+    fun `startLocalVideo should start camera capture and setMaxBitRateKbps with given video config`() {
+        every { mockVideoClientStateController.canAct(any()) } returns true
+        val localVideoConfig = LocalVideoConfiguration(600U)
+
+        testVideoClientController.startLocalVideo(localVideoConfig)
+
+        verify { anyConstructed<DefaultCameraCaptureSource>().start() }
+        verify { mockVideoClient.setExternalVideoSource(any(), any()) }
+        verify { mockVideoClient.setSending(true) }
+        verify { mockVideoClient.setMaxBitRateKbps(600) }
+    }
+
+    @Test
+    fun `startLocalVideo should not start camera capture and then video client`() {
         every { mockVideoClientStateController.canAct(any()) } returns true
 
         testVideoClientController.startLocalVideo(mockVideoSource)
@@ -155,6 +169,19 @@ class DefaultVideoClientControllerTest {
         verify(exactly = 0) { anyConstructed<DefaultCameraCaptureSource>().start() }
         verify { mockVideoClient.setExternalVideoSource(any(), any()) }
         verify { mockVideoClient.setSending(true) }
+    }
+
+    @Test
+    fun `startLocalVideo should not start camera capture and setMaxBitRateKbps with given video config`() {
+        every { mockVideoClientStateController.canAct(any()) } returns true
+        val localVideoConfig = LocalVideoConfiguration(600U)
+
+        testVideoClientController.startLocalVideo(mockVideoSource, localVideoConfig)
+
+        verify(exactly = 0) { anyConstructed<DefaultCameraCaptureSource>().start() }
+        verify { mockVideoClient.setExternalVideoSource(any(), any()) }
+        verify { mockVideoClient.setSending(true) }
+        verify { mockVideoClient.setMaxBitRateKbps(600) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientControllerTest.kt
@@ -150,7 +150,7 @@ class DefaultVideoClientControllerTest {
     @Test
     fun `startLocalVideo should start camera capture and setMaxBitRateKbps with given video config`() {
         every { mockVideoClientStateController.canAct(any()) } returns true
-        val localVideoConfig = LocalVideoConfiguration(600U)
+        val localVideoConfig = LocalVideoConfiguration(600)
 
         testVideoClientController.startLocalVideo(localVideoConfig)
 
@@ -174,7 +174,7 @@ class DefaultVideoClientControllerTest {
     @Test
     fun `startLocalVideo should not start camera capture and setMaxBitRateKbps with given video config`() {
         every { mockVideoClientStateController.canAct(any()) } returns true
-        val localVideoConfig = LocalVideoConfiguration(600U)
+        val localVideoConfig = LocalVideoConfiguration(600)
 
         testVideoClientController.startLocalVideo(mockVideoSource, localVideoConfig)
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -268,7 +268,7 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
         videoFormats.clear()
 
         val filteredFormats = freshVideoCaptureFormatList.filter {
-            it.height <= MAX_VIDEO_FORMAT_HEIGHT
+            it.height <= MAX_VIDEO_FORMAT_HEIGHT &&
             it.maxFps <= MAX_VIDEO_FORMAT_FPS
         }
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1114,7 +1114,7 @@ class MeetingFragment : Fragment(),
 
         videoConfigDialogBuilder.setView(maxBitRateInput)
         videoConfigDialogBuilder.setPositiveButton("Done", DialogInterface.OnClickListener { dialog, which ->
-            meetingModel.localVideoMaxBitRateKbps = maxBitRateInput.text.toString().toUIntOrNull() ?: 0U
+            meetingModel.localVideoMaxBitRateKbps = maxBitRateInput.text.toString().toIntOrNull() ?: 0
             // If local video is started, restart
             if (meetingModel.isLocalVideoStarted) {
                 startLocalVideo()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -9,6 +9,7 @@ import android.app.Activity
 import android.app.AlertDialog
 import android.content.ComponentName
 import android.content.Context
+import android.content.DialogInterface
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.pm.PackageManager
@@ -18,6 +19,7 @@ import android.os.Handler
 import android.os.IBinder
 import android.os.Looper
 import android.os.PowerManager
+import android.text.InputType
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -57,6 +59,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.ObservableMetric
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPriority
@@ -608,7 +611,8 @@ class MeetingFragment : Fragment(),
             context?.getString(if (cameraCaptureSource.torchEnabled) R.string.disable_flashlight else R.string.enable_flashlight),
             context?.getString(if (meetingModel.isUsingCpuVideoProcessor) R.string.disable_cpu_filter else R.string.enable_cpu_filter),
             context?.getString(if (meetingModel.isUsingGpuVideoProcessor) R.string.disable_gpu_filter else R.string.enable_gpu_filter),
-            context?.getString(if (meetingModel.isUsingCameraCaptureSource) R.string.disable_custom_capture_source else R.string.enable_custom_capture_source)
+            context?.getString(if (meetingModel.isUsingCameraCaptureSource) R.string.disable_custom_capture_source else R.string.enable_custom_capture_source),
+            context?.getString(R.string.video_configuration)
         )
         if (inReplicaMeeting()) {
             additionalToggles.add(context?.getString(R.string.demote_from_primary_meeting))
@@ -624,7 +628,8 @@ class MeetingFragment : Fragment(),
                 3 -> toggleCpuDemoFilter()
                 4 -> toggleGpuDemoFilter()
                 5 -> toggleCustomCaptureSource()
-                6 -> { // May not be accessible
+                6 -> presentVideoConfigDialog()
+                7 -> { // May not be accessible
                     if (inReplicaMeeting()) {
                         demoteFromPrimaryMeeting()
                     } else {
@@ -1099,6 +1104,25 @@ class MeetingFragment : Fragment(),
         }
     }
 
+    private fun presentVideoConfigDialog() {
+        val videoConfigDialogBuilder = AlertDialog.Builder(activity)
+        videoConfigDialogBuilder.setTitle(R.string.video_configuration)
+
+        val maxBitRateInput = EditText(activity)
+        maxBitRateInput.setHint(getString(R.string.video_max_bit_rate_hint))
+        maxBitRateInput.inputType = InputType.TYPE_CLASS_NUMBER
+
+        videoConfigDialogBuilder.setView(maxBitRateInput)
+        videoConfigDialogBuilder.setPositiveButton("Done", DialogInterface.OnClickListener { dialog, which ->
+            meetingModel.localVideoMaxBitRateKbps = maxBitRateInput.text.toString().toUIntOrNull() ?: 0U
+            // If local video is started, restart
+            if (meetingModel.isLocalVideoStarted) {
+                startLocalVideo()
+            }
+        })
+        videoConfigDialogBuilder.show()
+    }
+
     private fun refreshNoVideosOrScreenShareAvailableText() {
         if (meetingModel.tabIndex == SubTab.Video.position) {
             if (meetingModel.videoStatesInCurrentPage.isNotEmpty()) {
@@ -1121,25 +1145,26 @@ class MeetingFragment : Fragment(),
 
     private fun startLocalVideo() {
         meetingModel.isLocalVideoStarted = true
+        val localVideoConfig = LocalVideoConfiguration(meetingModel.localVideoMaxBitRateKbps)
         if (meetingModel.isUsingCameraCaptureSource) {
             if (meetingModel.isUsingGpuVideoProcessor) {
                 cameraCaptureSource.addVideoSink(gpuVideoProcessor)
-                audioVideo.startLocalVideo(gpuVideoProcessor)
+                audioVideo.startLocalVideo(gpuVideoProcessor, localVideoConfig)
             } else if (meetingModel.isUsingCpuVideoProcessor) {
                 cameraCaptureSource.addVideoSink(cpuVideoProcessor)
-                audioVideo.startLocalVideo(cpuVideoProcessor)
+                audioVideo.startLocalVideo(cpuVideoProcessor, localVideoConfig)
             } else if (meetingModel.isUsingBackgroundBlur) {
                 cameraCaptureSource.addVideoSink(backgroundBlurVideoFrameProcessor)
-                audioVideo.startLocalVideo(backgroundBlurVideoFrameProcessor)
+                audioVideo.startLocalVideo(backgroundBlurVideoFrameProcessor, localVideoConfig)
             } else if (meetingModel.isUsingBackgroundReplacement) {
                 cameraCaptureSource.addVideoSink(backgroundReplacementVideoFrameProcessor)
-                audioVideo.startLocalVideo(backgroundReplacementVideoFrameProcessor)
+                audioVideo.startLocalVideo(backgroundReplacementVideoFrameProcessor, localVideoConfig)
             } else {
-                audioVideo.startLocalVideo(cameraCaptureSource)
+                audioVideo.startLocalVideo(cameraCaptureSource, localVideoConfig)
             }
             cameraCaptureSource.start()
         } else {
-            audioVideo.startLocalVideo()
+            audioVideo.startLocalVideo(localVideoConfig)
         }
         buttonCamera.setImageResource(R.drawable.button_camera_on)
     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -53,7 +53,7 @@ class MeetingModel : ViewModel() {
     var isUsingCpuVideoProcessor = false
     var isUsingBackgroundBlur = false
     var isUsingBackgroundReplacement = false
-    var localVideoMaxBitRateKbps = 0U
+    var localVideoMaxBitRateKbps = 0
 
     fun updateVideoStatesInCurrentPage() {
         videoStatesInCurrentPage.clear()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -53,6 +53,7 @@ class MeetingModel : ViewModel() {
     var isUsingCpuVideoProcessor = false
     var isUsingBackgroundBlur = false
     var isUsingBackgroundReplacement = false
+    var localVideoMaxBitRateKbps = 0U
 
     fun updateVideoStatesInCurrentPage() {
         videoStatesInCurrentPage.clear()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="video_device_spinner">Video Device Spinner</string>
     <string name="video_format_title">Video Format</string>
     <string name="video_format_spinner">Video Format Spinner</string>
+    <string name="video_max_bit_rate_hint">Video Max Bit Rate in kbps</string>
     <string name="video_preview_title">Video Preview</string>
     <string name="video_preview_view">Video Preview View</string>
     <string name="meeting_join">Join</string>
@@ -99,6 +100,7 @@
     <string name="disable_background_blur">Turn off background blur</string>
     <string name="enable_background_replacement">Turn on background replacement</string>
     <string name="disable_background_replacement">Turn off background replacement</string>
+    <string name="video_configuration">Video Configuration</string>
 
     <!-- Alert -->
     <string name="cancel">Cancel</string>

--- a/guides/api_overview.md
+++ b/guides/api_overview.md
@@ -174,6 +174,10 @@ Video permissions are required for sending the local attendee's video.
 
 To start sending the local attendee's video, call meetingSession.audioVideo.[startLocalVideo()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-audio-video-controller-facade/start-local-video.html).
 
+To start sending video with a local video configuration, call meetingSession.audioVideo.startLocalVideo(config).
+
+To start sending video with a provided custom `VideoSource`, call meetingSession.audioVideo.startLocalVideo(source). 
+
 To stop sending the local attendee's video, call meetingSession.audioVideo.[stopLocalVideo()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-audio-video-controller-facade/stop-local-video.html).
 
 ### 8b. Getting and switching video device

--- a/guides/content_share.md
+++ b/guides/content_share.md
@@ -90,6 +90,12 @@ audioVideo.startContentShare(contentShareSource)
 audioVideo.stopContentShare()
 ```
 
+Additionally, you can set configuration for content share, e.g. maxBitRateKbps. Actual quality achieved may vary throughout the call depending on what system and network can provide.
+```kotlin
+val contentShareConfig = LocalVideoConfiguration(200)
+meetingSession.audioVideo.startContentShare(contentShareSource, contentShareConfig)
+```
+
 Note that the content share APIs do not manage the source and only provide a sink to transmit captured frames to remote participants, builders will be responsible to take care of its lifecycle including stopping and releasing the capture sources internal resources.
 
 ### Receiving content share events


### PR DESCRIPTION
## ℹ️ Description
Provide a way to configure video send encoding parameters when start local video and content share.

### Issue #, if available
Chime-48548

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [x] guildes update
- [x] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Start local video and content share with different maxBitRateKbps values, verified the metrics videoSendBitrate is closed to the maxBitRateKbps value.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available

![video_config1](https://user-images.githubusercontent.com/60948810/182975317-106d2bd3-aabb-4394-bdc4-e4b3c5685eb1.jpg)
![video_config2](https://user-images.githubusercontent.com/60948810/182975322-fb24bf03-7644-4491-9663-c0b54d5dffc8.jpg)
![video_config3](https://user-images.githubusercontent.com/60948810/182975327-425675c3-3ae7-425f-a8c5-056f377aacbc.jpg)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
