### PR TITLE
Make reconnecting timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ These configurations are available in `audioVideoConfiguration`:
 - `audioStreamType`
 - `audioRecordingPresetOverride`
 - `enableAudioRedundancy`
+- `reconnectTimeoutMs`
 
 AudioMode: The default audio format is Stereo/48KHz i.e Stereo Audio with 48KHz sampling rate (Stereo48K). Other supported audio formats include Mono/48KHz (Mono48K) or Mono/16KHz (Mono16K). You can specify a non-default audio mode in `AudioVideoConfiguration`, and then start the meeting session.
 
@@ -229,6 +230,8 @@ mentioned [here](https://android.googlesource.com/platform/frameworks/wilhelm/+/
 
 EnableAudioRedundancy: The default value is true. When enabled, the SDK will send redundant audio data on detecting packet loss to help reduce its effects on audio quality. More details can be found in the
 *Redundant Audio* section.
+
+ReconnectTimeoutMs: The default value is 180,000ms. Use this configuration to control the session reconnect timeout due to poor network condition.
 
 #### Use case 2. Add an observer to receive audio and video session life cycle events.
 
@@ -351,6 +354,7 @@ override fun onAudioDeviceChanged(freshAudioDeviceList: List<MediaDevice>) {
 > - Supported AudioStreamType options: *VoiceCall* and *Music*. Default is *VoiceCall*
 > - Supported AudioRecordingPresetOverride options: *None*, *Generic*, *Camcorder*, *VoiceRecognition* and *VoiceCommunication*. Default is *None*.
 > - Supported enableAudioRedundancy options: *true* and *false*. Default is *true*.
+> - Supported reconnectTimeoutMs values: Integers greater than or equal to 0. Default is *180,000*.
 
 ```kotlin
 meetingSession.audioVideo.start() // starts the audio video session with defaults mentioned above

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfiguration.kt
@@ -22,11 +22,15 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.audio.AudioStreamTyp
  *
  * @property audioStreamType: AudioStreamType - the audio stream type in which the audio client
  * should operate during a meeting session.
+ *
+ * @property reconnectTimeoutMs: Int - Maximum amount of time in milliseconds to allow for reconnecting. Default
+ * value is 180000.
  */
 data class AudioVideoConfiguration @JvmOverloads constructor(
     val audioMode: AudioMode = AudioMode.Stereo48K,
     val audioDeviceCapabilities: AudioDeviceCapabilities = AudioDeviceCapabilities.InputAndOutput,
     val audioStreamType: AudioStreamType = AudioStreamType.VoiceCall,
     val audioRecordingPresetOverride: AudioRecordingPresetOverride = AudioRecordingPresetOverride.None,
-    val enableAudioRedundancy: Boolean = true
+    val enableAudioRedundancy: Boolean = true,
+    val reconnectTimeoutMs: Int = 180 * 1000
 )

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoController.kt
@@ -61,7 +61,8 @@ class DefaultAudioVideoController(
             audioDeviceCapabilities = audioVideoConfiguration.audioDeviceCapabilities,
             audioStreamType = audioVideoConfiguration.audioStreamType,
             audioRecordingPresetOverride = audioVideoConfiguration.audioRecordingPresetOverride,
-            enableAudioRedundancy = audioVideoConfiguration.enableAudioRedundancy
+            enableAudioRedundancy = audioVideoConfiguration.enableAudioRedundancy,
+            reconnectTimeoutMs = audioVideoConfiguration.reconnectTimeoutMs
         )
         videoClientController.start()
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/AudioClientController.kt
@@ -32,7 +32,8 @@ interface AudioClientController {
         audioDeviceCapabilities: AudioDeviceCapabilities,
         audioStreamType: AudioStreamType,
         audioRecordingPresetOverride: AudioRecordingPresetOverride,
-        enableAudioRedundancy: Boolean
+        enableAudioRedundancy: Boolean,
+        reconnectTimeoutMs: Int
     )
 
     fun stop()

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -137,7 +137,8 @@ class DefaultAudioClientController(
         audioDeviceCapabilities: AudioDeviceCapabilities,
         audioStreamType: AudioStreamType,
         audioRecordingPresetOverride: AudioRecordingPresetOverride,
-        enableAudioRedundancy: Boolean
+        enableAudioRedundancy: Boolean,
+        reconnectTimeoutMs: Int
     ) {
         // Validate audio client state
         if (audioClientState != AudioClientState.INITIALIZED &&
@@ -201,12 +202,12 @@ class DefaultAudioClientController(
 
             val audioDeviceCapabilitiesInternal = mapAudioDeviceCapabilitiesToInternal(audioDeviceCapabilities)
 
-            var audioStreamTypeInternal = when (audioStreamType) {
+            val audioStreamTypeInternal = when (audioStreamType) {
                 AudioStreamType.VoiceCall -> AudioClient.AudioStreamType.VOICE_CALL
                 AudioStreamType.Music -> AudioClient.AudioStreamType.MUSIC
             }
 
-            var audioRecordingPresetInternal = when (audioRecordingPresetOverride) {
+            val audioRecordingPresetInternal = when (audioRecordingPresetOverride) {
                 AudioRecordingPresetOverride.None -> getDefaultRecordingPreset()
                 AudioRecordingPresetOverride.Generic -> AudioClient.AudioRecordingPreset.GENERIC
                 AudioRecordingPresetOverride.Camcorder -> AudioClient.AudioRecordingPreset.CAMCORDER
@@ -214,7 +215,7 @@ class DefaultAudioClientController(
                 AudioRecordingPresetOverride.VoiceCommunication -> AudioClient.AudioRecordingPreset.VOICE_COMMUNICATION
             }
 
-            var config = AudioClientSessionConfig.Builder(
+            val config = AudioClientSessionConfig.Builder(
                 host,
                 port,
                 joinToken,
@@ -232,6 +233,7 @@ class DefaultAudioClientController(
                 .withSpkMute(muteMicAndSpeaker)
                 .withPresenter(DEFAULT_PRESENTER)
                 .withProxyConfig(null)
+                .withReconnectTimeoutMs(reconnectTimeoutMs)
                 .build()
 
             val res = audioClient.startSession(config)

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/AudioVideoConfigurationTest.kt
@@ -32,4 +32,9 @@ class AudioVideoConfigurationTest {
     fun `audio redundancy should be enabled by default`() {
         Assert.assertEquals(AudioVideoConfiguration().enableAudioRedundancy, true)
     }
+
+    @Test
+    fun `default reconnectTimeoutMs should be 180000`() {
+        Assert.assertEquals(AudioVideoConfiguration().reconnectTimeoutMs, 180000)
+    }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -188,7 +188,8 @@ class DefaultAudioVideoControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
             )
         }
     }
@@ -208,7 +209,8 @@ class DefaultAudioVideoControllerTest {
                     AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
-                    true
+                    true,
+                    reconnectTimeoutMs = 180000
             )
         }
     }
@@ -228,7 +230,8 @@ class DefaultAudioVideoControllerTest {
                     AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
-                    true
+                    true,
+                    reconnectTimeoutMs = 180000
             )
         }
     }
@@ -248,7 +251,8 @@ class DefaultAudioVideoControllerTest {
                     AudioDeviceCapabilities.InputAndOutput,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
-                    true
+                    true,
+                    reconnectTimeoutMs = 180000
             )
         }
     }
@@ -269,7 +273,8 @@ class DefaultAudioVideoControllerTest {
                     capabilities,
                     AudioStreamType.VoiceCall,
                     AudioRecordingPresetOverride.None,
-                    true
+                    true,
+                    reconnectTimeoutMs = 180000
                 )
             }
         }
@@ -290,7 +295,8 @@ class DefaultAudioVideoControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
             )
         }
     }
@@ -310,7 +316,8 @@ class DefaultAudioVideoControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.Music,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
             )
         }
     }
@@ -330,7 +337,8 @@ class DefaultAudioVideoControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                false
+                false,
+                reconnectTimeoutMs = 180000
             )
         }
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -296,7 +296,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -322,7 +323,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -348,7 +350,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -374,7 +377,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.None,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -398,7 +402,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.OutputOnly,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -422,7 +427,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -446,7 +452,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -470,7 +477,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.Music,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -494,7 +502,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -516,7 +525,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify(exactly = 1) { mockAudioClientObserver.notifyAudioClientObserver(any()) }
@@ -535,7 +545,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify(exactly = 1) { mockEventAnalyticsController.publishEvent(EventName.meetingStartRequested, any()) }
@@ -558,7 +569,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         verify(exactly = 1) { mockEventAnalyticsController
@@ -589,7 +601,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -611,7 +624,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
         every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
 
@@ -637,7 +651,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         val enableOutput: Boolean = audioClientController.setVoiceFocusEnabled(true)
@@ -675,7 +690,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.None,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
 
         audioClientController.isVoiceFocusEnabled()
@@ -704,7 +720,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.None,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -728,7 +745,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.Generic,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -752,7 +770,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.Camcorder,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -776,7 +795,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.VoiceRecognition,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -800,7 +820,8 @@ class DefaultAudioClientControllerTest {
                 AudioDeviceCapabilities.InputAndOutput,
                 AudioStreamType.VoiceCall,
                 AudioRecordingPresetOverride.VoiceCommunication,
-                true
+                true,
+                reconnectTimeoutMs = 180000
         )
 
         verify {
@@ -824,7 +845,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.VoiceCommunication,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
     }
 
@@ -842,7 +864,8 @@ class DefaultAudioClientControllerTest {
             AudioDeviceCapabilities.InputAndOutput,
             AudioStreamType.VoiceCall,
             AudioRecordingPresetOverride.VoiceCommunication,
-            true
+            true,
+            reconnectTimeoutMs = 180000
         )
     }
 }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -53,12 +53,14 @@ class HomeActivity : AppCompatActivity() {
     private var audioMode: AppCompatSpinner? = null
     private var audioDeviceCapabilitiesSpinner: AppCompatSpinner? = null
     private var audioRedundancySwitch: SwitchCompat? = null
+    private var reconnectTimeoutSpinner: AppCompatSpinner? = null
     private var authenticationProgressBar: ProgressBar? = null
     private var meetingID: String? = null
     private var yourName: String? = null
     private var testUrl: String = ""
     private var audioModes = listOf("Stereo/48KHz Audio", "Mono/48KHz Audio", "Mono/16KHz Audio")
     private var audioDeviceCapabilitiesOptions = listOf("Input and Output", "None", "Output Only")
+    private var reconnectTimeoutOptions = listOf(180000, 20000, 5000, 0)
     private lateinit var audioVideoConfig: AudioVideoConfiguration
     private lateinit var debugSettingsViewModel: DebugSettingsViewModel
 
@@ -70,6 +72,7 @@ class HomeActivity : AppCompatActivity() {
         const val AUDIO_MODE_KEY = "AUDIO_MODE"
         const val AUDIO_DEVICE_CAPABILITIES_KEY = "AUDIO_DEVICE_CAPABILITIES"
         const val ENABLE_AUDIO_REDUNDANCY_KEY = "ENABLE_AUDIO_REDUNDANCY"
+        const val RECONNECT_TIMEOUT_MS = "RECONNECT_TIMEOUT_MS"
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -90,6 +93,10 @@ class HomeActivity : AppCompatActivity() {
         findViewById<Button>(R.id.buttonContinue)?.setOnClickListener {
             joinMeeting()
         }
+
+        reconnectTimeoutSpinner = findViewById(R.id.reconnectTimeoutSpinner)
+        reconnectTimeoutSpinner?.adapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, reconnectTimeoutOptions.map { "Reconnect timeout ms: $it" })
+
         findViewById<Button>(R.id.buttonDebugSettings)?.setOnClickListener { showDebugSettings() }
 
         val versionText: TextView = findViewById(R.id.versionText) as TextView
@@ -115,8 +122,10 @@ class HomeActivity : AppCompatActivity() {
             2 -> audioDeviceCapabilities = AudioDeviceCapabilities.OutputOnly
         }
 
+        val reconnectTimeoutMs = reconnectTimeoutOptions[reconnectTimeoutSpinner?.selectedItemPosition ?: 0]
+
         val redundancyEnabled = audioRedundancySwitch?.isChecked as Boolean
-        audioVideoConfig = AudioVideoConfiguration(audioMode = mode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = redundancyEnabled)
+        audioVideoConfig = AudioVideoConfiguration(audioMode = mode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = redundancyEnabled, reconnectTimeoutMs = reconnectTimeoutMs)
 
         meetingID = meetingEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")
         yourName = nameEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")
@@ -199,7 +208,8 @@ class HomeActivity : AppCompatActivity() {
                                 MEETING_ENDPOINT_KEY to meetingUrl,
                                 AUDIO_MODE_KEY to audioVideoConfig.audioMode.value,
                                 AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities,
-                                ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy
+                                ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy,
+                                RECONNECT_TIMEOUT_MS to audioVideoConfig.reconnectTimeoutMs
                             )
                         )
                     }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/MeetingActivity.kt
@@ -70,7 +70,8 @@ class MeetingActivity : AppCompatActivity(),
         } ?: AudioMode.Stereo48K
         val audioDeviceCapabilities = intent.extras?.get(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY) as? AudioDeviceCapabilities ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = intent.extras?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
-        audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
+        val reconnectTimeoutMs = intent.extras?.getInt(HomeActivity.RECONNECT_TIMEOUT_MS) as Int
+        audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy, reconnectTimeoutMs = reconnectTimeoutMs)
         meetingEndpointUrl = intent.extras?.getString(HomeActivity.MEETING_ENDPOINT_KEY) as String
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -237,7 +237,8 @@ class MeetingFragment : Fragment(),
                 HomeActivity.AUDIO_MODE_KEY to audioVideoConfig.audioMode.value,
                 HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY to audioVideoConfig.audioDeviceCapabilities,
                 HomeActivity.MEETING_ENDPOINT_KEY to meetingEndpointUrl,
-                HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy
+                HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY to audioVideoConfig.enableAudioRedundancy,
+                HomeActivity.RECONNECT_TIMEOUT_MS to audioVideoConfig.reconnectTimeoutMs
             )
             return fragment
         }
@@ -314,7 +315,8 @@ class MeetingFragment : Fragment(),
         } ?: AudioMode.Stereo48K
         val audioDeviceCapabilities = arguments?.get(HomeActivity.AUDIO_DEVICE_CAPABILITIES_KEY) as? AudioDeviceCapabilities ?: AudioDeviceCapabilities.InputAndOutput
         val enableAudioRedundancy = arguments?.getBoolean(HomeActivity.ENABLE_AUDIO_REDUNDANCY_KEY) as Boolean
-        val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy)
+        val reconnectTimeoutMs = arguments?.getInt(HomeActivity.RECONNECT_TIMEOUT_MS) as Int
+        val audioVideoConfig = AudioVideoConfiguration(audioMode = audioMode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = enableAudioRedundancy, reconnectTimeoutMs = reconnectTimeoutMs)
         // Start Audio Video
         audioVideo.start(audioVideoConfig)
         audioVideo.startRemoteVideo()

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -64,6 +64,13 @@
         android:text="@string/audio_redundancy_switch"
         android:layout_gravity="center"/>
 
+    <androidx.appcompat.widget.AppCompatSpinner
+            android:id="@+id/reconnectTimeoutSpinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:contentDescription="@string/reconnect_timeout_spinner"
+            android:layout_gravity="center"/>
+
     <Button
         android:id="@+id/buttonContinue"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="audio_mode_spinner">Audio Mode</string>
     <string name="audio_device_capabilities_spinner">Audio Device Capabilities</string>
     <string name="audio_redundancy_switch">Audio Redundancy</string>
+    <string name="reconnect_timeout_spinner">Reconnect Timeout MS</string>
     <string name="main_continue">Continue</string>
     <string name="main_continue_without_audio">Continue without audio</string>
     <string name="join_meeting">Join Meeting</string>


### PR DESCRIPTION
## ℹ️ Description
 - Add `reconnectTimeoutMs` to `AudioVideoConfiguration` to enable configurable reconnect timeout

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [x] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - An UI has been added on join meeting screen for configuring reconnect timeout, manually tested by configuring it and running the meeting.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
