### PR TITLE
Add global lock for egl related operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unrelease
+
+### Fixed
+* Fixed crash from openGL due to potential race condition.
+
 ## [0.17.1] - 2022-06-03
 
 ## [0.17.0] - 2022-05-18

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/DefaultEglCoreFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/gl/DefaultEglCoreFactory.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl
 
 import android.opengl.EGL14
 import android.opengl.EGLContext
+import com.amazonaws.services.chime.sdk.meetings.internal.video.gl.ShareEglLock
 import com.amazonaws.services.chime.sdk.meetings.utils.RefCountDelegate
 
 /**
@@ -15,12 +16,11 @@ import com.amazonaws.services.chime.sdk.meetings.utils.RefCountDelegate
  */
 class DefaultEglCoreFactory(private var sharedContext: EGLContext = EGL14.EGL_NO_CONTEXT) :
     EglCoreFactory {
-    private var rootEglCoreLock = Any()
     private var rootEglCore: EglCore? = null
     private var refCountDelegate: RefCountDelegate? = null
 
     override fun createEglCore(): EglCore {
-        synchronized(rootEglCoreLock) {
+        synchronized(ShareEglLock.Lock) {
             if (rootEglCore == null && sharedContext == EGL14.EGL_NO_CONTEXT) {
                 refCountDelegate = RefCountDelegate(Runnable { release() })
                 rootEglCore = DefaultEglCore().also {
@@ -38,7 +38,7 @@ class DefaultEglCoreFactory(private var sharedContext: EGLContext = EGL14.EGL_NO
     }
 
     private fun release() {
-        synchronized(rootEglCoreLock) {
+        synchronized(ShareEglLock.Lock) {
             if (rootEglCore != null) {
                 rootEglCore?.release()
                 rootEglCore = null

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/ShareEglLock.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/ShareEglLock.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.video.gl
+
+/**
+ * [ShareEglLock] is to synchronizes the EGL operations. The main motivation is to avoid crashes
+ * due to missing frames during rendering from race condition.
+ */
+class ShareEglLock {
+    companion object {
+        val Lock = object {}
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -8,6 +8,9 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientObserver
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
@@ -82,6 +85,9 @@ class DefaultAudioVideoControllerTest {
 
     @MockK
     private lateinit var mockTimer: Timer
+
+    @MockK
+    private lateinit var videoSource: VideoSource
 
     @ExperimentalCoroutinesApi
     private val testDispatcher = TestCoroutineDispatcher()
@@ -292,6 +298,13 @@ class DefaultAudioVideoControllerTest {
     }
 
     @Test
+    fun `startLocalVideo should call videoClientController startLocalVideo with given video source`() {
+        audioVideoController.startLocalVideo(videoSource)
+
+        verify { videoClientController.startLocalVideo(videoSource) }
+    }
+
+    @Test
     fun `stopLocalVideo should call videoClientController stopLocalVideo`() {
         audioVideoController.stopLocalVideo()
 
@@ -310,6 +323,16 @@ class DefaultAudioVideoControllerTest {
         audioVideoController.stopRemoteVideo()
 
         verify { videoClientController.stopRemoteVideo() }
+    }
+
+    @Test
+    fun `updateVideoSourceSubscriptions should call videoClientController updateVideoSourceSubscriptions`() {
+        val addedOrUpdated = emptyMap<RemoteVideoSource, VideoSubscriptionConfiguration>()
+        val removed = emptyArray<RemoteVideoSource>()
+
+        audioVideoController.updateVideoSourceSubscriptions(addedOrUpdated, removed)
+
+        verify { videoClientController.updateVideoSourceSubscriptions(addedOrUpdated, removed) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglCoreFactoryTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglCoreFactoryTest.kt
@@ -1,0 +1,66 @@
+package com.amazonaws.services.chime.sdk.meetings.internal.video.gl
+
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.DefaultEglCore
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.DefaultEglCoreFactory
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
+import com.amazonaws.services.chime.sdk.meetings.utils.RefCountDelegate
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.slot
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+class DefaultEglCoreFactoryTest {
+    @MockK
+    private lateinit var mockDisplay: EGLDisplay
+
+    @MockK
+    private lateinit var mockContext: EGLContext
+
+    @MockK
+    private var rootEglCore: EglCore? = null
+
+    @MockK
+    private lateinit var mockConfig: EGLConfig
+
+    @MockK
+    private lateinit var mockDefaultEglCore: DefaultEglCore
+
+    @MockK
+    private var refCountDelegate: RefCountDelegate? = null
+
+    @InjectMockKs
+    private lateinit var factory: DefaultEglCoreFactory
+
+    @Before
+    fun setUp() {
+        mockkStatic(EGL14::class)
+        mockkConstructor(DefaultEglCore::class)
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY) } returns mockDisplay
+        every { EGL14.eglInitialize(any(), any(), any(), any(), any()) } returns true
+        every { EGL14.eglQueryContext(any(), any(), any(), any(), any()) } returns true
+        val slot = slot<Array<EGLConfig>>()
+        every { EGL14.eglChooseConfig(any(), any(), any(), capture(slot), any(), any(), any(), any()) } answers {
+            slot.captured[0] = mockConfig
+            true
+        }
+        factory = DefaultEglCoreFactory(mockContext)
+    }
+
+    @Test
+    fun `createEglCore should create rootEglCore`() {
+        factory.createEglCore()
+
+        assertNotNull(rootEglCore)
+    }
+}


### PR DESCRIPTION
## ℹ️ Description
To fix crash that inside the openGL library when rendering the video frame, which potentially caused by race condition.
This fix synchronizes creating, rendering and destroying frames.

### Issue #, if available
Chime-50246

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
Trigger local video / screen share on and off repeatedly.
Verified by the reported builders.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
