### PR TITLE
Added additional MeetingSessionStatusCodes for Audio Input and Output Failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* Added additional session statuses for audio device I/O timeouts.
+
 ## [0.17.9] - 2022-12-02
 
 ## [0.17.8] - 2022-11-16

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -536,6 +536,8 @@ class DefaultAudioClientObserver(
             AudioClient.AUDIO_CLIENT_ERR_SERVICE_UNAVAILABLE -> MeetingSessionStatusCode.AudioServiceUnavailable
             AudioClient.AUDIO_CLIENT_ERR_SHOULD_DISCONNECT_AUDIO -> MeetingSessionStatusCode.AudioDisconnectAudio
             AudioClient.AUDIO_CLIENT_ERR_CALL_ENDED -> MeetingSessionStatusCode.AudioCallEnded
+            AudioClient.AUDIO_CLIENT_ERR_INPUT_DEVICE_NOT_RESPONDING -> MeetingSessionStatusCode.AudioInputDeviceNotResponding
+            AudioClient.AUDIO_CLIENT_ERR_OUTPUT_DEVICE_NOT_RESPONDING -> MeetingSessionStatusCode.AudioOutputDeviceNotResponding
             else -> null
         }
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionStatusCode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionStatusCode.kt
@@ -80,7 +80,17 @@ enum class MeetingSessionStatusCode(val value: Int) {
      * The video client has tried to send video but was unable to do so due to capacity reached.
      * However, the video client can still receive remote video streams.
      */
-    VideoAtCapacityViewOnly(13);
+    VideoAtCapacityViewOnly(13),
+
+    /**
+     * Designated output device is not responding and timed out.
+     */
+    AudioOutputDeviceNotResponding(14),
+
+    /**
+     * Designated input device is not responding and timed out.
+     */
+    AudioInputDeviceNotResponding(15);
 
     companion object {
         fun from(intValue: Int): MeetingSessionStatusCode? = values().find { it.value == intValue }


### PR DESCRIPTION
PR Created on behalf of @rnewhouse-amazon, who is the original author.

## ℹ️ Description
Added additional MeetingSessionStatusCodes of AudioOutputDeviceNotResponding(14) and AudioInputDeviceNotResponding(15) so as to provide more clarity to downstream consumers about what caused the AudioClient failure.

The Chime team was tracking incidents of AudioSessionStop callbacks with a null MeetingSessionStatusCode and traced the null MeetingSessionStatusCode to the following log event:
`AudioClient State raw value: 7 Unknown Status raw value: 82`
These were being triggered by a AudioClient failed state of `AudioClient.AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL` with an unknown status code of 82 which maps to `AUDIO_CLIENT_ERR_INPUT_DEVICE_NOT_RESPONDING`.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
