### PR TITLE
Add retry and run tests against the latest 2 OS versions

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -37,13 +37,16 @@ jobs:
         with:
           node-version: 15.x
 
-      - name: Run tests
+      - name: Run tests against the latest 2 Android versions
         id: tests
         run: |
           id=$(curl -F 'payload=@amazon-chime-sdk-app.apk' -F name=amazon-chime-sdk-app.apk -u "${{ secrets.SAUCE_USERNAME }}:${{ secrets.SAUCE_ACCESS_KEY }}" 'https://api.us-west-1.saucelabs.com/v1/storage/upload' |jq '.item.id')
           npm install
           npm run build
-          npm run cma -- --app-url "sample.apk" --log-level error --tag "@common" --app-id "${id}" --platform-version "9"
+          for os in 13 14; do
+            npm run cma -- --app-url "sample.apk" --log-level error --tag "@common" --app-id "${id}" --retry --platform-version $os
+            sleep 10
+          done
 
       - name: Send Notification
         uses: slackapi/slack-github-action@v1.25.0

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -3,8 +3,8 @@ name: Daily Test
 on:
   schedule:
     # More information on cron https://crontab.guru/
-    # GitHub actions is using UTC time. Scheduling action at 5 am PST
-    - cron: '0 13 * * *'
+    # GitHub actions is using UTC time. Scheduling action at 4 am PST
+    - cron: '0 12 * * *'
 
   workflow_dispatch:
 
@@ -43,7 +43,7 @@ jobs:
           id=$(curl -F 'payload=@amazon-chime-sdk-app.apk' -F name=amazon-chime-sdk-app.apk -u "${{ secrets.SAUCE_USERNAME }}:${{ secrets.SAUCE_ACCESS_KEY }}" 'https://api.us-west-1.saucelabs.com/v1/storage/upload' |jq '.item.id')
           npm install
           npm run build
-          for os in 13 14; do
+          for os in 12 13; do
             npm run cma -- --app-url "sample.apk" --log-level error --tag "@common" --app-id "${id}" --retry --platform-version $os
             sleep 10
           done


### PR DESCRIPTION
## ℹ️ Description
* To stabilize the success rate, retry each failed test step 2 additional times.
* Run the daily tests against the latest 2 Android versions.

revision 2
* move execution time 1 hour earlier than iOS daily tests.
* change test version to 12 and 13

Workflow run - https://github.com/aws/amazon-chime-sdk-android/actions/runs/10743103063/job/29797144276

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
