### PR TITLE
Send meetingStatus to ingestion service

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientObserver.kt
@@ -9,6 +9,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.AudioVideoObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.PrimaryMeetingPromotionObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.RealtimeObserver
 import com.amazonaws.services.chime.sdk.meetings.realtime.TranscriptEventObserver
+import com.amazonaws.services.chime.sdk.meetings.session.MeetingSessionStatusCode
 import com.xodee.client.audio.audioclient.AudioClientLogListener
 import com.xodee.client.audio.audioclient.AudioClientMetricsListener
 import com.xodee.client.audio.audioclient.AudioClientPresenceListener
@@ -37,4 +38,5 @@ interface AudioClientObserver : AudioClientStateChangeListener,
     fun unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver)
     // This only supports one observer at a time
     var primaryMeetingPromotionObserver: PrimaryMeetingPromotionObserver?
+    var currentAudioStatus: MeetingSessionStatusCode?
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -240,7 +240,8 @@ class DefaultAudioClientController(
                 logger.error(TAG, "Failed to start audio session. Response code: $res")
 
                 eventAnalyticsController.publishEvent(
-                    EventName.meetingStartFailed
+                    EventName.meetingStartFailed,
+                    mutableMapOf(EventAttributeName.meetingStatus to audioClientObserver.currentAudioStatus as MeetingSessionStatusCode)
                 )
             } else {
                 logger.info(TAG, "Started audio session.")

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserver.kt
@@ -66,7 +66,7 @@ class DefaultAudioClientObserver(
      * codes that we map to [MeetingSessionStatusCode].
      */
     private var currentAudioState = SessionStateControllerAction.Init
-    private var currentAudioStatus: MeetingSessionStatusCode? = MeetingSessionStatusCode.OK
+    override var currentAudioStatus: MeetingSessionStatusCode? = MeetingSessionStatusCode.OK
 
     private var audioClientStateObservers = ConcurrentSet.createConcurrentSet<AudioVideoObserver>()
     private var realtimeEventObservers = ConcurrentSet.createConcurrentSet<RealtimeObserver>()


### PR DESCRIPTION
## ℹ️ Description
Route meetingStatus to ingestion service for meeting start and failed events.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Tested the demo and checked ingestion logs

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
