### PR TITLE
Validate if audioHostUrl or audioFallbackUrl is blank

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -147,6 +147,14 @@ class DefaultAudioClientController(
             return
         }
 
+        if (audioHostUrl.isBlank() || audioFallbackUrl.isBlank()) {
+            logger.error(
+                TAG,
+                "`audioHostUrl` or `audioFallbackUrl` is blank"
+            )
+            throw Exception("Audio failed to start")
+        }
+
         val audioUrlParts: List<String> =
             audioHostUrl.split(":".toRegex()).dropLastWhile { it.isEmpty() }
 

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -33,6 +33,7 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.verify
+import java.lang.Exception
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -685,5 +686,39 @@ class DefaultAudioClientControllerTest {
                 assertEquals(AudioRecordingPreset.VOICE_COMMUNICATION, it.audioRecordingPreset)
             })
         }
+    }
+
+    @Test(expected = Exception::class)
+    fun `start should throw exception if audioHostUrl is blank`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            "",
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Mono16K,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.VoiceCommunication,
+            true
+        )
+    }
+
+    @Test(expected = Exception::class)
+    fun `start should throw exception if audioFallbackUrl is blank`() {
+        setupStartTests()
+
+        audioClientController.start(
+            "",
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Mono16K,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.VoiceCommunication,
+            true
+        )
     }
 }


### PR DESCRIPTION
## ℹ️ Description
 - Validate if audioHostUrl or audioFallbackUrl is blank before start audio session

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
