### PR TITLE
Fixed the remote video render delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* [Demo]Fixed the remote video render delay
+
 ## [0.17.9] - 2022-12-02
 
 ## [0.17.8] - 2022-11-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Fixed
-* [Demo]Fixed the remote video render delay
+* [Demo] Fixed the remote video render delay
 
 ## [0.17.9] - 2022-12-02
 

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/adapter/VideoAdapter.kt
@@ -215,15 +215,16 @@ class VideoHolder(
             }
 
             val updatedSource = mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
-            for (source in meetingModel.remoteVideoSourceConfigurations) {
+            for (source in meetingModel.getRemoteVideoSourceConfigurations()) {
                 if (source.key.attendeeId == attendeeId) {
                     val resolution: VideoResolution = source.value.targetResolution
-                    source.setValue(VideoSubscriptionConfiguration(priority, resolution))
+                    val config = VideoSubscriptionConfiguration(priority, resolution)
+                    meetingModel.setRemoteVideoSourceConfigurations(source.key, config)
                     updatedSource[source.key] = source.value
                 }
             }
             audioVideo.updateVideoSourceSubscriptions(
-                meetingModel.remoteVideoSourceConfigurations,
+                meetingModel.getRemoteVideoSourceConfigurations(),
                 emptyArray()
             )
             true
@@ -251,10 +252,11 @@ class VideoHolder(
             }
 
             val updatedSource = mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
-            for (source in meetingModel.remoteVideoSourceConfigurations) {
+            for (source in meetingModel.getRemoteVideoSourceConfigurations()) {
                 if (source.key.attendeeId == attendeeId) {
                     val priority: VideoPriority = source.value.priority
-                    source.setValue(VideoSubscriptionConfiguration(priority, resolution))
+                    val config = VideoSubscriptionConfiguration(priority, resolution)
+                    meetingModel.setRemoteVideoSourceConfigurations(source.key, config)
                     updatedSource[source.key] = source.value
                 }
             }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -92,7 +92,6 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionCredentia
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.DefaultModality
-import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.ConsoleLogger
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.LogLevel
 import com.amazonaws.services.chime.sdkdemo.R
@@ -121,6 +120,7 @@ import com.amazonaws.services.chime.sdkdemo.utils.GpuVideoProcessor
 import com.amazonaws.services.chime.sdkdemo.utils.PostLogger
 import com.amazonaws.services.chime.sdkdemo.utils.encodeURLParam
 import com.amazonaws.services.chime.sdkdemo.utils.formatTimestamp
+import com.amazonaws.services.chime.sdkdemo.utils.isContentShare
 import com.amazonaws.services.chime.sdkdemo.utils.isLandscapeMode
 import com.google.android.material.tabs.TabLayout
 import com.google.gson.Gson
@@ -485,7 +485,7 @@ class MeetingFragment : Fragment(),
 
     private fun setVideoSurfaceViewsVisibility(visibility: Int) {
         meetingModel.localVideoTileState?.setRenderViewVisibility(visibility)
-        meetingModel.remoteVideoTileStates.forEach { it.setRenderViewVisibility(visibility) }
+        meetingModel.getRemoteVideoTileStates().forEach { it.setRenderViewVisibility(visibility) }
     }
 
     private fun setScreenSurfaceViewsVisibility(visibility: Int) {
@@ -880,7 +880,7 @@ class MeetingFragment : Fragment(),
         uiScope.launch {
             mutex.withLock {
                 attendeeInfo.forEach { (attendeeId, externalUserId) ->
-                    if (DefaultModality(attendeeId).hasModality(ModalityType.Content) &&
+                    if (attendeeId.isContentShare() &&
                         !isSelfAttendee(attendeeId) &&
                         meetingModel.isSharingContent
                     ) {
@@ -914,7 +914,7 @@ class MeetingFragment : Fragment(),
         }
         val attendeeName = if (externalUserId.contains('#')) externalUserId.split('#')[1] else externalUserId
 
-        return if (DefaultModality(attendeeId).hasModality(ModalityType.Content)) {
+        return if (attendeeId.isContentShare()) {
             "$attendeeName $CONTENT_NAME_SUFFIX"
         } else {
             attendeeName
@@ -1272,7 +1272,7 @@ class MeetingFragment : Fragment(),
         oldList.addAll(meetingModel.videoStatesInCurrentPage)
         val potentialRemovedList: ArrayList<RemoteVideoSource> = arrayListOf()
         for (videoState in oldList) {
-            for ((key) in meetingModel.remoteVideoSourceConfigurations) {
+            for ((key) in meetingModel.getRemoteVideoSourceConfigurations()) {
                 if (videoState.videoTileState.attendeeId == key.attendeeId) {
                     potentialRemovedList.add(key)
                 }
@@ -1290,7 +1290,7 @@ class MeetingFragment : Fragment(),
         for (videoState in newList) {
             // This seems to be needed for demo application to show all tiles. Sometimes, it gets paused
             audioVideo.resumeRemoteVideoTile(videoState.videoTileState.tileId)
-            for ((key, value) in meetingModel.remoteVideoSourceConfigurations) {
+            for ((key, value) in meetingModel.getRemoteVideoSourceConfigurations()) {
                 if (videoState.videoTileState.attendeeId == key.attendeeId) {
                     updatedSources[key] = value
                 }
@@ -1324,24 +1324,14 @@ class MeetingFragment : Fragment(),
 
         revalidateVideoPageIndex()
 
-        val newList = mutableListOf<VideoCollectionTile>()
-        newList.addAll(meetingModel.videoStatesInCurrentPage)
-        val updatedSources: MutableMap<RemoteVideoSource, VideoSubscriptionConfiguration> =
-            mutableMapOf()
-        for (videoState in newList) {
-            for ((key, value) in meetingModel.remoteVideoSourceConfigurations) {
-                if (videoState.videoTileState.attendeeId == key.attendeeId) {
-                    updatedSources[key] = value
-                }
-            }
-        }
-        audioVideo.updateVideoSourceSubscriptions(updatedSources, emptyArray())
+        val videoSourcesInCurrentPage = meetingModel.getRemoteVideoSourcesInCurrentPage()
+        audioVideo.updateVideoSourceSubscriptions(videoSourcesInCurrentPage, emptyArray())
     }
 
     private fun subscribeRemoteVideoByTileState(tileSate: VideoTileState) {
         val updatedSources: MutableMap<RemoteVideoSource, VideoSubscriptionConfiguration> =
             mutableMapOf()
-        meetingModel.remoteVideoSourceConfigurations.forEach {
+        meetingModel.getRemoteVideoSourceConfigurations().forEach {
             if (it.key.attendeeId == tileSate.attendeeId) {
                 updatedSources[it.key] = it.value
             }
@@ -1351,7 +1341,7 @@ class MeetingFragment : Fragment(),
 
     private fun unsubscribeRemoteVideoByTileState(tileState: VideoTileState) {
         val removedList: ArrayList<RemoteVideoSource> = arrayListOf()
-        meetingModel.remoteVideoSourceConfigurations.forEach {
+        meetingModel.getRemoteVideoSourceConfigurations().forEach {
             if (it.key.attendeeId == tileState.attendeeId) {
                 removedList.add(it.key)
             }
@@ -1361,8 +1351,8 @@ class MeetingFragment : Fragment(),
 
     private fun unsubscribeAllRemoteVideos() {
         val removedList: ArrayList<RemoteVideoSource> = arrayListOf()
-        meetingModel.remoteVideoTileStates.forEach {
-            for ((key) in meetingModel.remoteVideoSourceConfigurations) {
+        meetingModel.getRemoteVideoTileStates().forEach {
+            for ((key) in meetingModel.getRemoteVideoSourceConfigurations()) {
                 if (key.attendeeId == it.videoTileState.attendeeId) {
                     removedList.add(key)
                 }
@@ -1519,7 +1509,7 @@ class MeetingFragment : Fragment(),
                 onVideoPageUpdated()
                 subscribeToRemoteVideosInCurrentPage()
             } else {
-                meetingModel.remoteVideoTileStates.add(videoCollectionTile)
+                meetingModel.addRemoteVideoTileState(videoCollectionTile)
                 onVideoPageUpdated()
                 subscribeToRemoteVideosInCurrentPage()
 
@@ -1654,15 +1644,24 @@ class MeetingFragment : Fragment(),
     }
 
     override fun onRemoteVideoSourceAvailable(sources: List<RemoteVideoSource>) {
+        // Note that the logic below is not needed unless managing video subscriptions by calling
+        // audioVideo.updateVideoSourceSubscriptions(addedOrUpdated, removed), please refer to the
+        // document for details: https://github.com/aws/amazon-chime-sdk-ios/blob/master/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift#L139
         for (source in sources) {
-            meetingModel.remoteVideoSourceConfigurations[source] =
-                VideoSubscriptionConfiguration(VideoPriority.Medium, VideoResolution.Medium)
+            val config = VideoSubscriptionConfiguration(VideoPriority.Medium, VideoResolution.Medium)
+            meetingModel.addVideoSource(source, config)
         }
-        // Use the default auto subscribe behavior
+        meetingModel.updateRemoteVideoSourceSelection()
+        meetingModel.updateRemoteVideoSourceSubscription(audioVideo)
     }
 
     override fun onRemoteVideoSourceUnavailable(sources: List<RemoteVideoSource>) {
-        sources.forEach { meetingModel.remoteVideoSourceConfigurations.remove(it) }
+        // Please note sources listed in `remoteVideoSourcesDidBecomeUnavailable` do not need to be
+        // removed(by calling AudioVideo.updateVideoSourceSubscriptions()), as they will be
+        // automatically unsubscribed in SDK.
+        logger.info(TAG, "test - onRemoteVideoSourceUnavailable called")
+        // The tracking sources still need to be removed in demo app
+        sources.forEach { meetingModel.removeVideoSource(it) }
     }
 
     override fun onVideoTileAdded(tileState: VideoTileState) {
@@ -1677,7 +1676,7 @@ class MeetingFragment : Fragment(),
             } else {
                 if (tileState.isLocalTile) {
                     showVideoTile(tileState)
-                } else if (meetingModel.remoteVideoTileStates.none { it.videoTileState.tileId == tileState.tileId }) {
+                } else if (meetingModel.getRemoteVideoTileStates().none { it.videoTileState.tileId == tileState.tileId }) {
                     showVideoTile(tileState)
                 }
             }
@@ -1699,11 +1698,9 @@ class MeetingFragment : Fragment(),
                 screenTileAdapter.notifyDataSetChanged()
             } else {
                 if (meetingModel.localVideoTileState?.videoTileState?.tileId == tileId) {
-                    meetingModel.remoteVideoTileStates.removeAll { it.videoTileState.tileId == tileId }
                     meetingModel.localVideoTileState = null
-                } else {
-                    meetingModel.remoteVideoTileStates.removeAll { it.videoTileState.tileId == tileId }
                 }
+                meetingModel.removeRemoteVideoTileState(tileId)
                 onVideoPageUpdated()
             }
             refreshNoVideosOrScreenShareAvailableText()
@@ -1728,7 +1725,7 @@ class MeetingFragment : Fragment(),
 
     override fun onVideoTileResumed(tileState: VideoTileState) {
         val collection =
-            if (tileState.isContent) meetingModel.currentScreenTiles else meetingModel.remoteVideoTileStates
+            if (tileState.isContent) meetingModel.currentScreenTiles else meetingModel.getRemoteVideoTileStates()
         collection.find { it.videoTileState.tileId == tileState.tileId }.apply {
             this?.setPauseMessageVisibility(View.INVISIBLE)
         }
@@ -1870,7 +1867,7 @@ class MeetingFragment : Fragment(),
         if (meetingModel.localVideoTileState != null) {
             audioVideo.unbindVideoView(meetingModel.localTileId)
         }
-        meetingModel.remoteVideoTileStates.forEach {
+        meetingModel.getRemoteVideoTileStates().forEach {
             audioVideo.unbindVideoView(it.videoTileState.tileId)
         }
         meetingModel.currentScreenTiles.forEach {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1644,9 +1644,6 @@ class MeetingFragment : Fragment(),
     }
 
     override fun onRemoteVideoSourceAvailable(sources: List<RemoteVideoSource>) {
-        // Note that the logic below is not needed unless managing video subscriptions by calling
-        // audioVideo.updateVideoSourceSubscriptions(addedOrUpdated, removed), please refer to the
-        // document for details: https://github.com/aws/amazon-chime-sdk-ios/blob/master/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift#L139
         for (source in sources) {
             val config = VideoSubscriptionConfiguration(VideoPriority.Medium, VideoResolution.Medium)
             meetingModel.addVideoSource(source, config)
@@ -1659,7 +1656,6 @@ class MeetingFragment : Fragment(),
         // Please note sources listed in `remoteVideoSourcesDidBecomeUnavailable` do not need to be
         // removed(by calling AudioVideo.updateVideoSourceSubscriptions()), as they will be
         // automatically unsubscribed in SDK.
-        logger.info(TAG, "test - onRemoteVideoSourceUnavailable called")
         // The tracking sources still need to be removed in demo app
         sources.forEach { meetingModel.removeVideoSource(it) }
     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -7,6 +7,7 @@ package com.amazonaws.services.chime.sdkdemo.model
 
 import androidx.lifecycle.ViewModel
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AttendeeInfo
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
@@ -15,6 +16,8 @@ import com.amazonaws.services.chime.sdkdemo.data.Message
 import com.amazonaws.services.chime.sdkdemo.data.MetricData
 import com.amazonaws.services.chime.sdkdemo.data.RosterAttendee
 import com.amazonaws.services.chime.sdkdemo.data.VideoCollectionTile
+import com.amazonaws.services.chime.sdkdemo.fragment.MeetingFragment
+import com.amazonaws.services.chime.sdkdemo.utils.isContentShare
 import kotlin.math.ceil
 import kotlin.math.min
 
@@ -26,9 +29,29 @@ class MeetingModel : ViewModel() {
     val currentMetrics = mutableMapOf<String, MetricData>()
     val currentRoster = mutableMapOf<String, RosterAttendee>()
     var localVideoTileState: VideoCollectionTile? = null
-    val remoteVideoTileStates = mutableListOf<VideoCollectionTile>()
-    val remoteVideoSourceConfigurations =
+    // Make it private to prevent consumers from manipulating it directly
+    // In order to access it, use getRemoteVideoTileStates()
+    private val remoteVideoTileStates = mutableListOf<VideoCollectionTile>()
+
+    // Make it private to prevent consumers from manipulating it directly
+    // In order to access it, use getRemoteVideoSourceConfigurations()
+    private val remoteVideoSourceConfigurations =
         mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
+
+    private val contentShareRemoteVideoSourceConfigurations =
+        mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
+
+    // Video sources without matching video tile state, they will be moved to
+    // remoteVideoSourceConfigurations once the matching video tile state is added
+    private val pendingVideoSourceConfigurations =
+        mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
+
+    private val videoSourcesToBeSubscribed =
+        mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
+
+    private val videoSourcesToBeUnsubscribed = mutableSetOf<RemoteVideoSource>()
+
+    // contains local video tile
     val videoStatesInCurrentPage = mutableListOf<VideoCollectionTile>()
     val userPausedVideoTileIds = mutableSetOf<Int>()
     val currentScreenTiles = mutableListOf<VideoCollectionTile>()
@@ -56,6 +79,28 @@ class MeetingModel : ViewModel() {
     var localVideoMaxBitRateKbps = 0
     var isCameraSendAvailable = false
 
+    fun getRemoteVideoTileStates(): List<VideoCollectionTile> {
+        return remoteVideoTileStates
+    }
+
+    // Add VideoTileState to remoteVideoTileStates, if there is matching video source
+    // in pendingVideoSourceConfigurations, move it to remoteVideoSourceConfigurations
+    fun addRemoteVideoTileState(state: VideoCollectionTile) {
+        remoteVideoTileStates.add(state)
+
+        // Move matching RemoteVideSource from pendingVideoSourceConfigurations
+        // to remoteVideoSourceConfigurations
+        val attendeeId = state.videoTileState.attendeeId
+        val movingVideoSources = pendingVideoSourceConfigurations
+            .filter { it.key.attendeeId == attendeeId }
+        movingVideoSources.forEach { pendingVideoSourceConfigurations.remove(it.key) }
+        remoteVideoSourceConfigurations.putAll(movingVideoSources)
+    }
+
+    fun removeRemoteVideoTileState(tileId: Int) {
+        remoteVideoTileStates.removeAll { it.videoTileState.tileId == tileId }
+    }
+
     fun updateVideoStatesInCurrentPage() {
         videoStatesInCurrentPage.clear()
 
@@ -70,6 +115,14 @@ class MeetingModel : ViewModel() {
         if (remoteVideoStartIndex <= remoteVideoEndIndex) {
             videoStatesInCurrentPage.addAll(remoteVideoTileStates.slice(remoteVideoStartIndex..remoteVideoEndIndex))
         }
+    }
+
+    fun getRemoteVideoSourceConfigurations(): Map<RemoteVideoSource, VideoSubscriptionConfiguration> {
+        return remoteVideoSourceConfigurations
+    }
+
+    fun setRemoteVideoSourceConfigurations(source: RemoteVideoSource, config: VideoSubscriptionConfiguration) {
+        remoteVideoSourceConfigurations[source] = config
     }
 
     fun updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: Array<AttendeeInfo>) {
@@ -100,5 +153,107 @@ class MeetingModel : ViewModel() {
         val maxVideoPageIndex =
             ceil(remoteVideoTileStates.size.toDouble() / remoteVideoTileCountPerPage).toInt() - 1
         return currentVideoPageIndex < maxVideoPageIndex
+    }
+
+    fun addVideoSource(source: RemoteVideoSource, config: VideoSubscriptionConfiguration) {
+        if (source.isContentShare()) {
+            contentShareRemoteVideoSourceConfigurations[source] = config
+        } else {
+            if (remoteVideoSourceConfigurations[source] == null) {
+                pendingVideoSourceConfigurations[source] = config
+            } else {
+                remoteVideoSourceConfigurations[source] = config
+            }
+        }
+    }
+
+    fun removeVideoSource(source: RemoteVideoSource) {
+        remoteVideoSourceConfigurations.remove(source)
+        pendingVideoSourceConfigurations.remove(source)
+        contentShareRemoteVideoSourceConfigurations.remove(source)
+    }
+
+    // A helper function for retrieving remote video sources in current page. It will retrieve
+    // video sources in remoteVideoSourceConfigurations based on videoStatesInCurrentPage, if
+    // videoStatesInCurrentPage.count() is smaller than videoTileCountPerPage and
+    // pendingVideoSourceConfigurations is not empty, it will retrieve
+    // (videoTileCountPerPage - videoStatesInCurrentPage.size) items from
+    // pendingVideoSourceConfigurations, and add to result
+    fun getRemoteVideoSourcesInCurrentPage(): Map<RemoteVideoSource, VideoSubscriptionConfiguration> {
+        val result = mutableMapOf<RemoteVideoSource, VideoSubscriptionConfiguration>()
+        // remote video sources in current page
+        result.putAll(getRemoteVideoSources(videoStatesInCurrentPage))
+
+        var numVideoSourcesFromPending = videoTileCountPerPage - videoStatesInCurrentPage.size
+        for (pendingVideoSourceEntry in pendingVideoSourceConfigurations.entries.iterator()) {
+            if (numVideoSourcesFromPending == 0) {
+                break
+            }
+            result[pendingVideoSourceEntry.key] = pendingVideoSourceEntry.value
+            numVideoSourcesFromPending--
+        }
+        return result
+    }
+
+    // A helper function for retrieving all remote video sources from
+    // remoteVideoSourceConfigurations which are not in current page
+    private fun remoteVideoSourcesNotInCurrentPage(): Set<RemoteVideoSource> {
+        val result = mutableSetOf<RemoteVideoSource>()
+        val attendeeIdsInCurrentPage = getRemoteVideoSourcesInCurrentPage()
+            .map { it.key.attendeeId }
+            .toHashSet()
+
+        for (remoteVideoSource in remoteVideoSourceConfigurations.keys) {
+            if (!attendeeIdsInCurrentPage.contains(remoteVideoSource.attendeeId)) {
+                result.add(remoteVideoSource)
+            }
+        }
+        return result
+    }
+
+    // Based on tabIndex, calculate the videos sources need to be:
+    //  - added/updated to subscription
+    //  - removed from subscription
+    // The results will be added to videoSourcesToBeSubscribed and videoSourcesToBeUnsubscribed
+    // respectively
+    fun updateRemoteVideoSourceSelection() {
+        when (tabIndex) {
+            MeetingFragment.SubTab.Video.position -> {
+                // If showing video screen, only subscribe the video sources on current video
+                // page index, unsubscribe the rest
+                videoSourcesToBeSubscribed.putAll(getRemoteVideoSourcesInCurrentPage())
+                videoSourcesToBeUnsubscribed.addAll(remoteVideoSourcesNotInCurrentPage())
+                videoSourcesToBeUnsubscribed.addAll(contentShareRemoteVideoSourceConfigurations.keys)
+            }
+            MeetingFragment.SubTab.Screen.position -> {
+                videoSourcesToBeSubscribed.putAll(contentShareRemoteVideoSourceConfigurations)
+                videoSourcesToBeUnsubscribed.addAll(remoteVideoSourceConfigurations.keys)
+            }
+            else -> {
+                videoSourcesToBeUnsubscribed.addAll(remoteVideoSourceConfigurations.keys)
+                videoSourcesToBeUnsubscribed.addAll(contentShareRemoteVideoSourceConfigurations.keys)
+            }
+        }
+    }
+
+    // Update video source subscription. `audioVideo` has to be passed from MeetingFragment
+    // into this function as a parameter for now, it should be moved to MeetingModel in the future
+    // for practicing MVVM pattern
+    fun updateRemoteVideoSourceSubscription(audioVideo: AudioVideoFacade) {
+        if (videoSourcesToBeSubscribed.isEmpty() && videoSourcesToBeUnsubscribed.isEmpty()) {
+            return
+        }
+        audioVideo.updateVideoSourceSubscriptions(videoSourcesToBeSubscribed,
+            videoSourcesToBeUnsubscribed.toTypedArray())
+        videoSourcesToBeSubscribed.clear()
+        videoSourcesToBeUnsubscribed.clear()
+    }
+
+    // A helper function for fetching remote video sources/config from
+    // remoteVideoSourceConfigurations based on attendee ID, given a list of video tiles,
+    private fun getRemoteVideoSources(videoTiles: List<VideoCollectionTile>):
+        Map<RemoteVideoSource, VideoSubscriptionConfiguration> {
+        val attendeeIds = videoTiles.map { it.videoTileState.attendeeId }.toHashSet()
+        return remoteVideoSourceConfigurations.filter { attendeeIds.contains(it.key.attendeeId) }
     }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -184,13 +184,13 @@ class MeetingModel : ViewModel() {
         // remote video sources in current page
         result.putAll(getRemoteVideoSources(videoStatesInCurrentPage))
 
-        var numVideoSourcesFromPending = videoTileCountPerPage - videoStatesInCurrentPage.size
+        var numVideoSourcesNeededFromPending = videoTileCountPerPage - videoStatesInCurrentPage.size
         for (pendingVideoSourceEntry in pendingVideoSourceConfigurations.entries.iterator()) {
-            if (numVideoSourcesFromPending == 0) {
+            if (numVideoSourcesNeededFromPending == 0) {
                 break
             }
             result[pendingVideoSourceEntry.key] = pendingVideoSourceEntry.value
-            numVideoSourcesFromPending--
+            numVideoSourcesNeededFromPending--
         }
         return result
     }
@@ -198,17 +198,8 @@ class MeetingModel : ViewModel() {
     // A helper function for retrieving all remote video sources from
     // remoteVideoSourceConfigurations which are not in current page
     private fun remoteVideoSourcesNotInCurrentPage(): Set<RemoteVideoSource> {
-        val result = mutableSetOf<RemoteVideoSource>()
-        val attendeeIdsInCurrentPage = getRemoteVideoSourcesInCurrentPage()
-            .map { it.key.attendeeId }
-            .toHashSet()
-
-        for (remoteVideoSource in remoteVideoSourceConfigurations.keys) {
-            if (!attendeeIdsInCurrentPage.contains(remoteVideoSource.attendeeId)) {
-                result.add(remoteVideoSource)
-            }
-        }
-        return result
+        val keysToRemove = getRemoteVideoSourcesInCurrentPage().keys
+        return remoteVideoSourceConfigurations.minus(keysToRemove).keys
     }
 
     // Based on tabIndex, calculate the videos sources need to be:

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/Extensions.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/utils/Extensions.kt
@@ -13,6 +13,9 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.utils.DefaultModality
+import com.amazonaws.services.chime.sdk.meetings.utils.ModalityType
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -35,4 +38,12 @@ fun isLandscapeMode(context: Context?): Boolean {
 
 fun formatTimestamp(timestamp: Long): String {
     return SimpleDateFormat("hh:mm:ss a").format(Date(timestamp))
+}
+
+fun String.isContentShare(): Boolean {
+    return DefaultModality(this).hasModality(ModalityType.Content)
+}
+
+fun RemoteVideoSource.isContentShare(): Boolean {
+    return this.attendeeId.isContentShare()
 }


### PR DESCRIPTION
## ℹ️ Description
* This is for fixing the remote video render delay in demo app.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
* Verified the same remote video render on Android and JS demo at the same time
* Verified 8 remote video tiles will paginate and render with no delay
* Verified remote video render when local video is on
* Verified remote video will render on join meeting.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
