### PR TITLE
Move filterByteBuffer to local variable in getProcessedFrame()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixed
+
+* Move BackgroundFilterVideoFrameProcessor.filterByteBuffer to local variable in getProcessedFrame() to prevent race condition
+
 ## [0.19.0] - 2023-12-20
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/backgroundfilter/BackgroundFilterVideoFrameProcessor.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/backgroundfilter/BackgroundFilterVideoFrameProcessor.kt
@@ -51,7 +51,6 @@ class BackgroundFilterVideoFrameProcessor(
 
     private var cachedWidth: Int = 0
     private var cachedHeight: Int = 0
-    private lateinit var filteredByteBuffer: ByteBuffer
 
     private val defaultInputModelShape = ModelShape()
     private val channels = defaultInputModelShape.channels
@@ -124,6 +123,7 @@ class BackgroundFilterVideoFrameProcessor(
         filteredBitmap: Bitmap?,
         rgbaData: ByteBuffer
     ): VideoFrame {
+        var filteredByteBuffer: ByteBuffer
         if (filteredBitmap == null) {
             // Display original frame when there is an error getting segmentation mask and/or blurring.
             filteredByteBuffer = rgbaData


### PR DESCRIPTION
## ℹ️ Description
Move filterByteBuffer to local variable in getProcessedFrame() to prevent race condition

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Steps:
 - Enable background blur on preview screen
 - Start the demo app
 - On preview page, verify the background blur is enabled
 - Press back button to exit the meeting, verified the app doesn't crash
 - Start the demo app again
 - Enter the meeting screen
 - Enable background blur for local video, verify background blur is enabled

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
