### PR TITLE
Fix background blur rendering issue and rgba video memory issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Fixed
 * Fixed bugs that occured at video capacity
 * [Demo] Updated demo to use new functionality to prevent camera from toggling at video limit
+* Fixed background filtered video rendering before joining a meeting session
+* Fixed memory leak issue in rgba video rendering
 
 ## [0.17.6] - 2022-08-25
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/backgroundfilter/BackgroundFilterVideoFrameProcessor.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/backgroundfilter/BackgroundFilterVideoFrameProcessor.kt
@@ -131,6 +131,7 @@ class BackgroundFilterVideoFrameProcessor(
             filteredByteBuffer =
                 JniUtil.nativeAllocateByteBuffer(frame.getRotatedWidth() * frame.getRotatedHeight() * channels)
             filteredBitmap.copyPixelsToBuffer(filteredByteBuffer)
+            filteredByteBuffer.position(0)
         }
         val rgbaBuffer =
             VideoFrameRGBABuffer(

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultGlVideoFrameDrawer.kt
@@ -142,10 +142,9 @@ class DefaultGlVideoFrameDrawer() : GlVideoFrameDrawer {
                 copyBuffer = ByteBuffer.allocateDirect(copyCapacityNeeded)
             }
 
-            // Make sure YUV textures are allocated.
-            val textureId =
-                if (textureId == 0) GlUtil.generateTexture(GLES20.GL_TEXTURE_2D) else textureId
-
+            if (textureId == 0) {
+                textureId = GlUtil.generateTexture(GLES20.GL_TEXTURE_2D)
+            }
             GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
             GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId)
 


### PR DESCRIPTION
## ℹ️ Description

Demo change is for QA verification only, will revert before merge. Demo app will not be changed eventually. 

This PR fixes 2 issues:
1. Background video filters cannot be rendered in video view before joining the meeting session.
2. GRBA video rendering costs too much memory resources by accumulated graphics bitmap

### Issue #, if available
https://github.com/aws/amazon-chime-sdk-android/issues/504
https://github.com/aws/amazon-chime-sdk-android/issues/362


### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
