### PR TITLE
Demo content share

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -474,7 +474,6 @@ class MeetingFragment : Fragment(),
                     unsubscribeAllRemoteVideos()
                     setVideoSurfaceViewsVisibility(View.GONE)
                 } else if (tab?.position == SubTab.Screen.position) {
-                    pauseAllContentShares()
                     setScreenSurfaceViewsVisibility(View.GONE)
                 }
             }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -514,7 +514,6 @@ class MeetingFragment : Fragment(),
             SubTab.Screen.position -> {
                 recyclerViewScreenShareCollection.visibility = View.VISIBLE
                 setScreenSurfaceViewsVisibility(View.VISIBLE)
-                resumeAllContentSharesExceptUserPausedVideos()
             }
             SubTab.Captions.position -> {
                 recyclerViewCaptions.visibility = View.VISIBLE
@@ -1309,15 +1308,6 @@ class MeetingFragment : Fragment(),
         audioVideo.updateVideoSourceSubscriptions(updatedSources, emptyArray())
     }
 
-    private fun resumeAllContentSharesExceptUserPausedVideos() {
-        meetingModel.currentScreenTiles.forEach {
-            if (!meetingModel.userPausedVideoTileIds.contains(it.videoTileState.tileId) && it.videoTileState.pauseState == VideoPauseState.PausedByUserRequest) {
-                subscribeRemoteVideoByTileState(it.videoTileState)
-                audioVideo.resumeRemoteVideoTile(it.videoTileState.tileId)
-            }
-        }
-    }
-
     private fun subscribeRemoteVideoByTileState(tileSate: VideoTileState) {
         val updatedSources: MutableMap<RemoteVideoSource, VideoSubscriptionConfiguration> =
             mutableMapOf()
@@ -1484,6 +1474,10 @@ class MeetingFragment : Fragment(),
         if (tileState.isContent) {
             meetingModel.currentScreenTiles.add(videoCollectionTile)
             screenTileAdapter.notifyDataSetChanged()
+            meetingModel.currentScreenTiles.forEach {
+                subscribeRemoteVideoByTileState(it.videoTileState)
+                audioVideo.resumeRemoteVideoTile(it.videoTileState.tileId)
+            }
 
             // Currently not in the Screen tab, no need to render the video tile
             if (meetingModel.tabIndex != SubTab.Screen.position) {


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*
Fix the issue that the content share is not available when a JSUser joint after mobile app user.
Call the upadteVideoSourceSubscription() to subscribe to the content share video when it has been added.

### Issue #, if available
WTBugs-27334

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
