### PR TITLE
Pass client UTC offset to audio and video client for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+### Added
+* Pass client UTC offset to audio and video client for metrics.
+
+### Changed
+
+### Removed
+
+### Fixed
+
+
 ## [0.18.0] - 2023-03-16
 
 ### Changed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/AppInfoUtil.kt
@@ -8,6 +8,7 @@ package com.amazonaws.services.chime.sdk.meetings.internal.utils
 import android.content.Context
 import com.xodee.client.audio.audioclient.AppInfo
 import com.xodee.client.video.VideoClient
+import java.util.TimeZone
 
 object AppInfoUtil {
     private lateinit var manufacturer: String
@@ -17,6 +18,7 @@ object AppInfoUtil {
     private lateinit var appCode: String
     private const val clientSource = "amazon-chime-sdk"
     private lateinit var sdkVersion: String
+    private lateinit var clientUtcOffset: String
 
     private fun initializeAppInfo(context: Context) {
         manufacturer = DeviceUtils.deviceManufacturer
@@ -27,6 +29,8 @@ object AppInfoUtil {
         appName = String.format("Android %s", packageInfo.versionName)
         appCode = packageInfo.versionCode.toString()
         sdkVersion = DeviceUtils.sdkVersion
+        val deviceTimezone = TimeZone.getDefault()
+        clientUtcOffset = TimezoneUtils.getUtcOffset(deviceTimezone)
     }
 
     fun initializeVideoClientAppDetailedInfo(context: Context) {
@@ -39,7 +43,8 @@ object AppInfoUtil {
             manufacturer,
             osVersion,
             clientSource,
-            sdkVersion
+            sdkVersion,
+            clientUtcOffset
         )
     }
 
@@ -53,7 +58,8 @@ object AppInfoUtil {
             model,
             osVersion,
             clientSource,
-            sdkVersion
+            sdkVersion,
+            clientUtcOffset
         )
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
@@ -12,7 +12,7 @@ class TimezoneUtils {
     companion object {
 
         /**
-         * Return utc offset from timezone in +- hh:mm format.
+         * Return utc offset from timezone in +-hh:mm format.
          * E.g Asia/Calcutta timezone is returned as +05:30 UTC offset
          */
         fun getUtcOffset(timezone: TimeZone): String {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+class TimezoneUtils {
+    companion object {
+
+        /**
+         * Return utc offset from timezone in +- hh:mm format.
+         * E.g Asia/Calcutta timezone is returned as +05:30 UTC offset
+         */
+        fun getUtcOffset(timezone: TimeZone): String {
+            val offsetInMillis = timezone.getOffset(GregorianCalendar.getInstance(timezone).timeInMillis)
+            var offset: String = String.format("%02d:%02d", Math.abs(offsetInMillis / 3600000), Math.abs((offsetInMillis / 60000) % 60))
+            offset = (if (offsetInMillis >= 0) "+" else "-") + offset
+            return offset
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtils.kt
@@ -10,15 +10,18 @@ import java.util.TimeZone
 
 class TimezoneUtils {
     companion object {
+        private const val UTC_OFFSET_FORMAT = "%02d:%02d"
 
         /**
          * Return utc offset from timezone in +-hh:mm format.
          * E.g Asia/Calcutta timezone is returned as +05:30 UTC offset
          */
         fun getUtcOffset(timezone: TimeZone): String {
-            val offsetInMillis = timezone.getOffset(GregorianCalendar.getInstance(timezone).timeInMillis)
-            var offset: String = String.format("%02d:%02d", Math.abs(offsetInMillis / 3600000), Math.abs((offsetInMillis / 60000) % 60))
-            offset = (if (offsetInMillis >= 0) "+" else "-") + offset
+            val offsetMillis = timezone.getOffset(GregorianCalendar.getInstance(timezone).timeInMillis)
+            val offsetHours = Math.abs((offsetMillis / 60000) / 60)
+            val offsetMinutes = Math.abs((offsetMillis / 60000) % 60)
+            var offset: String = String.format(UTC_OFFSET_FORMAT, offsetHours, offsetMinutes)
+            offset = (if (offsetMillis >= 0) "+" else "-") + offset
             return offset
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -148,7 +148,8 @@ class DefaultAudioClientControllerTest {
             "model",
             "version",
             "amazon-chime-sdk",
-            "sdkVersion"
+            "sdkVersion",
+            "-07:00"
         )
 
         mockkObject(AppInfoUtil)

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtilsTest.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.utils
+
+import java.util.TimeZone
+import org.junit.Assert
+import org.junit.Test
+
+class TimezoneUtilsTest {
+    @Test
+    fun `getUtcOffset should return correctly formatted Utc offset`() {
+        Assert.assertEquals("+05:30", TimezoneUtils.getUtcOffset(TimeZone.getTimeZone("Asia/Calcutta")))
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/TimezoneUtilsTest.kt
@@ -11,7 +11,12 @@ import org.junit.Test
 
 class TimezoneUtilsTest {
     @Test
-    fun `getUtcOffset should return correctly formatted Utc offset`() {
+    fun `getUtcOffset should return correctly formatted positive Utc offset`() {
         Assert.assertEquals("+05:30", TimezoneUtils.getUtcOffset(TimeZone.getTimeZone("Asia/Calcutta")))
+    }
+
+    @Test
+    fun `getUtcOffset should return correctly formatted negative Utc offset`() {
+        Assert.assertEquals("-06:00", TimezoneUtils.getUtcOffset(TimeZone.getTimeZone("America/Costa_Rica")))
     }
 }


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*
Pass client UTC offset to audio and video client for metrics. This is being done for investigation of audio quality scores with the purpose of improving the audio quality for Amazon chime sdk customer.

### Issue #, if available
None

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [x] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Tested by running android demo app successfully with the changes being proposed and verified via logs.

### Unit test coverage
* Class coverage: Same as previous
* Line coverage: Same as previous

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
