### PR TITLE
fixed video capacity bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+* Fixed bugs that occured at video capacity
+* [Demo] Updated demo to use new functionality to prevent camera from toggling at video limit
+
 ## [0.17.6] - 2022-08-25
 
 ### Fixed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoObserver.kt
@@ -123,4 +123,11 @@ interface AudioVideoObserver {
      * @param sources: [List] - List of RemoteVideoSource objects.
      */
     fun onRemoteVideoSourceAvailable(sources: List<RemoteVideoSource>)
+
+    /**
+     * Called when video capacity status is added or removed.
+     *
+     * Note: this callback will be called on main thread.
+     */
+    fun onCameraSendAvailabilityUpdated(available: Boolean)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoObserver.kt
@@ -125,9 +125,11 @@ interface AudioVideoObserver {
     fun onRemoteVideoSourceAvailable(sources: List<RemoteVideoSource>)
 
     /**
-     * Called when video capacity status is added or removed.
+     * Called when video capacity status is updated.
      *
      * Note: this callback will be called on main thread.
+     *
+     * @param available: Boolean - True if camera send is available (video capacity status is false).
      */
     fun onCameraSendAvailabilityUpdated(available: Boolean)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserver.kt
@@ -119,6 +119,9 @@ class DefaultVideoClientObserver(
 
     override fun cameraSendIsAvailable(client: VideoClient?, available: Boolean) {
         logger.debug(TAG, "cameraSendIsAvailable: $available")
+        forEachVideoClientStateObserver {
+            it.onCameraSendAvailabilityUpdated(available)
+        }
     }
 
     override fun pauseRemoteVideo(client: VideoClient?, display_id: Int, pause: Boolean) {

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientObserverTest.kt
@@ -364,4 +364,18 @@ class DefaultVideoClientObserverTest {
         verify(exactly = 3) { mockDefaultUrlRewriter(any()) }
         assert(outUris.equals(turnUris))
     }
+
+    @Test
+    fun `cameraSendIsAvailable should notify onCameraSendAvailabilityUpdated of available is false`() {
+        testVideoClientObserver.cameraSendIsAvailable(mockVideoClient, false)
+
+        verify { mockAudioVideoObserver.onCameraSendAvailabilityUpdated(false) }
+    }
+
+    @Test
+    fun `cameraSendIsAvailable should notify onCameraSendAvailabilityUpdated of available is true`() {
+        testVideoClientObserver.cameraSendIsAvailable(mockVideoClient, true)
+
+        verify { mockAudioVideoObserver.onCameraSendAvailabilityUpdated(true) }
+    }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1144,29 +1144,34 @@ class MeetingFragment : Fragment(),
     }
 
     private fun startLocalVideo() {
-        meetingModel.isLocalVideoStarted = true
-        val localVideoConfig = LocalVideoConfiguration(meetingModel.localVideoMaxBitRateKbps)
-        if (meetingModel.isUsingCameraCaptureSource) {
-            if (meetingModel.isUsingGpuVideoProcessor) {
-                cameraCaptureSource.addVideoSink(gpuVideoProcessor)
-                audioVideo.startLocalVideo(gpuVideoProcessor, localVideoConfig)
-            } else if (meetingModel.isUsingCpuVideoProcessor) {
-                cameraCaptureSource.addVideoSink(cpuVideoProcessor)
-                audioVideo.startLocalVideo(cpuVideoProcessor, localVideoConfig)
-            } else if (meetingModel.isUsingBackgroundBlur) {
-                cameraCaptureSource.addVideoSink(backgroundBlurVideoFrameProcessor)
-                audioVideo.startLocalVideo(backgroundBlurVideoFrameProcessor, localVideoConfig)
-            } else if (meetingModel.isUsingBackgroundReplacement) {
-                cameraCaptureSource.addVideoSink(backgroundReplacementVideoFrameProcessor)
-                audioVideo.startLocalVideo(backgroundReplacementVideoFrameProcessor, localVideoConfig)
+        if (meetingModel.isCameraSendAvailable) {
+            meetingModel.isLocalVideoStarted = true
+            val localVideoConfig = LocalVideoConfiguration(meetingModel.localVideoMaxBitRateKbps)
+            if (meetingModel.isUsingCameraCaptureSource) {
+                if (meetingModel.isUsingGpuVideoProcessor) {
+                    cameraCaptureSource.addVideoSink(gpuVideoProcessor)
+                    audioVideo.startLocalVideo(gpuVideoProcessor, localVideoConfig)
+                } else if (meetingModel.isUsingCpuVideoProcessor) {
+                    cameraCaptureSource.addVideoSink(cpuVideoProcessor)
+                    audioVideo.startLocalVideo(cpuVideoProcessor, localVideoConfig)
+                } else if (meetingModel.isUsingBackgroundBlur) {
+                    cameraCaptureSource.addVideoSink(backgroundBlurVideoFrameProcessor)
+                    audioVideo.startLocalVideo(backgroundBlurVideoFrameProcessor, localVideoConfig)
+                } else if (meetingModel.isUsingBackgroundReplacement) {
+                    cameraCaptureSource.addVideoSink(backgroundReplacementVideoFrameProcessor)
+                    audioVideo.startLocalVideo(
+                        backgroundReplacementVideoFrameProcessor,
+                        localVideoConfig
+                    )
+                } else {
+                    audioVideo.startLocalVideo(cameraCaptureSource, localVideoConfig)
+                }
+                cameraCaptureSource.start()
             } else {
-                audioVideo.startLocalVideo(cameraCaptureSource, localVideoConfig)
+                audioVideo.startLocalVideo(localVideoConfig)
             }
-            cameraCaptureSource.start()
-        } else {
-            audioVideo.startLocalVideo(localVideoConfig)
+            buttonCamera.setImageResource(R.drawable.button_camera_on)
         }
-        buttonCamera.setImageResource(R.drawable.button_camera_on)
     }
 
     private fun stopLocalVideo() {
@@ -1621,6 +1626,20 @@ class MeetingFragment : Fragment(),
         logWithFunctionName(
             object {}.javaClass.enclosingMethod?.name,
             "${sessionStatus.statusCode}"
+        )
+    }
+
+    override fun onCameraSendAvailabilityUpdated(available: Boolean) {
+        if (available) {
+            meetingModel.isCameraSendAvailable = true
+        } else {
+            meetingModel.isCameraSendAvailable = false
+            notifyHandler("Currently cannot enable video in meeting")
+            refreshNoVideosOrScreenShareAvailableText()
+        }
+        logWithFunctionName(
+            object {}.javaClass.enclosingMethod?.name,
+            "Camera Send Available: $available"
         )
     }
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -54,6 +54,7 @@ class MeetingModel : ViewModel() {
     var isUsingBackgroundBlur = false
     var isUsingBackgroundReplacement = false
     var localVideoMaxBitRateKbps = 0
+    var isCameraSendAvailable = false
 
     fun updateVideoStatesInCurrentPage() {
         videoStatesInCurrentPage.clear()


### PR DESCRIPTION
## ℹ️ Description
Original Problems:
- If Android is sending video with local video on, and video capacity status is added, Android will stop sending video and turn off local video
- If Android is not sending video, and enables video, causing video capacity status to be added, Android will stop sending video and turn off local video
- In some cases at video limit, Android will turn on local video without actually sending video
- In some cases at video limit, Android will be unable to turn off local video

Many of these problems were fixed in an update to Media Client. These SDK changes expose an observer to allow the app to monitor capacity status. Demo app was also updated to prevent camera toggle button from enabling and local video from turning on when at video capacity.

### Issue #, if available
[#351 ](https://github.com/aws/amazon-chime-sdk-ios/issues/351)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Changes tested on both Android and iOS. This is the second step after a Media Client change that exposed cameraSendIsAvailable(). Video Capacity was 100. Used a Load Test to put 98 robots into a test meeting with their video turned on and opened two additional manual tabs on Chrome and entered the meeting on each mobile device separately.

Test cases:
Attempt to enable camera when current videos are already 100
Enable camera as 99th video participant, then add one more Chrome video participant
Enable camera as 100th video participant, then check that 101st participant is unable to enable camera
Check race condition by having 99 video participants, then simultaneously attempting to enable camera on Chrome and Mobile--repeat 10-20 times.
Test cases all pass.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
