### PR TITLE
Fixes incorrect event being published when the meeting is ended normally.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Fixed
+* When meeting has ended normally, but not initiated by the client, send a meetingEnded event rather than a meetingFailed event. 
+
 ### Changed
 * Upgrade gradle version and dokka
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionStatusCode.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/session/MeetingSessionStatusCode.kt
@@ -106,7 +106,12 @@ enum class MeetingSessionStatusCode(val value: Int) {
     /**
      * Designated input device is not responding and timed out.
      */
-    AudioInputDeviceNotResponding(15);
+    AudioInputDeviceNotResponding(15),
+
+    /**
+     * Chime SDK audio server hung up.
+     */
+    AudioServerHungup(16);
 
     companion object {
         fun from(intValue: Int): MeetingSessionStatusCode? = values().find { it.value == intValue }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
@@ -1106,6 +1106,64 @@ class DefaultAudioClientObserverTest {
         verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
     }
 
+    fun `onAudioClientStateChange should stop session and notify of session stop event when finish disconnecting while connecting`() {
+        every { mockAudioClient.stopSession() } returns 0
+
+        runBlockingTest {
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_CONNECTING,
+                AudioClient.AUDIO_CLIENT_OK
+            )
+
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_SERVER_HUNGUP,
+                AudioClient.AUDIO_CLIENT_ERR_SERVER_HUNGUP
+            )
+        }
+
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockEventAnalyticsController.publishEvent(EventName.meetingEnded, any()) }
+    }
+
+    fun `onAudioClientStateChange should stop session and notify of session stop event when finish disconnecting while connected`() {
+        every { mockAudioClient.stopSession() } returns 0
+
+        runBlockingTest {
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_CONNECTED,
+                AudioClient.AUDIO_CLIENT_OK
+            )
+
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_SERVER_HUNGUP,
+                AudioClient.AUDIO_CLIENT_ERR_SERVER_HUNGUP
+            )
+        }
+
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockEventAnalyticsController.publishEvent(EventName.meetingEnded, any()) }
+    }
+
+    fun `onAudioClientStateChange should stop session and notify of session stop event when finish disconnecting while reconnecting`() {
+        runBlockingTest {
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_RECONNECTING,
+                AudioClient.AUDIO_CLIENT_OK
+            )
+
+            audioClientObserver.onAudioClientStateChange(
+                AudioClient.AUDIO_CLIENT_STATE_SERVER_HUNGUP,
+                AudioClient.AUDIO_CLIENT_ERR_SERVER_HUNGUP
+            )
+        }
+
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioVideoObserver.onAudioSessionStopped(any()) }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockEventAnalyticsController.publishEvent(EventName.meetingEnded, any()) }
+    }
+
     @Test
     fun `onAudioClientStateChange should notify of session fail event to EventAnalyticsController when failed to connect`() {
         every { mockAudioClient.stopSession() } returns 0


### PR DESCRIPTION
## ℹ️ Description
Fixes incorrect event being published when the meeting is ended normally.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
