### PR TITLE
Prevent DefaultMeetingEventBufer.processDirtyEvents() from crashing when dirty events are malformed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+### Fixed
+* Gracefully deserialize malformed ingestion events JSON data in local database to prevent crashes.
+
 ## [0.17.5] - 2022-08-12
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventBuffer.kt
@@ -139,13 +139,14 @@ class DefaultMeetingEventBuffer @JvmOverloads constructor(
             // 2. If failed to send, check ttl and delete
             // 3. If succeeded, remove dirtyEvents
 
-            var dirtyEvents =
-                dirtyEventDao.listDirtyMeetingEventItems(ingestionConfiguration.flushSize)
-            var ingestionRecord =
-                IngestionEventConverter.fromDirtyMeetingEventItems(dirtyEvents, ingestionConfiguration)
-
-            var isSentSuccessful = true
             try {
+                var dirtyEvents =
+                    dirtyEventDao.listDirtyMeetingEventItems(ingestionConfiguration.flushSize)
+                var ingestionRecord =
+                    IngestionEventConverter.fromDirtyMeetingEventItems(dirtyEvents, ingestionConfiguration)
+
+                var isSentSuccessful = true
+
                 while (ingestionRecord.events.isNotEmpty() && isSentSuccessful) {
                     isSentSuccessful = eventSender.sendRecord(ingestionRecord)
                     // Find the ids that will be removed based on success status

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactory.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.ingestion
 
 import android.content.Context
+import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.EventTypeConverters
 import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.DirtyEventSQLiteDao
 import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.EventSQLiteDao
 import com.amazonaws.services.chime.sdk.meetings.internal.ingestion.database.SQLiteDatabaseManager
@@ -29,15 +30,21 @@ class DefaultMeetingEventReporterFactory(
                 context,
                 logger
             )
+
+        val eventTypeConverter = EventTypeConverters(logger)
+
         val eventDao =
             EventSQLiteDao(
                 sqliteManager,
-                logger
+                logger,
+                eventTypeConverter
             )
+
         val dirtyEventDao =
             DirtyEventSQLiteDao(
                 sqliteManager,
-                logger
+                logger,
+                eventTypeConverter
             )
 
         val eventBuffer = DefaultMeetingEventBuffer(

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConverters.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConverters.kt
@@ -5,13 +5,48 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
 
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializer
+import com.google.gson.reflect.TypeToken
 
 /**
  * EventTypeConverters facilitate the conversion on some common event types
  */
-object EventTypeConverters {
-    val gson = Gson()
+class EventTypeConverters(private val logger: Logger) {
+    private val TAG = "EventTypeConverters"
+    private val gson: Gson
+
+    init {
+        val deserializer: JsonDeserializer<SDKEvent> =
+            JsonDeserializer { json, _, _ ->
+                val jsonObject = json.asJsonObject
+
+                var name = ""
+                var eventAttributes: EventAttributes? = null
+
+                try {
+                    name = jsonObject["name"].asString
+                } catch (exception: Exception) {
+                    logger.error(TAG, "Unable to deserialize name $exception")
+                }
+
+                try {
+                    val eventAttributeType = object : TypeToken<EventAttributes>() {}.type
+                    eventAttributes = Gson().fromJson(jsonObject["eventAttributes"], eventAttributeType)
+                } catch (exception: Exception) {
+                    logger.error(TAG, "Unable to deserialize eventAttributes $exception")
+                }
+                SDKEvent(name, eventAttributes ?: mutableMapOf())
+            }
+
+        val gsonBuilder = GsonBuilder()
+        gsonBuilder.registerTypeAdapter(SDKEvent::class.java, deserializer)
+        gson = gsonBuilder.create()
+    }
+
     fun toMeetingEvent(data: String): SDKEvent = gson.fromJson(data, SDKEvent::class.java)
     fun fromMeetingEvent(event: SDKEvent): String = gson.toJson(event)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -138,7 +138,7 @@ object IngestionEventConverter {
     private fun toIngestionPayload(event: MeetingEventItem): IngestionPayload {
         val payload = mutableMapOf(
             NAME_KEY to event.data.name,
-            TIMESTAMP_KEY to (event.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
+            TIMESTAMP_KEY to (event.data.eventAttributes[EventAttributeName.timestampMs] as? Double ?: 0.0).toLong(),
             ID_KEY to event.id
         )
         // Filter out meeting id and attendee id since this is not needed for payload
@@ -154,7 +154,7 @@ object IngestionEventConverter {
         val payload = mutableMapOf(
             NAME_KEY to dirtyEvent.data.name,
             TTL_KEY to dirtyEvent.ttl,
-            TIMESTAMP_KEY to (dirtyEvent.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
+            TIMESTAMP_KEY to (dirtyEvent.data.eventAttributes[EventAttributeName.timestampMs] as? Double ?: 0.0).toLong(),
             ID_KEY to dirtyEvent.id
         )
         dirtyEvent.data.eventAttributes.filterNot { attributesToFilter.contains(it.key) }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/IngestionEventConverter.kt
@@ -138,7 +138,7 @@ object IngestionEventConverter {
     private fun toIngestionPayload(event: MeetingEventItem): IngestionPayload {
         val payload = mutableMapOf(
             NAME_KEY to event.data.name,
-            TIMESTAMP_KEY to (event.data.eventAttributes[EventAttributeName.timestampMs] as? Double ?: 0.0).toLong(),
+            TIMESTAMP_KEY to (event.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
             ID_KEY to event.id
         )
         // Filter out meeting id and attendee id since this is not needed for payload
@@ -154,7 +154,7 @@ object IngestionEventConverter {
         val payload = mutableMapOf(
             NAME_KEY to dirtyEvent.data.name,
             TTL_KEY to dirtyEvent.ttl,
-            TIMESTAMP_KEY to (dirtyEvent.data.eventAttributes[EventAttributeName.timestampMs] as? Double ?: 0.0).toLong(),
+            TIMESTAMP_KEY to (dirtyEvent.data.eventAttributes[EventAttributeName.timestampMs] as Double).toLong(),
             ID_KEY to dirtyEvent.id
         )
         dirtyEvent.data.eventAttributes.filterNot { attributesToFilter.contains(it.key) }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/SDKEvent.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/SDKEvent.kt
@@ -9,16 +9,10 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributes
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEventName
 
-class SDKEvent {
-    val name: String
+class SDKEvent(
+    val name: String,
     val eventAttributes: EventAttributes
-
-    constructor(eventName: EventName, eventAttributes: EventAttributes) {
-        this.name = eventName.name
-        this.eventAttributes = eventAttributes
-    }
-    constructor(eventName: MeetingHistoryEventName, eventAttributes: EventAttributes) {
-        this.name = eventName.name
-        this.eventAttributes = eventAttributes
-    }
+) {
+    constructor(eventName: EventName, eventAttributes: EventAttributes) : this(eventName.name, eventAttributes)
+    constructor(eventName: MeetingHistoryEventName, eventAttributes: EventAttributes) : this(eventName.name, eventAttributes)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DirtyEventSQLiteDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/DirtyEventSQLiteDao.kt
@@ -13,7 +13,8 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 
 class DirtyEventSQLiteDao(
     private val databaseManager: DatabaseManager,
-    private val logger: Logger
+    private val logger: Logger,
+    private val eventTypeConverter: EventTypeConverters
 ) : DirtyEventDao, DatabaseTable {
     override val tableName = "DirtyEvents"
     override val columns: Map<String, String>
@@ -38,7 +39,7 @@ class DirtyEventSQLiteDao(
         return retrievedDataList.map { retrievedData ->
             DirtyMeetingEventItem(
                 retrievedData[idColumnName] as String,
-                EventTypeConverters.toMeetingEvent(retrievedData[dataColumnName] as String),
+                eventTypeConverter.toMeetingEvent(retrievedData[dataColumnName] as String),
                 retrievedData[ttlColumnName] as Long
             )
         }
@@ -52,7 +53,7 @@ class DirtyEventSQLiteDao(
         return databaseManager.insert(tableName, dirtyEvents.map { dirtyEvent ->
             ContentValues().apply {
                 put(idColumnName, dirtyEvent.id)
-                put(dataColumnName, EventTypeConverters.fromMeetingEvent(dirtyEvent.data))
+                put(dataColumnName, eventTypeConverter.fromMeetingEvent(dirtyEvent.data))
                 put(ttlColumnName, dirtyEvent.ttl)
             }
         })

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/EventSQLiteDao.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/database/EventSQLiteDao.kt
@@ -13,7 +13,8 @@ import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 
 class EventSQLiteDao(
     private val databaseManager: DatabaseManager,
-    private val logger: Logger
+    private val logger: Logger,
+    private val eventTypeConverter: EventTypeConverters
 ) : EventDao, DatabaseTable {
     override val tableName = "Events"
     override val columns: Map<String, String>
@@ -39,7 +40,7 @@ class EventSQLiteDao(
         return retrievedDataList.map { retrievedData ->
             MeetingEventItem(
                 retrievedData[idColumnName] as String,
-                EventTypeConverters.toMeetingEvent(retrievedData[dataColumnName] as String)
+                eventTypeConverter.toMeetingEvent(retrievedData[dataColumnName] as String)
             )
         }
     }
@@ -47,7 +48,7 @@ class EventSQLiteDao(
     override fun insertMeetingEvent(event: MeetingEventItem): Boolean {
         val values = ContentValues().apply {
             put(idColumnName, event.id)
-            put(dataColumnName, EventTypeConverters.fromMeetingEvent(event.data))
+            put(dataColumnName, eventTypeConverter.fromMeetingEvent(event.data))
         }
 
         return databaseManager.insert(tableName, listOf(values))

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactoryTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/ingestion/DefaultMeetingEventReporterFactoryTest.kt
@@ -1,0 +1,44 @@
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+import android.content.Context
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+
+class DefaultMeetingEventReporterFactoryTest {
+
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var ingestionConfiguration: IngestionConfiguration
+
+    @MockK
+    private lateinit var logger: Logger
+
+    private lateinit var factory: DefaultMeetingEventReporterFactory
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        every { ingestionConfiguration.ingestionUrl } returns "http://test.com/"
+        every { ingestionConfiguration.flushIntervalMs } returns 1L
+
+        factory = DefaultMeetingEventReporterFactory(context, ingestionConfiguration, logger)
+    }
+
+    @Test
+    fun `createEventReporter should return EventReporter`() {
+
+        every { ingestionConfiguration.disabled } returns false
+
+        val reporter = factory.createEventReporter()
+
+        assertNotNull(reporter)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventSQLiteDaoTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/DirtyEventSQLiteDaoTests.kt
@@ -32,6 +32,9 @@ class DirtyEventSQLiteDaoTests {
     @MockK
     private lateinit var logger: Logger
 
+    @MockK
+    private lateinit var eventTypeConverter: EventTypeConverters
+
     private val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
 
     private val mockEvent = SDKEvent(
@@ -58,8 +61,10 @@ class DirtyEventSQLiteDaoTests {
                 "ttl" to 1242312412424
             )
         )
+        every { eventTypeConverter.fromMeetingEvent(any()) } returns ""
+        every { eventTypeConverter.toMeetingEvent(any()) } returns mockEvent
 
-        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger)
+        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger, eventTypeConverter)
     }
 
     @Test
@@ -117,7 +122,7 @@ class DirtyEventSQLiteDaoTests {
 
     @Test
     fun `constructor should invoke database manager createTable`() {
-        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger)
+        dirtyEventDao = DirtyEventSQLiteDao(databaseManager, logger, eventTypeConverter)
 
         verify { databaseManager.createTable(dirtyEventDao) }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventSQLiteDaoTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventSQLiteDaoTests.kt
@@ -32,6 +32,9 @@ class EventSQLiteDaoTests {
     @MockK
     private lateinit var logger: Logger
 
+    @MockK
+    private lateinit var eventTypeConverter: EventTypeConverters
+
     private val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
 
     private val mockEvent = SDKEvent(
@@ -57,11 +60,14 @@ class EventSQLiteDaoTests {
                 "data" to gson.toJson(mockEvent)
             )
         )
+        every { eventTypeConverter.fromMeetingEvent(any()) } returns ""
+        every { eventTypeConverter.toMeetingEvent(any()) } returns mockEvent
 
         eventDao =
             EventSQLiteDao(
                 databaseManager,
-                logger
+                logger,
+                eventTypeConverter
             )
     }
 
@@ -113,7 +119,8 @@ class EventSQLiteDaoTests {
         eventDao =
             EventSQLiteDao(
                 databaseManager,
-                logger
+                logger,
+                eventTypeConverter
             )
 
         verify { databaseManager.createTable(eventDao) }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConvertersTests.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/ingestion/EventTypeConvertersTests.kt
@@ -1,0 +1,101 @@
+package com.amazonaws.services.chime.sdk.meetings.internal.ingestion
+
+import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class EventTypeConvertersTests {
+
+    private lateinit var eventTypeConverters: EventTypeConverters
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        eventTypeConverters = EventTypeConverters(logger)
+    }
+
+    @Test
+    fun `toMeetingEvent should convert json string to object`() {
+
+        val nameValue = "test name"
+        val deviceNameKey = EventAttributeName.deviceName.toString()
+        val deviceNameValue = "test device"
+        val tsKey = EventAttributeName.timestampMs.toString()
+        val tsValue = 1659759236803
+        val data = "{\"name\":\"$nameValue\", \"eventAttributes\":{\"$deviceNameKey\":\"$deviceNameValue\", \"$tsKey\":$tsValue}}"
+        val event = eventTypeConverters.toMeetingEvent(data)
+
+        assertEquals(event.name, nameValue)
+        assertEquals(event.eventAttributes[EventAttributeName.deviceName] as? String, deviceNameValue)
+        assertEquals((event.eventAttributes[EventAttributeName.timestampMs] as? Double ?: 0.0).toLong(), tsValue)
+    }
+
+    @Test
+    fun `toMeetingEvent should handle null name`() {
+
+        val data = "{\"name\":null, \"eventAttributes\":{}}"
+        val event = eventTypeConverters.toMeetingEvent(data)
+
+        assertEquals(event.name, "")
+    }
+
+    @Test
+    fun `toMeetingEvent should handle malformed name`() {
+
+        val data = "{\"name\":{}, \"eventAttributes\":{}}"
+        val event = eventTypeConverters.toMeetingEvent(data)
+
+        verify(exactly = 1) { logger.error(any(), any()) }
+
+        assertEquals(event.name, "")
+    }
+
+    @Test
+    fun `toMeetingEvent should handle null event attributes data`() {
+
+        val nameValue = "test name"
+        val data = "{\"name\":\"$nameValue\", \"eventAttributes\":null}"
+        val event = eventTypeConverters.toMeetingEvent(data)
+
+        assertEquals(event.eventAttributes.count(), 0)
+    }
+
+    @Test
+    fun `toMeetingEvent should handle malformed event attributes data`() {
+
+        val nameValue = "test name"
+        val data = "{\"name\":\"$nameValue\", \"eventAttributes\":\"invalid data\"}"
+        val event = eventTypeConverters.toMeetingEvent(data)
+
+        verify(exactly = 1) { logger.error(any(), any()) }
+
+        assertEquals(event.eventAttributes.count(), 0)
+    }
+
+    @Test
+    fun `fromMeetingEvent should convert object to json string`() {
+
+        val nameValue = "test name"
+        val deviceNameKey = EventAttributeName.deviceName.toString()
+        val deviceNameValue = "test device"
+        val tsKey = EventAttributeName.timestampMs.toString()
+        val tsValue = 1659759236803
+        val mockEvent = SDKEvent(nameValue, mutableMapOf(
+            EventAttributeName.deviceName to deviceNameValue,
+            EventAttributeName.timestampMs to tsValue
+        ))
+        val result = eventTypeConverters.fromMeetingEvent(mockEvent)
+
+        val jsonString = "{\"name\":\"test name\",\"eventAttributes\":{\"$deviceNameKey\":\"$deviceNameValue\",\"$tsKey\":$tsValue}}"
+        assertEquals(result, jsonString)
+    }
+}


### PR DESCRIPTION
## ℹ️ Description
When deserialize `SDKEvent` from local database using Gson,  the malformed `eventAttributes` data could cause `SDKEvent.eventAttributes` to be `null` even the attribute is `non-null`, and crash. A custom Gson deserializer is added for handling it.

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Started a meeting session, and faked and verified the malformed data can be gracefully handled without causing crashes.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
