### PR TITLE
Update audio redundancy join screen UI element from dropdown to switch

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -173,6 +173,9 @@ class DefaultAudioClientController(
                 false
             )
         }
+        logger.info(TAG,
+            "audioMode: $audioMode, audioStreamType: $audioStreamType, audioRecordingPresetOverride: $audioRecordingPresetOverride, enableAudioRedundancy: $enableAudioRedundancy"
+        )
         audioManager.mode = AudioManager.MODE_IN_COMMUNICATION
 
         val appInfo = AppInfoUtil.initializeAudioClientAppInfo(context)

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -17,6 +17,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatSpinner
+import androidx.appcompat.widget.SwitchCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
@@ -55,13 +56,12 @@ class HomeActivity : AppCompatActivity() {
     private var meetingEditText: EditText? = null
     private var nameEditText: EditText? = null
     private var audioMode: AppCompatSpinner? = null
-    private var audioRedundancy: AppCompatSpinner? = null
+    private var audioRedundancySwitch: SwitchCompat? = null
     private var authenticationProgressBar: ProgressBar? = null
     private var meetingID: String? = null
     private var yourName: String? = null
     private var testUrl: String = ""
     private var audioModes = listOf("Stereo/48KHz Audio", "Mono/48KHz Audio", "Mono/16KHz Audio")
-    private var audioRedundancyModes = listOf("Enable Audio Redundancy", "Disable Audio Redundancy")
     private lateinit var audioVideoConfig: AudioVideoConfiguration
     private lateinit var debugSettingsViewModel: DebugSettingsViewModel
 
@@ -81,12 +81,12 @@ class HomeActivity : AppCompatActivity() {
         meetingEditText = findViewById(R.id.editMeetingId)
         nameEditText = findViewById(R.id.editName)
         audioMode = findViewById(R.id.audioModeSpinner)
-        audioRedundancy = findViewById(R.id.audioRedundancySpinner)
+        audioRedundancySwitch = findViewById(R.id.audioRedundancySwitch)
+        audioRedundancySwitch?.setChecked(true)
         authenticationProgressBar = findViewById(R.id.progressAuthentication)
         debugSettingsViewModel = ViewModelProvider(this).get(DebugSettingsViewModel::class.java)
 
         audioMode?.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, audioModes)
-        audioRedundancy?.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, audioRedundancyModes)
         findViewById<Button>(R.id.buttonContinue)?.setOnClickListener {
             joinMeeting()
         }
@@ -109,12 +109,7 @@ class HomeActivity : AppCompatActivity() {
             2 -> mode = AudioMode.Mono16K
         }
 
-        var redundancyEnabled = true
-        when (audioRedundancy?.selectedItemPosition ?: 0) {
-            0 -> redundancyEnabled = true
-            1 -> redundancyEnabled = false
-        }
-
+        val redundancyEnabled = audioRedundancySwitch?.isChecked as Boolean
         audioVideoConfig = AudioVideoConfiguration(audioMode = mode, enableAudioRedundancy = redundancyEnabled)
 
         meetingID = meetingEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -49,11 +49,11 @@
         android:contentDescription="@string/audio_mode_spinner"
         android:layout_gravity="center"/>
 
-    <androidx.appcompat.widget.AppCompatSpinner
-        android:id="@+id/audioRedundancySpinner"
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/audioRedundancySwitch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:contentDescription="@string/audio_redundancy_spinner"
+        android:contentDescription="@string/audio_redundancy_switch"
         android:layout_gravity="center"/>
 
     <Button

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -54,6 +54,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:contentDescription="@string/audio_redundancy_switch"
+        android:text="@string/audio_redundancy_switch"
         android:layout_gravity="center"/>
 
     <Button

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,7 +9,7 @@
     <string name="edit_name">Your Name</string>
     <string name="main_title">Join a meeting</string>
     <string name="audio_mode_spinner">Audio Mode</string>
-    <string name="audio_redundancy_spinner">Audio Redundancy</string>
+    <string name="audio_redundancy_switch">Audio Redundancy</string>
     <string name="main_continue">Continue</string>
     <string name="main_continue_without_audio">Continue without audio</string>
     <string name="join_meeting">Join Meeting</string>


### PR DESCRIPTION
## ℹ️ Description
Update audio redundancy join screen UI element from dropdown to switch

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Ran sanity test for audio by joining meeting. 

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*
![image-8fd5b5a6-5786-40ae-94d6-e582dbdfbec7](https://github.com/aws/amazon-chime-sdk-android/assets/30274478/a7f996fd-f7f4-4ce2-afbc-d61b3740fd6e)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
