### PR TITLE
Enable configuring audio device capabilities before starting a meeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+### Added
+* Added `AudioDeviceCapabilities` to `AudioVideoConfiguration`, which allows configuring whether the audio input and output devices are enabled or disabled before starting a meeting.
+  * Audio recording permissions will only be required when using `AudioDeviceCapabilities.InputAndOutput`
+  * [Demo] Added spinner to join screen to configure the audio device capabilities
+
+### Removed
+* **Breaking** Removed `AudioMode.NoDevice`, which is now replaced by `AudioDeviceCapabilities.None`. Apps which previously used `AudioMode.NoDevice` can achieve the same functionality by using `AudioDeviceCapabilities.None` when constructing an `AudioVideoConfiguration`, e.g. `AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.None)`.
+
 ## [0.19.1] - 2024-02-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -190,13 +190,16 @@ Start a session with custom configurations:
 meetingSession.audioVideo.start(audioVideoConfiguration)
 ```
 
-There are 4 configurations available in `audioVideoConfiguration`:
+These configurations are available in `audioVideoConfiguration`:
 - `audioMode`
+- `audioDeviceCapabilities`
 - `audioStreamType`
 - `audioRecordingPresetOverride`
 - `enableAudioRedundancy`
 
 AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
+
+AudioDeviceCapabilities: The default audio device capabilities are to have both the audio input and output devices enabled, i.e. both microphone and speaker are enabled (`InputAndOutput`). Other options are `OutputOnly` (microphone disabled and speaker enabled) and `None` (both microphone and speaker disabled).
 
 AudioStreamType: The default value is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
 
@@ -324,10 +327,11 @@ override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
 
 > When joining a meeting, each configuration will have a default if not explicitly specified when starting the audio session.
 > 
-> Supported AudioMode options: *Mono/16KHz*, *Mono/48KHz*, and *Stereo/48KHz*. Default is *Stereo/48KHz*.
-> Supported AudioStreamType options: *VoiceCall* and *Music*. Default is *VoiceCall*
-> Supported AudioRecordingPresetOverride options: *None*, *Generic*, *Camcorder*, *VoiceRecognition* and *VoiceCommunication*. Default is *None*.
-> Supported enableAudioRedundancy options: *true* and *false*. Default is *true*.
+> - Supported AudioMode options: *Mono/16KHz*, *Mono/48KHz*, and *Stereo/48KHz*. Default is *Stereo/48KHz*.
+> - Supported AudioDeviceCapabilities options: *Input and Output*, *Output Only*, and *None*. Default is *Input and Output*.
+> - Supported AudioStreamType options: *VoiceCall* and *Music*. Default is *VoiceCall*
+> - Supported AudioRecordingPresetOverride options: *None*, *Generic*, *Camcorder*, *VoiceRecognition* and *VoiceCommunication*. Default is *None*.
+> - Supported enableAudioRedundancy options: *true* and *false*. Default is *true*.
 
 ```kotlin
 meetingSession.audioVideo.start() // starts the audio video session with defaults mentioned above

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ If you discover a potential security issue in this project we ask that you notif
 
 #### Use case 1. Start a session.
 
-You need to start the meeting session to start sending and receiving audio. Make sure that the user has granted audio permission first.
+You need to start the meeting session to start sending and receiving audio.
 
 Start a session with default configurations:
 ```kotlin
@@ -199,7 +199,7 @@ These configurations are available in `audioVideoConfiguration`:
 
 AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
 
-AudioDeviceCapabilities: The default audio device capabilities are to have both the audio input and output devices enabled, i.e. both microphone and speaker are enabled (`InputAndOutput`). Other options are `OutputOnly` (microphone disabled and speaker enabled) and `None` (both microphone and speaker disabled).
+AudioDeviceCapabilities: The default audio device capabilities are to have both the audio input and output devices enabled (`InputAndOutput`), i.e. both microphone and speaker are enabled. `InputAndOutput` will require `MODIFY_AUDIO_SETTINGS` and `RECORD_AUDIO` permissions. Other options are `OutputOnly` (microphone disabled and speaker enabled; requires `MODIFY_AUDIO_SETTINGS` permission) and `None` (both microphone and speaker disabled; does not require any audio permissions).
 
 AudioStreamType: The default value is ```VoiceCall```. The available options are ```VoiceCall``` and ```Music```, they are equivalent of `STREAM_VOICE_CALL` and `STREAM_MUSIC` respectively in [AudioManager](https://developer.android.com/reference/android/media/AudioManager). This configuration is for addressing the audio volume [issue](https://github.com/aws/amazon-chime-sdk-android/issues/296) on Oculus Quest 2. If you don't know what it is, you probably don't need to worry about it. For more information, please refer to Android documentation: [STREAM_VOICE_CALL](https://developer.android.com/reference/android/media/AudioManager#STREAM_VOICE_CALL), [STREAM_MUSIC](https://developer.android.com/reference/android/media/AudioManager#STREAM_MUSIC).
 

--- a/amazon-chime-sdk/src/main/AndroidManifest.xml
+++ b/amazon-chime-sdk/src/main/AndroidManifest.xml
@@ -8,7 +8,5 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.CAMERA" />
 </manifest>

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
@@ -5,6 +5,7 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
@@ -16,11 +17,15 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamTyp
  * @property audioMode: AudioMode - the audio mode in which the audio client should operate during
  * a meeting session.
  *
+ * @property audioDeviceCapabilities: AudioDeviceCapabilities - the audio device capabilities that the audio client
+ * should have during a meeting session.
+ *
  * @property audioStreamType: AudioStreamType - the audio stream type in which the audio client
  * should operate during a meeting session.
  */
 data class AudioVideoConfiguration @JvmOverloads constructor(
     val audioMode: AudioMode = AudioMode.Stereo48K,
+    val audioDeviceCapabilities: AudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput,
     val audioStreamType: AudioStreamType = AudioStreamType.VoiceCall,
     val audioRecordingPresetOverride: AudioRecordingPresetOverride = AudioRecordingPresetOverride.None,
     val enableAudioRedundancy: Boolean = true

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -58,6 +58,7 @@ class DefaultAudioVideoController(
             attendeeId = configuration.credentials.attendeeId,
             joinToken = configuration.credentials.joinToken,
             audioMode = audioVideoConfiguration.audioMode,
+            audioDeviceCapabilities = audioVideoConfiguration.audioDeviceCapabilities,
             audioStreamType = audioVideoConfiguration.audioStreamType,
             audioRecordingPresetOverride = audioVideoConfiguration.audioRecordingPresetOverride,
             enableAudioRedundancy = audioVideoConfiguration.enableAudioRedundancy

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacade.kt
@@ -5,7 +5,6 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
-import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Build
@@ -49,9 +48,6 @@ class DefaultAudioVideoFacade(
     private val contentShareController: ContentShareController,
     private val eventAnalyticsController: EventAnalyticsController
 ) : AudioVideoFacade {
-
-    private val audioInputPermissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.RECORD_AUDIO)
-    private val audioOutputPermissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS)
 
     override fun start() {
         start(AudioVideoConfiguration())
@@ -274,14 +270,9 @@ class DefaultAudioVideoFacade(
     }
 
     private fun checkAudioPermissions(audioDeviceCapabilities: AudioDeviceCapabilities) {
-        val requiredPermissions: Array<String> = when (audioDeviceCapabilities) {
-            AudioDeviceCapabilities.None -> emptyArray()
-            AudioDeviceCapabilities.OutputOnly -> audioOutputPermissions
-            AudioDeviceCapabilities.InputAndOutput -> audioInputPermissions + audioOutputPermissions
-        }
-        val hasRequiredPermissions: Boolean = requiredPermissions.all { ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED }
+        val hasRequiredPermissions: Boolean = audioDeviceCapabilities.requiredPermissions().all { ContextCompat.checkSelfPermission(context, it) == PackageManager.PERMISSION_GRANTED }
         if (!hasRequiredPermissions) {
-            throw SecurityException("Missing necessary permissions for WebRTC: ${requiredPermissions.joinToString()}")
+            throw SecurityException("Missing necessary permissions for WebRTC: ${audioDeviceCapabilities.requiredPermissions().joinToString()}")
         }
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
@@ -5,30 +5,36 @@
 
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
 
+import android.Manifest
+
 /**
  * [AudioDeviceCapabilities] describes whether the audio input and output devices are enabled or disabled. Disabling
  * either the audio input or output will change what audio permissions are required in order to join a meeting.
  */
-enum class AudioDeviceCapabilities(val value: Int) {
+enum class AudioDeviceCapabilities {
     /**
      * Disable both the audio input and output devices (i.e. connections to the microphone and speaker devices are not
      * opened). Muted packets are sent to the server. No audio permissions are required.
      */
-    None(0),
+    None,
 
     /**
      * Disable the audio input device and only enable the audio output device (i.e. the connection to the microphone
      * device is not opened). Muted packets are sent to the server. MODIFY_AUDIO_SETTINGS permission is required.
      */
-    OutputOnly(1),
+    OutputOnly,
 
     /**
      * Enable both the audio input and output devices. MODIFY_AUDIO_SETTINGS and RECORD_AUDIO permissions are required.
      */
-    InputAndOutput(2);
+    InputAndOutput;
 
-    companion object {
-        fun from(intValue: Int): AudioDeviceCapabilities? = values().find { it.value == intValue }
-        fun from(intValue: Int, defaultAudioDeviceCapabilities: AudioDeviceCapabilities): AudioDeviceCapabilities = from(intValue) ?: defaultAudioDeviceCapabilities
+    private val audioInputPermissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.RECORD_AUDIO)
+    private val audioOutputPermissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS)
+
+    fun requiredPermissions(): Array<String> = when (this) {
+        None -> emptyArray()
+        OutputOnly -> audioOutputPermissions
+        InputAndOutput -> (audioInputPermissions + audioOutputPermissions).distinct().toTypedArray()
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
+
+/**
+ * [AudioDeviceCapabilities] describes whether the audio input and output devices are enabled or disabled.
+ */
+enum class AudioDeviceCapabilities(val value: Int) {
+    /**
+     * Disable both the audio input and output devices (i.e. connections to the microphone and speaker devices are not
+     * opened). Muted packets are sent to the server.
+     */
+    None(0),
+
+    /**
+     * Disable the audio input device and only enable the audio output device (i.e. the connection to the microphone
+     * device is not opened). Muted packets are sent to the server.
+     */
+    OutputOnly(1),
+
+    /**
+     * Enable both the audio input and output devices.
+     */
+    InputAndOutput(2);
+
+    companion object {
+        fun from(intValue: Int): AudioDeviceCapabilities? = values().find { it.value == intValue }
+        fun from(intValue: Int, defaultAudioDeviceCapabilities: AudioDeviceCapabilities): AudioDeviceCapabilities = from(intValue) ?: defaultAudioDeviceCapabilities
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilities.kt
@@ -6,23 +6,24 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
 
 /**
- * [AudioDeviceCapabilities] describes whether the audio input and output devices are enabled or disabled.
+ * [AudioDeviceCapabilities] describes whether the audio input and output devices are enabled or disabled. Disabling
+ * either the audio input or output will change what audio permissions are required in order to join a meeting.
  */
 enum class AudioDeviceCapabilities(val value: Int) {
     /**
      * Disable both the audio input and output devices (i.e. connections to the microphone and speaker devices are not
-     * opened). Muted packets are sent to the server.
+     * opened). Muted packets are sent to the server. No audio permissions are required.
      */
     None(0),
 
     /**
      * Disable the audio input device and only enable the audio output device (i.e. the connection to the microphone
-     * device is not opened). Muted packets are sent to the server.
+     * device is not opened). Muted packets are sent to the server. MODIFY_AUDIO_SETTINGS permission is required.
      */
     OutputOnly(1),
 
     /**
-     * Enable both the audio input and output devices.
+     * Enable both the audio input and output devices. MODIFY_AUDIO_SETTINGS and RECORD_AUDIO permissions are required.
      */
     InputAndOutput(2);
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -29,7 +29,8 @@ enum class AudioMode(val value: Int) {
     NoDevice(4);
 
     companion object {
-        fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }
+        // Return null for value 4 since NoDevice should not be accessible from this function
+        fun from(intValue: Int): AudioMode? = if (intValue == 4) null else values().find { it.value == intValue }
         fun from(intValue: Int, defaultAudioMode: AudioMode): AudioMode = from(intValue) ?: defaultAudioMode
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -23,9 +23,7 @@ enum class AudioMode(val value: Int) {
      * The stereo audio mode with two audio channels for speaker, and single audio channel for microphone,
      * both with 48KHz sampling rate.
      */
-    Stereo48K(3),
-
-    NoDevice(4);
+    Stereo48K(3);
 
     companion object {
         fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -23,7 +23,10 @@ enum class AudioMode(val value: Int) {
      * The stereo audio mode with two audio channels for speaker, and single audio channel for microphone,
      * both with 48KHz sampling rate.
      */
-    Stereo48K(3);
+    Stereo48K(3),
+
+    @Deprecated("Use AudioDeviceCapabilities.None instead", level = DeprecationLevel.HIDDEN)
+    NoDevice(4);
 
     companion object {
         fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -23,13 +23,27 @@ enum class AudioMode(val value: Int) {
      * The stereo audio mode with two audio channels for speaker, and single audio channel for microphone,
      * both with 48KHz sampling rate.
      */
-    Stereo48K(3);
+    Stereo48K(3),
 
-    // Value 4 is reserved for the obsolete NoDevice case, which is replaced by AudioDeviceCapabilities.None
-    // NoDevice(4) 
+    /**
+     * The [NoDevice] audio mode is obsolete, and is replaced by [AudioDeviceCapabilities.None]. To achieve the
+     * same functionality as NoDevice, pass AudioDeviceCapabilities.None into the AudioVideoConfiguration constructor
+     * instead, e.g. AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.None)
+     */
+    @Deprecated("To achieve the same functionality as NoDevice, pass AudioDeviceCapabilities.None into" +
+            " the AudioVideoConfiguration constructor instead, e.g." +
+            " AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.None)", level = DeprecationLevel.HIDDEN)
+    NoDevice(4);
 
     companion object {
-        fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }
+        fun from(intValue: Int): AudioMode? {
+            if (intValue == 4) {
+                // NoDevice cannot be instantiated since it is obsolete
+                return null
+            }
+            return values().find { it.value == intValue }
+        }
+
         fun from(intValue: Int, defaultAudioMode: AudioMode): AudioMode = from(intValue) ?: defaultAudioMode
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioMode.kt
@@ -23,14 +23,13 @@ enum class AudioMode(val value: Int) {
      * The stereo audio mode with two audio channels for speaker, and single audio channel for microphone,
      * both with 48KHz sampling rate.
      */
-    Stereo48K(3),
+    Stereo48K(3);
 
-    @Deprecated("Use AudioDeviceCapabilities.None instead", level = DeprecationLevel.HIDDEN)
-    NoDevice(4);
+    // Value 4 is reserved for the obsolete NoDevice case, which is replaced by AudioDeviceCapabilities.None
+    // NoDevice(4) 
 
     companion object {
-        // Return null for value 4 since NoDevice should not be accessible from this function
-        fun from(intValue: Int): AudioMode? = if (intValue == 4) null else values().find { it.value == intValue }
+        fun from(intValue: Int): AudioMode? = values().find { it.value == intValue }
         fun from(intValue: Int, defaultAudioMode: AudioMode): AudioMode = from(intValue) ?: defaultAudioMode
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
@@ -28,6 +29,7 @@ interface AudioClientController {
         attendeeId: String,
         joinToken: String,
         audioMode: AudioMode,
+        audioDeviceCapabilities: AudioDeviceCapabilities,
         audioStreamType: AudioStreamType,
         audioRecordingPresetOverride: AudioRecordingPresetOverride,
         enableAudioRedundancy: Boolean

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -70,7 +70,6 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> 16000
             AudioMode.Mono48K -> 48000
             AudioMode.Stereo48K -> 48000
-            else -> 48000
         }
         audioClient.sendMessage(
             AudioClient.MESS_SET_IO_SAMPLE_RATE,
@@ -82,7 +81,6 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Mono48K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Stereo48K -> AudioFormat.CHANNEL_OUT_STEREO
-            else -> AudioFormat.CHANNEL_OUT_STEREO
         }
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
@@ -196,7 +194,6 @@ class DefaultAudioClientController(
                 AudioMode.Mono16K -> AudioModeInternal.MONO_16K
                 AudioMode.Mono48K -> AudioModeInternal.MONO_48K
                 AudioMode.Stereo48K -> AudioModeInternal.STEREO_48K
-                else -> AudioModeInternal.STEREO_48K
             }
 
             val audioDeviceCapabilitiesInternal = when (audioDeviceCapabilities) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -15,6 +15,7 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
@@ -24,6 +25,7 @@ import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatus
 import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.AudioClient.AudioDeviceCapabilitiesInternal
 import com.xodee.client.audio.audioclient.AudioClient.AudioModeInternal
 import com.xodee.client.audio.audioclient.AudioClientSessionConfig
 import kotlinx.coroutines.CoroutineScope
@@ -68,7 +70,6 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> 16000
             AudioMode.Mono48K -> 48000
             AudioMode.Stereo48K -> 48000
-            AudioMode.NoDevice -> 16000
         }
         audioClient.sendMessage(
             AudioClient.MESS_SET_IO_SAMPLE_RATE,
@@ -80,7 +81,6 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Mono48K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Stereo48K -> AudioFormat.CHANNEL_OUT_STEREO
-            AudioMode.NoDevice -> AudioFormat.CHANNEL_OUT_MONO
         }
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
@@ -132,6 +132,7 @@ class DefaultAudioClientController(
         attendeeId: String,
         joinToken: String,
         audioMode: AudioMode,
+        audioDeviceCapabilities: AudioDeviceCapabilities,
         audioStreamType: AudioStreamType,
         audioRecordingPresetOverride: AudioRecordingPresetOverride,
         enableAudioRedundancy: Boolean
@@ -193,7 +194,12 @@ class DefaultAudioClientController(
                 AudioMode.Mono16K -> AudioModeInternal.MONO_16K
                 AudioMode.Mono48K -> AudioModeInternal.MONO_48K
                 AudioMode.Stereo48K -> AudioModeInternal.STEREO_48K
-                AudioMode.NoDevice -> AudioModeInternal.NO_DEVICE
+            }
+
+            val audioDeviceCapabilitiesInternal = when (audioDeviceCapabilities) {
+                AudioDeviceCapabilities.None -> AudioDeviceCapabilitiesInternal.NONE
+                AudioDeviceCapabilities.OutputOnly -> AudioDeviceCapabilitiesInternal.OUTPUT_ONLY
+                AudioDeviceCapabilities.InputAndOutput -> AudioDeviceCapabilitiesInternal.INPUT_AND_OUTPUT
             }
 
             var audioStreamTypeInternal = when (audioStreamType) {
@@ -218,6 +224,7 @@ class DefaultAudioClientController(
                 audioFallbackUrl,
                 appInfo,
                 audioModeInternal,
+                audioDeviceCapabilitiesInternal,
                 audioStreamTypeInternal,
                 audioRecordingPresetInternal,
                 enableAudioRedundancy

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -70,6 +70,7 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> 16000
             AudioMode.Mono48K -> 48000
             AudioMode.Stereo48K -> 48000
+            else -> 48000
         }
         audioClient.sendMessage(
             AudioClient.MESS_SET_IO_SAMPLE_RATE,
@@ -81,6 +82,7 @@ class DefaultAudioClientController(
             AudioMode.Mono16K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Mono48K -> AudioFormat.CHANNEL_OUT_MONO
             AudioMode.Stereo48K -> AudioFormat.CHANNEL_OUT_STEREO
+            else -> AudioFormat.CHANNEL_OUT_STEREO
         }
         val spkMinBufSizeInSamples = AudioTrack.getMinBufferSize(
             nativeSR,
@@ -194,6 +196,7 @@ class DefaultAudioClientController(
                 AudioMode.Mono16K -> AudioModeInternal.MONO_16K
                 AudioMode.Mono48K -> AudioModeInternal.MONO_48K
                 AudioMode.Stereo48K -> AudioModeInternal.STEREO_48K
+                else -> AudioModeInternal.STEREO_48K
             }
 
             val audioDeviceCapabilitiesInternal = when (audioDeviceCapabilities) {

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -199,11 +199,7 @@ class DefaultAudioClientController(
                 else -> AudioModeInternal.STEREO_48K
             }
 
-            val audioDeviceCapabilitiesInternal = when (audioDeviceCapabilities) {
-                AudioDeviceCapabilities.None -> AudioDeviceCapabilitiesInternal.NONE
-                AudioDeviceCapabilities.OutputOnly -> AudioDeviceCapabilitiesInternal.OUTPUT_ONLY
-                AudioDeviceCapabilities.InputAndOutput -> AudioDeviceCapabilitiesInternal.INPUT_AND_OUTPUT
-            }
+            val audioDeviceCapabilitiesInternal = mapAudioDeviceCapabilitiesToInternal(audioDeviceCapabilities)
 
             var audioStreamTypeInternal = when (audioStreamType) {
                 AudioStreamType.VoiceCall -> AudioClient.AudioStreamType.VOICE_CALL
@@ -345,5 +341,11 @@ class DefaultAudioClientController(
             return
         }
         audioClient.demoteFromPrimaryMeeting()
+    }
+
+    private fun mapAudioDeviceCapabilitiesToInternal(audioDeviceCapabilities: AudioDeviceCapabilities): AudioDeviceCapabilitiesInternal = when (audioDeviceCapabilities) {
+        AudioDeviceCapabilities.None -> AudioDeviceCapabilitiesInternal.NONE
+        AudioDeviceCapabilities.OutputOnly -> AudioDeviceCapabilitiesInternal.OUTPUT_ONLY
+        AudioDeviceCapabilities.InputAndOutput -> AudioDeviceCapabilitiesInternal.INPUT_AND_OUTPUT
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
@@ -1,6 +1,9 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
 import org.junit.Assert
 import org.junit.Test
 
@@ -8,5 +11,25 @@ class AudioVideoConfigurationTest {
     @Test
     fun `default audio mode should be stereo`() {
         Assert.assertEquals(AudioVideoConfiguration().audioMode, AudioMode.Stereo48K)
+    }
+
+    @Test
+    fun `default audio device capabilities should be input and output`() {
+        Assert.assertEquals(AudioVideoConfiguration().audioDeviceCapabilities, AudioDeviceCapabilities.InputAndOutput)
+    }
+
+    @Test
+    fun `default audio stream type should be voice call`() {
+        Assert.assertEquals(AudioVideoConfiguration().audioStreamType, AudioStreamType.VoiceCall)
+    }
+
+    @Test
+    fun `default audio recording preset override should be none`() {
+        Assert.assertEquals(AudioVideoConfiguration().audioRecordingPresetOverride, AudioRecordingPresetOverride.None)
+    }
+
+    @Test
+    fun `audio redundancy should be enabled by default`() {
+        Assert.assertEquals(AudioVideoConfiguration().enableAudioRedundancy, true)
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -6,6 +6,7 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo
 
 import android.util.Log
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
@@ -184,6 +185,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -203,6 +205,7 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Mono16K,
+                    AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
                     true
@@ -222,6 +225,7 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Mono48K,
+                    AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
                     true
@@ -241,10 +245,33 @@ class DefaultAudioVideoControllerTest {
                     attendeeId,
                     joinToken,
                     AudioMode.Stereo48K,
+                    AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
                     true
             )
+        }
+    }
+
+    @Test
+    fun `start with specified audio device capabilities should call audioClientController start with the parameters in configuration and the correct audio device capabilities`() {
+        for (capabilities in AudioDeviceCapabilities.values()) {
+            val testAudioVideoConfiguration = AudioVideoConfiguration(audioDeviceCapabilities = capabilities)
+            audioVideoController.start(testAudioVideoConfiguration)
+            verify {
+                audioClientController.start(
+                    audioFallbackURL,
+                    audioHostURL,
+                    meetingId,
+                    attendeeId,
+                    joinToken,
+                    AudioMode.Stereo48K,
+                    capabilities,
+                    AudioStreamType.VoiceCall,
+                    AudioRecordingPresetOverride.None,
+                    true
+                )
+            }
         }
     }
 
@@ -260,6 +287,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -279,26 +307,8 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.Music,
-                AudioRecordingPresetOverride.None,
-                true
-            )
-        }
-    }
-
-    @Test
-    fun `start with no_device should call audioClientController start with the parameters in configuration and no device`() {
-        val testAudioVideoConfiguration = AudioVideoConfiguration(audioMode = AudioMode.NoDevice)
-        audioVideoController.start(testAudioVideoConfiguration)
-        verify {
-            audioClientController.start(
-                audioFallbackURL,
-                audioHostURL,
-                meetingId,
-                attendeeId,
-                joinToken,
-                AudioMode.NoDevice,
-                AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
             )
@@ -317,6 +327,7 @@ class DefaultAudioVideoControllerTest {
                 attendeeId,
                 joinToken,
                 AudioMode.Stereo48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 false

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -129,7 +129,7 @@ class DefaultAudioVideoFacadeTest {
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns 0
         audioVideoFacade.start(AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.OutputOnly))
-        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
+        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
     }
 
     @Test
@@ -137,8 +137,8 @@ class DefaultAudioVideoFacadeTest {
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns 0
         audioVideoFacade.start(AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput))
-        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
-        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.RECORD_AUDIO) }
+        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
+        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.RECORD_AUDIO) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoFacadeTest.kt
@@ -129,7 +129,7 @@ class DefaultAudioVideoFacadeTest {
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns 0
         audioVideoFacade.start(AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.OutputOnly))
-        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
+        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
     }
 
     @Test
@@ -137,8 +137,8 @@ class DefaultAudioVideoFacadeTest {
         mockkStatic(ContextCompat::class)
         every { ContextCompat.checkSelfPermission(any(), any()) } returns 0
         audioVideoFacade.start(AudioVideoConfiguration(audioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput))
-        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
-        verify(exactly = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.RECORD_AUDIO) }
+        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.MODIFY_AUDIO_SETTINGS) }
+        verify(atLeast = 1) { ContextCompat.checkSelfPermission(any(), Manifest.permission.RECORD_AUDIO) }
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilitiesTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilitiesTest.kt
@@ -1,23 +1,22 @@
 package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
 
-import org.junit.Assert
+import android.Manifest
 import org.junit.Test
 
 class AudioDeviceCapabilitiesTest {
     @Test
-    fun `get enum value from int`() {
-        Assert.assertEquals(AudioDeviceCapabilities.from(0), AudioDeviceCapabilities.None)
-        Assert.assertEquals(AudioDeviceCapabilities.from(1), AudioDeviceCapabilities.OutputOnly)
-        Assert.assertEquals(AudioDeviceCapabilities.from(2), AudioDeviceCapabilities.InputAndOutput)
+    fun `should not require permissions for None`() {
+        assert(AudioDeviceCapabilities.None.requiredPermissions().isEmpty())
     }
 
     @Test
-    fun `get enum value from invalid int returns null`() {
-        Assert.assertNull(AudioDeviceCapabilities.from(-1))
+    fun `should require MODIFY_AUDIO_SETTINGS permissions for OutputOnly`() {
+        assert(AudioDeviceCapabilities.OutputOnly.requiredPermissions().contains(Manifest.permission.MODIFY_AUDIO_SETTINGS))
     }
 
     @Test
-    fun `get enum value from int with fallback to default value`() {
-        Assert.assertEquals(AudioDeviceCapabilities.from(-1, AudioDeviceCapabilities.InputAndOutput), AudioDeviceCapabilities.InputAndOutput)
+    fun `should check MODIFY_AUDIO_SETTINGS and RECORD_AUDIO permissions for InputAndOutput`() {
+        assert(AudioDeviceCapabilities.InputAndOutput.requiredPermissions().contains(Manifest.permission.MODIFY_AUDIO_SETTINGS))
+        assert(AudioDeviceCapabilities.InputAndOutput.requiredPermissions().contains(Manifest.permission.RECORD_AUDIO))
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilitiesTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioDeviceCapabilitiesTest.kt
@@ -1,0 +1,23 @@
+package com.amazonaws.services.chime.sdk.meetings.audiovideo.audio
+
+import org.junit.Assert
+import org.junit.Test
+
+class AudioDeviceCapabilitiesTest {
+    @Test
+    fun `get enum value from int`() {
+        Assert.assertEquals(AudioDeviceCapabilities.from(0), AudioDeviceCapabilities.None)
+        Assert.assertEquals(AudioDeviceCapabilities.from(1), AudioDeviceCapabilities.OutputOnly)
+        Assert.assertEquals(AudioDeviceCapabilities.from(2), AudioDeviceCapabilities.InputAndOutput)
+    }
+
+    @Test
+    fun `get enum value from invalid int returns null`() {
+        Assert.assertNull(AudioDeviceCapabilities.from(-1))
+    }
+
+    @Test
+    fun `get enum value from int with fallback to default value`() {
+        Assert.assertEquals(AudioDeviceCapabilities.from(-1, AudioDeviceCapabilities.InputAndOutput), AudioDeviceCapabilities.InputAndOutput)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
@@ -9,7 +9,6 @@ class AudioModeTest {
         Assert.assertEquals(AudioMode.from(1), AudioMode.Mono16K)
         Assert.assertEquals(AudioMode.from(2), AudioMode.Mono48K)
         Assert.assertEquals(AudioMode.from(3), AudioMode.Stereo48K)
-        Assert.assertEquals(AudioMode.from(4), AudioMode.NoDevice)
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/audio/AudioModeTest.kt
@@ -14,6 +14,7 @@ class AudioModeTest {
     @Test
     fun `get enum value from invalid int returns null`() {
         Assert.assertNull(AudioMode.from(-1))
+        Assert.assertNull(AudioMode.from(4))
     }
 
     @Test

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -15,6 +15,7 @@ import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.analytics.MeetingStatsCollector
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioRecordingPresetOverride
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamType
@@ -22,6 +23,7 @@ import com.amazonaws.services.chime.sdk.meetings.internal.utils.AppInfoUtil
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AppInfo
 import com.xodee.client.audio.audioclient.AudioClient
+import com.xodee.client.audio.audioclient.AudioClient.AudioDeviceCapabilitiesInternal
 import com.xodee.client.audio.audioclient.AudioClient.AudioModeInternal
 import com.xodee.client.audio.audioclient.AudioClient.AudioRecordingPreset
 import io.mockk.MockKAnnotations
@@ -287,6 +289,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -294,6 +297,8 @@ class DefaultAudioClientControllerTest {
 
         verify {
             mockAudioClient.startSession(withArg {
+                assertFalse(it.micMute)
+                assertFalse(it.spkMute)
                 assertEquals(AudioModeInternal.STEREO_48K, it.audioMode)
             })
         }
@@ -310,6 +315,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -335,6 +341,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -350,6 +357,78 @@ class DefaultAudioClientControllerTest {
     }
 
     @Test
+    fun `start with audio device capabilities none should call AudioClient startSession with capability none`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Stereo48K,
+            AudioDeviceCapabilities.None,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.None,
+            true
+        )
+
+        verify {
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioDeviceCapabilitiesInternal.NONE, it.audioDeviceCapabilities)
+            })
+        }
+    }
+
+    @Test
+    fun `start with audio device capabilities output only should call AudioClient startSession with capability output only`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Stereo48K,
+            AudioDeviceCapabilities.OutputOnly,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.None,
+            true
+        )
+
+        verify {
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioDeviceCapabilitiesInternal.OUTPUT_ONLY, it.audioDeviceCapabilities)
+            })
+        }
+    }
+
+    @Test
+    fun `start with audio device capabilities input and output should call AudioClient startSession with capability input and output`() {
+        setupStartTests()
+
+        audioClientController.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.None,
+            true
+        )
+
+        verify {
+            mockAudioClient.startSession(withArg {
+                assertEquals(AudioDeviceCapabilitiesInternal.INPUT_AND_OUTPUT, it.audioDeviceCapabilities)
+            })
+        }
+    }
+
+    @Test
     fun `start() with voice call stream should call startSession(AudioClientSessionConfig) with AudioStreamType VOICE_CALL`() {
         setupStartTests()
 
@@ -360,6 +439,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -383,6 +463,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.Music,
             AudioRecordingPresetOverride.None,
             true
@@ -406,6 +487,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Stereo48K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -427,6 +509,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -445,6 +528,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -473,6 +557,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -494,6 +579,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -519,6 +605,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -556,6 +643,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
             true
@@ -584,6 +672,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
                 true
@@ -607,6 +696,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.Generic,
                 true
@@ -630,6 +720,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.Camcorder,
                 true
@@ -653,6 +744,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.VoiceRecognition,
                 true
@@ -676,6 +768,7 @@ class DefaultAudioClientControllerTest {
                 testAttendeeId,
                 testJoinToken,
                 AudioMode.Mono16K,
+                AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.VoiceCommunication,
                 true
@@ -699,6 +792,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono16K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.VoiceCommunication,
             true
@@ -716,6 +810,7 @@ class DefaultAudioClientControllerTest {
             testAttendeeId,
             testJoinToken,
             AudioMode.Mono16K,
+            AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.VoiceCommunication,
             true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -48,12 +48,6 @@ class HomeActivity : AppCompatActivity() {
     private val TAG = "MeetingHomeActivity"
     private val WEBRTC_PERMISSION_REQUEST_CODE = 1
 
-    private val WEBRTC_PERM = arrayOf(
-        Manifest.permission.MODIFY_AUDIO_SETTINGS,
-        Manifest.permission.RECORD_AUDIO,
-        Manifest.permission.CAMERA
-    )
-
     private var meetingEditText: EditText? = null
     private var nameEditText: EditText? = null
     private var audioMode: AppCompatSpinner? = null
@@ -136,11 +130,7 @@ class HomeActivity : AppCompatActivity() {
             if (hasPermissionsAlready()) {
                 authenticate(testUrl, meetingID, yourName)
             } else {
-                var permissions = when (audioVideoConfig.audioDeviceCapabilities) {
-                    AudioDeviceCapabilities.None -> arrayOf(Manifest.permission.CAMERA)
-                    AudioDeviceCapabilities.OutputOnly -> arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
-                    else -> WEBRTC_PERM
-                }
+                val permissions = audioVideoConfig.audioDeviceCapabilities.requiredPermissions() + arrayOf(Manifest.permission.CAMERA)
                 ActivityCompat.requestPermissions(this, permissions, WEBRTC_PERMISSION_REQUEST_CODE)
             }
         }
@@ -152,11 +142,7 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun hasPermissionsAlready(): Boolean {
-        var permissions = when (audioVideoConfig.audioDeviceCapabilities) {
-            AudioDeviceCapabilities.None -> arrayOf(Manifest.permission.CAMERA)
-            AudioDeviceCapabilities.OutputOnly -> arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
-            else -> WEBRTC_PERM
-        }
+        val permissions = audioVideoConfig.audioDeviceCapabilities.requiredPermissions() + arrayOf(Manifest.permission.CAMERA)
         return permissions.all {
             ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED
         }
@@ -212,7 +198,7 @@ class HomeActivity : AppCompatActivity() {
                                 NAME_KEY to attendeeName,
                                 MEETING_ENDPOINT_KEY to meetingUrl,
                                 AUDIO_MODE_KEY to audioVideoConfig.audioMode.value,
-                                AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities.value,
+                                AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities,
                                 ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy
                             )
                         )

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -136,10 +136,10 @@ class HomeActivity : AppCompatActivity() {
             if (hasPermissionsAlready()) {
                 authenticate(testUrl, meetingID, yourName)
             } else {
-                var permissions = WEBRTC_PERM
-                when (audioVideoConfig.audioDeviceCapabilities) {
-                    AudioDeviceCapabilities.None -> permissions = arrayOf(Manifest.permission.CAMERA)
-                    AudioDeviceCapabilities.OutputOnly -> permissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
+                var permissions = when (audioVideoConfig.audioDeviceCapabilities) {
+                    AudioDeviceCapabilities.None -> arrayOf(Manifest.permission.CAMERA)
+                    AudioDeviceCapabilities.OutputOnly -> arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
+                    else -> WEBRTC_PERM
                 }
                 ActivityCompat.requestPermissions(this, permissions, WEBRTC_PERMISSION_REQUEST_CODE)
             }
@@ -152,10 +152,10 @@ class HomeActivity : AppCompatActivity() {
     }
 
     private fun hasPermissionsAlready(): Boolean {
-        var permissions = WEBRTC_PERM
-        when (audioVideoConfig.audioDeviceCapabilities) {
-            AudioDeviceCapabilities.None -> permissions = arrayOf(Manifest.permission.CAMERA)
-            AudioDeviceCapabilities.OutputOnly -> permissions = arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
+        var permissions = when (audioVideoConfig.audioDeviceCapabilities) {
+            AudioDeviceCapabilities.None -> arrayOf(Manifest.permission.CAMERA)
+            AudioDeviceCapabilities.OutputOnly -> arrayOf(Manifest.permission.MODIFY_AUDIO_SETTINGS, Manifest.permission.CAMERA)
+            else -> WEBRTC_PERM
         }
         return permissions.all {
             ContextCompat.checkSelfPermission(this, it) == PackageManager.PERMISSION_GRANTED

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -68,9 +68,7 @@ class MeetingActivity : AppCompatActivity(),
         val audioMode = intent.extras?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
             AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
         } ?: AudioMode.Stereo48K
-        val audioDeviceCapabilities = intent.extras?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
-            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
-        } ?: AudioDeviceCapabilities.InputAndOutput
+        val audioDeviceCapabilities = intent.extras?.get(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY) as? AudioDeviceCapabilities ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = intent.extras?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
         audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
         meetingEndpointUrl = intent.extras?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -11,6 +11,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoConfiguration
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoFacade
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoResolution
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.backgroundfilter.backgroundblur.BackgroundBlurConfiguration
@@ -67,8 +68,11 @@ class MeetingActivity : AppCompatActivity(),
         val audioMode = intent.extras?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
             AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
         } ?: AudioMode.Stereo48K
+        val audioDeviceCapabilities = intent.extras?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
+            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
+        } ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = intent.extras?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
-        audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, enableAudioRedundancy = enableAudioRedundancy)
+        audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
         meetingEndpointUrl = intent.extras?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -235,7 +235,7 @@ class MeetingFragment : Fragment(),
             fragment.arguments = bundleOf(
                 HomeActivity.MEETING_ID_KEY to meetingId,
                 HomeActivity.AUDIO_MODE_KEY to audioVideoConfig.audioMode.value,
-                HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities.value,
+                HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities,
                 HomeActivity.MEETING_ENDPOINT_KEY to meetingEndpointUrl,
                 HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy
             )
@@ -312,9 +312,7 @@ class MeetingFragment : Fragment(),
         val audioMode = arguments?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
             AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
         } ?: AudioMode.Stereo48K
-        val audioDeviceCapabilities = arguments?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
-            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
-        } ?: AudioDeviceCapabilities.InputAndOutput
+        val audioDeviceCapabilities = arguments?.get(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY) as? AudioDeviceCapabilities ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = arguments?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
         val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
         // Start Audio Video
@@ -327,9 +325,7 @@ class MeetingFragment : Fragment(),
         buttonMute = view.findViewById(R.id.buttonMute)
         buttonMute.setImageResource(if (meetingModel.isMuted) R.drawable.button_mute_on else R.drawable.button_mute)
         buttonMute.setOnClickListener { toggleMute() }
-        val audioDeviceCapabilities = arguments?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
-            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
-        } ?: AudioDeviceCapabilities.InputAndOutput
+        val audioDeviceCapabilities = arguments?.get(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY) as? AudioDeviceCapabilities ?: AudioDeviceCapabilities.InputAndOutput
         if (audioDeviceCapabilities == AudioDeviceCapabilities.None || audioDeviceCapabilities == AudioDeviceCapabilities.OutputOnly) {
             buttonMute.isEnabled = false
             meetingModel.isMuted = true

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -52,6 +52,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptItem
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatus
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.TranscriptionStatusType
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.VolumeUpdate
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioDeviceCapabilities
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioMode
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerdetector.ActiveSpeakerObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.activespeakerpolicy.DefaultActiveSpeakerPolicy
@@ -234,6 +235,7 @@ class MeetingFragment : Fragment(),
             fragment.arguments = bundleOf(
                 HomeActivity.MEETING_ID_KEY to meetingId,
                 HomeActivity.AUDIO_MODE_KEY to audioVideoConfig.audioMode.value,
+                HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities.value,
                 HomeActivity.MEETING_ENDPOINT_KEY to meetingEndpointUrl,
                 HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy
             )
@@ -310,8 +312,11 @@ class MeetingFragment : Fragment(),
         val audioMode = arguments?.getInt(HomeActivity.AUDIO_MODE_KEY)?.let { intValue ->
             AudioMode.from(intValue, defaultAudioMode = AudioMode.Stereo48K)
         } ?: AudioMode.Stereo48K
+        val audioDeviceCapabilities = arguments?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
+            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
+        } ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = arguments?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
-        val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, enableAudioRedundancy = enableAudioRedundancy)
+        val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
         // Start Audio Video
         audioVideo.start(audioVideoConfig)
         audioVideo.startRemoteVideo()

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -327,6 +327,14 @@ class MeetingFragment : Fragment(),
         buttonMute = view.findViewById(R.id.buttonMute)
         buttonMute.setImageResource(if (meetingModel.isMuted) R.drawable.button_mute_on else R.drawable.button_mute)
         buttonMute.setOnClickListener { toggleMute() }
+        val audioDeviceCapabilities = arguments?.getInt(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY)?.let { intValue ->
+            AudioDeviceCapabilities.from(intValue, defaultAudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput)
+        } ?: AudioDeviceCapabilities.InputAndOutput
+        if (audioDeviceCapabilities == AudioDeviceCapabilities.None || audioDeviceCapabilities == AudioDeviceCapabilities.OutputOnly) {
+            buttonMute.isEnabled = false
+            meetingModel.isMuted = true
+            buttonMute.setImageResource(R.drawable.button_mute_on)
+        }
 
         buttonSpeaker = view.findViewById(R.id.buttonSpeaker)
         buttonSpeaker.setOnClickListener { toggleSpeaker() }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -49,6 +49,13 @@
         android:contentDescription="@string/audio_mode_spinner"
         android:layout_gravity="center"/>
 
+    <androidx.appcompat.widget.AppCompatSpinner
+        android:id="@+id/audioDeviceCapabilitiesSpinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/audio_device_capabilities_spinner"
+        android:layout_gravity="center"/>
+
     <androidx.appcompat.widget.SwitchCompat
         android:id="@+id/audioRedundancySwitch"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="edit_name">Your Name</string>
     <string name="main_title">Join a meeting</string>
     <string name="audio_mode_spinner">Audio Mode</string>
+    <string name="audio_device_capabilities_spinner">Audio Device Capabilities</string>
     <string name="audio_redundancy_switch">Audio Redundancy</string>
     <string name="main_continue">Continue</string>
     <string name="main_continue_without_audio">Continue without audio</string>

--- a/guides/api_overview.md
+++ b/guides/api_overview.md
@@ -59,17 +59,20 @@ A DeviceChangeObserver has the following method:
 
 Before starting audio or video, you will need to request permissions from the user and verify that
 they are granted. Otherwise, the API will throw a `SecurityException`. Amazon Chime SDK for Android 
-already declares these permissions in its manifest file.
-
-Audio permissions:
-```
-Manifest.permission.MODIFY_AUDIO_SETTINGS,
-Manifest.permission.RECORD_AUDIO
-```
+already declares the following permissions in its manifest file.
 
 Video permissions:
 ```
 Manifest.permission.CAMERA
+```
+
+Based on which `AudioDeviceCapabilities` you plan to have users join meetings with, you will need to
+request certain audio permissions and declare them in your manifest file.
+
+Audio permissions:
+```
+Manifest.permission.MODIFY_AUDIO_SETTINGS // Required for `AudioDeviceCapabilities.InputAndOutput` and `AudioDeviceCapabilities.OutputOnly`
+Manifest.permission.RECORD_AUDIO          // Required for `AudioDeviceCapabilities.InputAndOutput`
 ```
 
 ## 4. Register an audio video observer 
@@ -96,8 +99,7 @@ An AudioVideoObserver has the following methods:
 
 ## 5. Starting and stopping the meeting session
 
-Call this method after doing pre-requisite configuration (See previous sections). Audio permissions
-are required for starting the meeting session. 
+Call this method after doing pre-requisite configuration (See previous sections).
 
 To start the meeting session, call meetingSession.audioVideo.[start()](https://aws.github.io/amazon-chime-sdk-android/amazon-chime-sdk/com.amazonaws.services.chime.sdk.meetings.audiovideo/-audio-video-controller-facade/start.html). This will start underlying
 media clients and will start sending and receiving audio.

--- a/guides/getting_started.md
+++ b/guides/getting_started.md
@@ -37,12 +37,12 @@ compileOptions {
     targetCompatibility JavaVersion.VERSION_1_8
 }
 ```
-6. `MODIFY_AUDIO_SETTINGS`, `RECORD_AUDIO`, and `CAMERA` permissions are already added to the manifest by the Amazon Chime SDK. Your activity should also request the appropriate permissions.
+6. `CAMERA` permissions are already added to the manifest by the Amazon Chime SDK. Your activity should also request the appropriate permissions. Additionally, based on which `AudioDeviceCapabilities` you plan to have users join meetings with, you will need to add `MODIFY_AUDIO_SETTINGS` or `RECORD_AUDIO` to your manifest file and request these permissions in your application.
 ```
 private val PERMISSION_REQUEST_CODE = 1
 private val PERMISSIONS = arrayOf(
-    Manifest.permission.MODIFY_AUDIO_SETTINGS,
-    Manifest.permission.RECORD_AUDIO,
+    Manifest.permission.MODIFY_AUDIO_SETTINGS, // Required for `AudioDeviceCapabilities.InputAndOutput` and `AudioDeviceCapabilities.OutputOnly`
+    Manifest.permission.RECORD_AUDIO,          // Required for `AudioDeviceCapabilities.InputAndOutput`
     Manifest.permission.CAMERA)
 
 ActivityCompat.requestPermissions(applicationContext, PERMISSIONS, PERMISSION_REQUEST_CODE)


### PR DESCRIPTION
## ℹ️ Description
1. Added `AudioDeviceCapabilities` to enable configuring audio device capabilities before starting a meeting. The supported capabilities are:
    1. Input and Output (both microphone and speaker enabled)
    2. Output only (microphone disabled and speaker enabled, this is a new feature)
    3. None (both microphone and speaker disabled, this replaces `AudioMode.NoDevice`)
2. Removed `AudioMode.NoDevice` since it has been replaced by `AudioDeviceCapabilities.None`
3. [Demo] Added option to select audio device capabilities on join screen

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
A demo build of these changes has successfully gone through QA testing. Also manually tested the following scenarios:
1. Joined meeting with `AudioDeviceCapabilities.InputAndOutput` and verified that:
    1. Audio recording permissions were required
    3. Was able to send audio to remote attendee
    4. Was able to receive audio from remote attendee
2. Joined meeting with `AudioDeviceCapabilities.OutputOnly` and verified that:
    1. Audio recording permissions were *not* required
    2. Was *not* able to send audio to remote attendee
    3. Was able to receive audio from remote attendee
3. Joined meeting with `AudioDeviceCapabilities.None` and verified that:
    1. Audio recording permissions were *not* required
    2. Was *not* able to send audio to remote attendee
    3. Was *not* able to receive audio from remote attendee

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
![capabilities-android](https://github.com/aws/amazon-chime-sdk-android/assets/117114313/870b5db6-6371-4ba1-bc6e-b86c0904e8da)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
