### PR TITLE
add codec selection API

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoControllerFacade.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -199,4 +200,18 @@ interface AudioVideoControllerFacade {
      * to revert UX, etc.
      */
     fun demoteFromPrimaryMeeting()
+
+    /**
+     * Set codec preferences for this clients send stream in order of most preferred to least preferred. The controller will
+     * fallback for one of two reasons
+     * - The codec is not supported by the browser
+     * - Another client that has joined the conference does not support receiving the video. Note that if another client does not support
+     *   any of the codecs provided the sender will not fallback, and that client will not be able to receive from this sender.
+     *
+     * If there is no overlap between what is passed in and what is supported by the browser, this function
+     * may not have any effect, and the default set of codecs for this browser will be used.
+     *
+     * @param videoCodecPreference list of VideoCodecCapability in order of preference
+     */
+    fun setVideoCodecSendPreferences(videoCodecPreference: List<VideoCodecPreference>)
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.audiovideo
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
@@ -204,5 +205,9 @@ class DefaultAudioVideoController(
         CoroutineScope(Dispatchers.Main).launch {
             primaryMeetingPromotionObserver?.onPrimaryMeetingDemotion(MeetingSessionStatus(MeetingSessionStatusCode.OK))
         }
+    }
+
+    override fun setVideoCodecSendPreferences(videoCodecPreference: List<VideoCodecPreference>) {
+        videoClientController.setVideoCodecSendPreferences(videoCodecPreference)
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -25,6 +25,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRenderView
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -144,6 +145,10 @@ class DefaultAudioVideoFacade(
     override fun demoteFromPrimaryMeeting() {
         contentShareController.stopContentShare()
         audioVideoController.demoteFromPrimaryMeeting()
+    }
+
+    override fun setVideoCodecSendPreferences(videoCodecPreference: List<VideoCodecPreference>) {
+        audioVideoController.setVideoCodecSendPreferences(videoCodecPreference)
     }
 
     override fun realtimeLocalMute(): Boolean {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoCodecPreference.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/VideoCodecPreference.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.video
+
+data class VideoCodecPreference(
+    val name: String,
+    val clockRate: Int,
+    val params: Map<String, String>
+) {
+    override fun toString(): String = name
+}
+
+val h264cbp = VideoCodecPreference(
+    "H264", 90000, mapOf(
+        "level-asymmetry-allowed" to "1",
+        "packetization-mode" to "1",
+        "profile-level-id" to "42e01f"
+    )
+)
+
+val h264h = VideoCodecPreference(
+    "H264", 90000, mapOf(
+        "level-asymmetry-allowed" to "1",
+        "packetization-mode" to "1",
+        "profile-level-id" to "640c1f"
+    )
+)
+
+val vp8 = VideoCodecPreference("VP8", 90000, emptyMap())

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/CameraCaptureSource.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 
 /**
@@ -15,6 +16,13 @@ import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
  * All the APIs here can be called regardless of whether the [AudioVideoFacade] is started or not.
  */
 interface CameraCaptureSource : VideoCaptureSource {
+
+    /**
+     * List of video codec capability in order of preference, specified in
+     * AudioVideoControllerFacade.setVideoCodecSendPreferences()
+     */
+    var codecPreferences: List<VideoCodecPreference>
+
     /**
      * Current camera device. This is only null if the phone/device doesn't have any cameras
      * May be called regardless of whether [start] or [stop] has been called.

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -29,12 +29,15 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingHistoryEventName
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoContentHint
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoRotation
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSink
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameBuffer
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.buffer.VideoFrameTextureBuffer
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.h264cbp
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.vp8
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
@@ -175,6 +178,8 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
                 start()
             }
         }
+
+    override var codecPreferences: List<VideoCodecPreference> = listOf(h264cbp, vp8)
 
     override fun start() {
         if (ActivityCompat.checkSelfPermission(

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -10,6 +10,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsControl
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.DefaultCameraCaptureSource
@@ -28,6 +29,7 @@ import com.xodee.client.video.RemoteVideoSourceInternal
 import com.xodee.client.video.VideoClient
 import com.xodee.client.video.VideoClientConfig
 import com.xodee.client.video.VideoClientConfigBuilder
+import com.xodee.client.video.VideoCodecCapabilitiesInternal
 import com.xodee.client.video.VideoPriorityInternal
 import com.xodee.client.video.VideoResolutionInternal
 import com.xodee.client.video.VideoSubscriptionConfigurationInternal
@@ -258,6 +260,14 @@ class DefaultVideoClientController(
 
     override fun demoteFromPrimaryMeeting() {
         if (videoClientStateController.canAct(VideoClientState.INITIALIZED)) videoClient?.demoteFromPrimaryMeeting()
+    }
+
+    override fun setVideoCodecSendPreferences(codecPreference: List<VideoCodecPreference>) {
+        logger.info(TAG, codecPreference.toString())
+        val codecPreferencesInternal = codecPreference.map { preference ->
+            VideoCodecCapabilitiesInternal(preference.name, preference.clockRate, preference.params.toString())
+        }
+        videoClient?.setVideoCodecPreferences(codecPreferencesInternal)
     }
 
     override fun initializeVideoClient() {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/VideoClientController.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.video
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoFrame
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSubscriptionConfiguration
@@ -160,4 +161,9 @@ interface VideoClientController {
      * See [AudioVideoFacade.demoteFromPrimaryMeeting]
      */
     fun demoteFromPrimaryMeeting()
+
+    /**
+     * See [AudioVideoFacade.setVideoCodecSendPreferences]
+     */
+    fun setVideoCodecSendPreferences(codecPreference: List<VideoCodecPreference>)
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/DeviceManagementFragment.kt
@@ -22,8 +22,11 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoConfigurat
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.DefaultVideoRenderView
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoCodecPreference
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.CameraCaptureSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.VideoCaptureFormat
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.h264cbp
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.vp8
 import com.amazonaws.services.chime.sdk.meetings.device.DeviceChangeObserver
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
 import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
@@ -44,6 +47,7 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
     private val audioDevices = mutableListOf<MediaDevice>()
     private val videoDevices = mutableListOf<MediaDevice>()
     private val videoFormats = mutableListOf<VideoCaptureFormat>()
+    private val videoCodecs = listOf(listOf(h264cbp, vp8), listOf(vp8, h264cbp))
 
     private lateinit var cameraManager: CameraManager
 
@@ -60,12 +64,15 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
     private lateinit var videoDeviceArrayAdapter: ArrayAdapter<MediaDevice>
     private lateinit var videoFormatSpinner: Spinner
     private lateinit var videoFormatArrayAdapter: ArrayAdapter<VideoCaptureFormat>
+    private lateinit var videoCodecSpinner: Spinner
+    private lateinit var videoCodecArrayAdapter: ArrayAdapter<List<VideoCodecPreference>>
 
     private val VIDEO_ASPECT_RATIO_16_9 = 0.5625
 
     private val AUDIO_DEVICE_SPINNER_INDEX_KEY = "audioDeviceSpinnerIndex"
     private val VIDEO_DEVICE_SPINNER_INDEX_KEY = "videoDeviceSpinnerIndex"
     private val VIDEO_FORMAT_SPINNER_INDEX_KEY = "videoFormatSpinnerIndex"
+    private val VIDEO_CODEC_SPINNER_INDEX_KEY = "videoCodecSpinnerIndex"
 
     private val MAX_VIDEO_FORMAT_HEIGHT = 800
     private val MAX_VIDEO_FORMAT_FPS = 30
@@ -146,6 +153,13 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
         videoFormatSpinner.isSelected = false
         videoFormatSpinner.setSelection(0, true)
         videoFormatSpinner.onItemSelectedListener = onVideoFormatSelected
+
+        videoCodecSpinner = view.findViewById(R.id.spinnerVideoCodec)
+        videoCodecArrayAdapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, videoCodecs)
+        videoCodecSpinner.adapter = videoCodecArrayAdapter
+        videoCodecSpinner.isSelected = false
+        videoCodecSpinner.setSelection(0, true)
+        videoCodecSpinner.onItemSelectedListener = onVideoCodecSelected
 
         audioVideo.addDeviceChangeObserver(this)
 
@@ -247,6 +261,15 @@ class DeviceManagementFragment : Fragment(), DeviceChangeObserver {
         }
 
         // Abstract, requires implementation
+        override fun onNothingSelected(parent: AdapterView<*>?) {
+        }
+    }
+
+    private val onVideoCodecSelected = object : AdapterView.OnItemSelectedListener {
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+            cameraCaptureSource.codecPreferences = parent?.getItemAtPosition(position) as List<VideoCodecPreference>
+        }
+
         override fun onNothingSelected(parent: AdapterView<*>?) {
         }
     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -1617,6 +1617,7 @@ class MeetingFragment : Fragment(),
             object {}.javaClass.enclosingMethod?.name,
             "${sessionStatus.statusCode}"
         )
+        audioVideo.setVideoCodecSendPreferences(cameraCaptureSource.codecPreferences)
     }
 
     override fun onCameraSendAvailabilityUpdated(available: Boolean) {

--- a/app/src/main/res/layout/fragment_device_management.xml
+++ b/app/src/main/res/layout/fragment_device_management.xml
@@ -84,6 +84,24 @@
                 android:paddingRight="32dp" />
 
             <TextView
+                android:id="@+id/textViewVideoCodec"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:paddingLeft="32dp"
+                android:paddingRight="32dp"
+                android:text="@string/video_codec_title" />
+
+            <Spinner
+                android:id="@+id/spinnerVideoCodec"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="16dp"
+                android:contentDescription="@string/video_codec_spinner"
+                android:paddingLeft="32dp"
+                android:paddingRight="32dp" />
+
+            <TextView
                 android:id="@+id/textViewVideoPreview"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,8 +47,10 @@
     <string name="video_device_spinner">Video Device Spinner</string>
     <string name="video_format_title">Video Format</string>
     <string name="video_format_spinner">Video Format Spinner</string>
+    <string name="video_codec_spinner">Video Codec Spinner</string>
     <string name="video_max_bit_rate_hint">Video Max Bit Rate in kbps</string>
     <string name="video_preview_title">Video Preview</string>
+    <string name="video_codec_title">Video Codecs</string>
     <string name="video_preview_view">Video Preview View</string>
     <string name="meeting_join">Join</string>
     <string name="preview_meeting_info">Ready to join meeting %1$s as %2$s.</string>


### PR DESCRIPTION
## ℹ️ Description
use codec selection API on media to allow user specific send codec preference

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
use different VideoCodecPreference enumeration and checked sending codec

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
