### PR TITLE
Make mutable set thread safe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.iml
 .gradle
-/local.properties
-/.idea
+local.properties
+.idea
 .DS_Store
 /build
 /captures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+### Fixed
+* Use thread safe mutableSet for observers
+
 ## [0.17.4] - 2022-07-28
 
 ### Changed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.analytics
 
 import com.amazonaws.services.chime.sdk.meetings.ingestion.EventReporter
 import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.SDKEvent
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.EventAttributesUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionConfiguration
@@ -19,7 +20,7 @@ class DefaultEventAnalyticsController(
     private val meetingStatsCollector: MeetingStatsCollector,
     private val eventReporter: EventReporter? = null
 ) : EventAnalyticsController {
-    private var eventAnalyticsObservers: MutableSet<EventAnalyticsObserver> = mutableSetOf()
+    private var eventAnalyticsObservers = ConcurrentSet.createConcurrentSet<EventAnalyticsObserver>()
 
     override fun publishEvent(name: EventName, attributes: EventAttributes?) {
         val now = Calendar.getInstance().timeInMillis

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/DefaultVideoTileController.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglVideoRenderView
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientController
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
@@ -25,7 +26,7 @@ class DefaultVideoTileController(
     private val renderViewToBoundVideoTileMap = mutableMapOf<VideoRenderView, VideoTile>()
     private val TAG = "DefaultVideoTileController"
 
-    private var videoTileObservers = mutableSetOf<VideoTileObserver>()
+    private var videoTileObservers = ConcurrentSet.createConcurrentSet<VideoTileObserver>()
 
     override fun onReceiveFrame(
         frame: VideoFrame?,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -78,7 +78,7 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
     // create a new one
     private var surfaceTextureSource: SurfaceTextureCaptureSource? = null
 
-    private val observers = mutableSetOf<CaptureSourceObserver>()
+    private val observers = ConcurrentSet.createConcurrentSet<CaptureSourceObserver>()
 
     // Concurrency modification could happen when sink gets
     // added/removed from another thread while sending frames

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -22,6 +22,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEventNa
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientState
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.DefaultAudioClientController
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientController
 import com.xodee.client.audio.audioclient.AudioClient
@@ -34,7 +35,7 @@ class DefaultDeviceController(
     private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
     private val buildVersion: Int = Build.VERSION.SDK_INT
 ) : DeviceController {
-    private val deviceChangeObservers = mutableSetOf<DeviceChangeObserver>()
+    private val deviceChangeObservers = ConcurrentSet.createConcurrentSet<DeviceChangeObserver>()
 
     // TODO: remove code blocks for lower API level after the minimum SDK version becomes 23
     private val AUDIO_MANAGER_API_LEVEL = 23

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -30,6 +30,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeUpdate
 import com.amazonaws.services.chime.sdk.meetings.internal.AttendeeStatus
 import com.amazonaws.services.chime.sdk.meetings.internal.SessionStateControllerAction
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
@@ -67,9 +68,9 @@ class DefaultAudioClientObserver(
     private var currentAudioState = SessionStateControllerAction.Init
     private var currentAudioStatus: MeetingSessionStatusCode? = MeetingSessionStatusCode.OK
 
-    private var audioClientStateObservers = mutableSetOf<AudioVideoObserver>()
-    private var realtimeEventObservers = mutableSetOf<RealtimeObserver>()
-    private var transcriptEventObservers = mutableSetOf<TranscriptEventObserver>()
+    private var audioClientStateObservers = ConcurrentSet.createConcurrentSet<AudioVideoObserver>()
+    private var realtimeEventObservers = ConcurrentSet.createConcurrentSet<RealtimeObserver>()
+    private var transcriptEventObservers = ConcurrentSet.createConcurrentSet<TranscriptEventObserver>()
 
     /**
      * Volume state change can be used to figure out the meeting's current attendees.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -13,6 +13,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCore
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.gl.EglCoreFactory
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientFactory
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoSourceAdapter
@@ -30,7 +31,7 @@ class DefaultContentShareVideoClientController(
     private val videoClientFactory: VideoClientFactory,
     private val eglCoreFactory: EglCoreFactory
 ) : ContentShareVideoClientController {
-    private val observers = mutableSetOf<ContentShareObserver>()
+    private val observers = ConcurrentSet.createConcurrentSet<ContentShareObserver>()
     private val videoSourceAdapter = VideoSourceAdapter()
     private var videoClient: VideoClient? = null
     private var eglCore: EglCore? = null

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientObserver.kt
@@ -10,6 +10,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.ContentShareStatusCode
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.DNSServerUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.TURNRequestUtils
@@ -33,7 +34,7 @@ class DefaultContentShareVideoClientObserver(
 ) : ContentShareVideoClientObserver {
     private val TAG = "DefaultContentShareVideoClientObserver"
 
-    private val contentShareObservers = mutableSetOf<ContentShareObserver>()
+    private val contentShareObservers = ConcurrentSet.createConcurrentSet<ContentShareObserver>()
 
     private val uiScope = CoroutineScope(Dispatchers.Main)
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollector.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollector.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.metric
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.ObservableMetric
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.xodee.client.audio.audioclient.AudioClient
 import com.xodee.client.video.VideoClient
@@ -18,7 +19,7 @@ import java.util.Calendar
  */
 class DefaultClientMetricsCollector :
     ClientMetricsCollector {
-    private var metricsObservers = mutableSetOf<MetricsObserver>()
+    private var metricsObservers = ConcurrentSet.createConcurrentSet<MetricsObserver>()
     private var cachedObservableMetrics = mutableMapOf<ObservableMetric, Double?>()
     private var lastEmittedMetricsTime = Calendar.getInstance().timeInMillis
     private val METRICS_EMISSION_INTERVAL_MS = 1000

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -17,6 +17,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFr
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameI420Buffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
 import com.amazonaws.services.chime.sdk.meetings.internal.metric.ClientMetricsCollector
+import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.DNSServerUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.TURNRequestUtils
@@ -48,12 +49,12 @@ class DefaultVideoClientObserver(
 ) : VideoClientObserver {
     private val TAG = "DefaultVideoClientObserver"
 
-    private var videoClientStateObservers = mutableSetOf<AudioVideoObserver>()
-    private var videoClientTileObservers = mutableSetOf<VideoTileController>()
+    private var videoClientStateObservers = ConcurrentSet.createConcurrentSet<AudioVideoObserver>()
+    private var videoClientTileObservers = ConcurrentSet.createConcurrentSet<VideoTileController>()
     private var dataMessageObserversByTopic = mutableMapOf<String, MutableSet<DataMessageObserver>>()
     // We have designed the SDK API to allow using `RemoteVideoSource` as a key in a map, e.g. for  `updateVideoSourceSubscription`.
     // Therefore we need to map to a consistent set of sources from the internal sources, by using attendeeId as a unique identifier.
-    private var cachedRemoveVideoSources = mutableSetOf<RemoteVideoSource>()
+    private var cachedRemoveVideoSources = ConcurrentSet.createConcurrentSet<RemoteVideoSource>()
 
     override var primaryMeetingPromotionObserver: PrimaryMeetingPromotionObserver? = null
 


### PR DESCRIPTION
## ℹ️ Description
https://github.com/aws/amazon-chime-sdk-android/issues/488
https://github.com/aws/amazon-chime-sdk-android/issues/419

Changed mutable set of observers to thread safe.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Unit test

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
