### PR TITLE
increase max fps to 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Changed
+* Changed `listSupportedVideoCaptureFormats` to find max fps from device
+
 ## [0.17.3] - 2022-07-14
 
 ## [0.17.2] - 2022-06-17

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -41,7 +41,6 @@ import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import kotlin.math.abs
-import kotlin.math.min
 import kotlinx.coroutines.Runnable
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
@@ -87,8 +86,7 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
 
     override val contentHint = VideoContentHint.Motion
 
-    private val MAX_INTERNAL_SUPPORTED_FPS = 15
-    private val DESIRED_CAPTURE_FORMAT = VideoCaptureFormat(960, 720, MAX_INTERNAL_SUPPORTED_FPS)
+    private val DESIRED_CAPTURE_FORMAT = VideoCaptureFormat(960, 720, 30)
     private val ROTATION_360_DEGREES = 360
 
     private val TAG = "DefaultCameraCaptureSource"
@@ -169,15 +167,7 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
                 return
             }
 
-            if (value.maxFps > MAX_INTERNAL_SUPPORTED_FPS) {
-                logger.info(TAG, "Limiting capture to 15 FPS to avoid frame drops")
-            }
-            field = VideoCaptureFormat(
-                value.width, value.height, min(
-                    value.maxFps,
-                    MAX_INTERNAL_SUPPORTED_FPS
-                )
-            )
+            field = VideoCaptureFormat(value.width, value.height, value.maxFps)
 
             // Restart capture if already running (i.e. we have a valid surface texture source)
             surfaceTextureSource?.let {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDeviceTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDeviceTest.kt
@@ -5,14 +5,10 @@
 
 package com.amazonaws.services.chime.sdk.meetings.device
 
-import android.graphics.SurfaceTexture
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CameraMetadata
-import android.hardware.camera2.params.StreamConfigurationMap
 import android.media.AudioDeviceInfo
-import android.util.Size
-import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.VideoCaptureFormat
 import io.mockk.MockKAnnotations
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -34,15 +30,6 @@ class MediaDeviceTest {
 
     @MockK
     private lateinit var mockOtherCameraCharacteristics: CameraCharacteristics
-
-    @MockK
-    private lateinit var mockStreamMap: StreamConfigurationMap
-
-    @MockK
-    private lateinit var mockSize1: Size
-
-    @MockK
-    private lateinit var mockSize2: Size
 
     @Before
     fun setUp() {
@@ -112,26 +99,5 @@ class MediaDeviceTest {
         assertEquals(devices[0].type, MediaDeviceType.VIDEO_FRONT_CAMERA)
         assertEquals(devices[1].type, MediaDeviceType.VIDEO_BACK_CAMERA)
         assertEquals(devices[2].type, MediaDeviceType.OTHER)
-    }
-
-    @Test
-    fun `listSupportedVideoCaptureFormats converts from formats provided from CameraManager`() {
-        every { mockCameraManager.getCameraCharacteristics("0") } returns mockFrontCameraCharacteristics
-        every { mockFrontCameraCharacteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP) } returns mockStreamMap
-        every { mockStreamMap.getOutputSizes(SurfaceTexture::class.java) } returns arrayOf(mockSize1, mockSize2)
-        every { mockStreamMap.getOutputMinFrameDuration(SurfaceTexture::class.java, any()) } returns (1.0e9 / 15).toLong()
-        every { mockSize1.width } returns 1
-        every { mockSize1.height } returns 2
-        every { mockSize2.width } returns 3
-        every { mockSize2.height } returns 4
-
-        val formats = MediaDevice.listSupportedVideoCaptureFormats(
-                mockCameraManager,
-                MediaDevice("testLabel", MediaDeviceType.VIDEO_FRONT_CAMERA, "0")
-        )
-
-        assertEquals(formats.size, 2)
-        assertEquals(VideoCaptureFormat(1, 2, 15), formats[0])
-        assertEquals(VideoCaptureFormat(3, 4, 15), formats[1])
     }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -68,7 +68,7 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
     private val VIDEO_FORMAT_SPINNER_INDEX_KEY = "videoFormatSpinnerIndex"
 
     private val MAX_VIDEO_FORMAT_HEIGHT = 800
-    private val MAX_VIDEO_FORMAT_FPS = 15
+    private val MAX_VIDEO_FORMAT_FPS = 30
 
     companion object {
         fun newInstance(meetingId: String, name: String, audioVideoConfig: AudioVideoConfiguration): DeviceManagementFragment {
@@ -267,11 +267,13 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
     private fun populateVideoFormatList(freshVideoCaptureFormatList: List<VideoCaptureFormat>) {
         videoFormats.clear()
 
-        val filteredFormats = freshVideoCaptureFormatList.filter { it.height <= MAX_VIDEO_FORMAT_HEIGHT }
+        val filteredFormats = freshVideoCaptureFormatList.filter {
+            it.height <= MAX_VIDEO_FORMAT_HEIGHT
+            it.maxFps <= MAX_VIDEO_FORMAT_FPS
+        }
 
         for (format in filteredFormats) {
-            // AmazonChimeSDKMedia library doesn't yet support 30FPS so anything above will lead to frame drops
-            videoFormats.add(VideoCaptureFormat(format.width, format.height, MAX_VIDEO_FORMAT_FPS))
+            videoFormats.add(VideoCaptureFormat(format.width, format.height, format.maxFps))
         }
         videoFormatArrayAdapter.notifyDataSetChanged()
     }


### PR DESCRIPTION
## ℹ️ Description
bridge parity gap with js sdk by allowing 30 fps

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
ran demo app with 1920 x 1080 @ 30 and observing videoSendFps metric around 30

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
