### PR TITLE
Apply meeting constraint for android mobile sdk

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -83,7 +83,7 @@ data class MediaDevice(
                             ?: return emptyList()
             val nativeSizes = streamMap.getOutputSizes(SurfaceTexture::class.java)
                     ?: return emptyList()
-            var filterList = nativeSizes.filter{it.width <= 1280 && it.height <= 720}
+            val filterList = nativeSizes.filter{it.width <= 1280 && it.height <= 720}
 
             return filterList.map { size -> VideoCaptureFormat(size.width, size.height, fps) }
         }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -83,8 +83,9 @@ data class MediaDevice(
                             ?: return emptyList()
             val nativeSizes = streamMap.getOutputSizes(SurfaceTexture::class.java)
                     ?: return emptyList()
+            var filterList = nativeSizes.filter{it.width <= 1280 && it.height <= 720}
 
-            return nativeSizes.map { size -> VideoCaptureFormat(size.width, size.height, fps) }
+            return filterList.map { size -> VideoCaptureFormat(size.width, size.height, fps) }
         }
     }
 }


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

Apply meeting constraint for android mobile sdk 

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
1. Join a meeting from android phone
2. Share content from phone
3. Join the same meeting from chrome browser
4. Check chrome://webrtc-internals and confirm that the resolution of content stream is not above constraint (1920x1080)
5. For camera resolution selection, there should not be resolution above 720p

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
