### PR TITLE
Fix instruction for building media-no-video-codecs on Maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,15 @@ dependencies {
 ```
 The version numbers could be obtained from the latest [release](https://github.com/aws/amazon-chime-sdk-android/releases/latest).
 
-If you don't need video and content share functionality, or software video codec support, you could use `amazon-chime-sdk-media-no-video-codecs` instead to reduce size:
+If you don't need video and content share functionality, or software video codec support, you could use `amazon-chime-sdk-media-no-video-codecs` instead to reduce size. Exclude the usage of `amazon-chime-sdk-media` module and/or `amazon-chime-sdk-machine-learning` module from the transitive dependency of `amazon-chime-sdk`:
 
 ```
 dependencies {
     implementation 'software.aws.chimesdk:amazon-chime-sdk-media-no-video-codecs:$MEDIA_VERSION'
-    implementation 'software.aws.chimesdk:amazon-chime-sdk:$SDK_VERSION'
+    implementation ('software.aws.chimesdk:amazon-chime-sdk:$MEDIA_VERSION') {
+        exclude module: 'amazon-chime-sdk-media'
+        exclude module: 'amazon-chime-sdk-machine-learning'
+    }
 }
 ```
 


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

If builders tries to build with `media-no-video-codecs` following the instruction in README, they will be getting `Duplicate class` error as classes of `amazon-chime-sdk-media` were also getting pulled in from `amazon-chime-sdk` dependency

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

Built with normal media module and no-video-codecs module and verified the demo app and its app size.

```
implementation 'software.aws.chimesdk:amazon-chime-sdk:0.19.0'
implementation 'software.aws.chimesdk:amazon-chime-sdk-media:0.19.0'
```

```
implementation 'software.aws.chimesdk:amazon-chime-sdk-media-no-video-codecs:0.19.0'
implementation ('software.aws.chimesdk:amazon-chime-sdk:0.19.0') {
    exclude module: 'amazon-chime-sdk-media'
}
```

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
