### PR TITLE
Add battery level and state to meeting event attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 * Added following meeting events: meetingReconnected/audioInputFailed/videoClientSignalingDropped/contentShareSignalingDropped/appStateChanged/appMemoryLow
-* Added following meeting event attributes: meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState
+* Added following meeting event attributes: meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState
 
 ## [0.25.0] - 2025-06-17
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -54,9 +54,8 @@ class DefaultEventAnalyticsController(
         }
 
         eventAttributes[EventAttributeName.appState] = appStateMonitor.appState.description
-        val batteryLevel = appStateMonitor.getBatteryLevel()
-        if (batteryLevel != null) {
-            eventAttributes[EventAttributeName.batteryLevel] = batteryLevel
+        appStateMonitor.getBatteryLevel()?.let {
+            eventAttributes[EventAttributeName.batteryLevel] = it
         }
         eventAttributes[EventAttributeName.batteryState] = appStateMonitor.getBatteryState().description
 
@@ -77,9 +76,8 @@ class DefaultEventAnalyticsController(
             EventAttributeName.batteryState to appStateMonitor.getBatteryState().description
         ) as EventAttributes
 
-        val batteryLevel = appStateMonitor.getBatteryLevel()
-        if (batteryLevel != null) {
-            eventAttributes[EventAttributeName.batteryLevel] = batteryLevel
+        appStateMonitor.getBatteryLevel()?.let {
+            eventAttributes[EventAttributeName.batteryLevel] = it
         }
 
         eventReporter?.report(SDKEvent(historyEventName, eventAttributes))

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/DefaultEventAnalyticsController.kt
@@ -54,6 +54,11 @@ class DefaultEventAnalyticsController(
         }
 
         eventAttributes[EventAttributeName.appState] = appStateMonitor.appState.description
+        val batteryLevel = appStateMonitor.getBatteryLevel()
+        if (batteryLevel != null) {
+            eventAttributes[EventAttributeName.batteryLevel] = batteryLevel
+        }
+        eventAttributes[EventAttributeName.batteryState] = appStateMonitor.getBatteryState().description
 
         eventReporter?.report(SDKEvent(name, eventAttributes))
 
@@ -67,8 +72,15 @@ class DefaultEventAnalyticsController(
     override fun pushHistory(historyEventName: MeetingHistoryEventName) {
         val currentTimeMs = Calendar.getInstance().timeInMillis
         val eventAttributes = mutableMapOf(
-            EventAttributeName.timestampMs to currentTimeMs
+            EventAttributeName.timestampMs to currentTimeMs,
+            EventAttributeName.appState to appStateMonitor.appState.description,
+            EventAttributeName.batteryState to appStateMonitor.getBatteryState().description
         ) as EventAttributes
+
+        val batteryLevel = appStateMonitor.getBatteryLevel()
+        if (batteryLevel != null) {
+            eventAttributes[EventAttributeName.batteryLevel] = batteryLevel
+        }
 
         eventReporter?.report(SDKEvent(historyEventName, eventAttributes))
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/analytics/EventAttributeName.kt
@@ -109,6 +109,16 @@ enum class EventAttributeName {
     appState,
 
     /**
+     * The current battery level
+     */
+    batteryLevel,
+
+    /**
+     * The current battery state
+     */
+    batteryState,
+
+    /**
      * Meeting Status [MeetingSessionStatus]
      */
     meetingStatus,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/AppStateMonitor.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/AppStateMonitor.kt
@@ -39,7 +39,7 @@ interface AppStateMonitor {
 
     /**
      * Returns the current battery state
-     * @return Battery state (CHARGING, DISCHARGING, NOT_CHARGING, FULL, UNKNOWN)
+     * @return Battery state
      */
     fun getBatteryState(): BatteryState
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/AppStateMonitor.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/AppStateMonitor.kt
@@ -30,4 +30,16 @@ interface AppStateMonitor {
      * Stop monitoring application state changes
      */
     fun stop()
+
+    /**
+     * Returns the current battery level as a value between 0.0 and 1.0
+     * @return Battery level (0.0 = empty, 1.0 = full), or null if unable to determine
+     */
+    fun getBatteryLevel(): Float?
+
+    /**
+     * Returns the current battery state
+     * @return Battery state (CHARGING, DISCHARGING, NOT_CHARGING, FULL, UNKNOWN)
+     */
+    fun getBatteryState(): BatteryState
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/BatteryState.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/ingestion/BatteryState.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.ingestion
+
+/**
+ * Enum representing different battery states
+ */
+enum class BatteryState(val description: String) {
+    /** Battery is currently being charged by a power source */
+    CHARGING("Charging"),
+
+    /** Battery is currently being used and losing charge */
+    DISCHARGING("Discharging"),
+
+    /** Battery is connected to power but not actively charging (e.g., battery is full or charging is paused) */
+    NOT_CHARGING("NotCharging"),
+
+    /** Battery is at maximum capacity (100% charged) */
+    FULL("Full"),
+
+    /** Battery state cannot be determined or is not available */
+    UNKNOWN("Unknown")
+}

--- a/guides/meeting_events.md
+++ b/guides/meeting_events.md
@@ -138,6 +138,8 @@ The following table describes attributes for a meeting.
 |`retryCount`|The number of connection retries performed during the meeting.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingReconnected`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`signalingDroppedErrorMessage`|The error message that explains why the signaling websocket connection dropped.|`videoClientSignalingDropped`, `contentShareSignalingDropped`
 |`appState`|The current app state when the event occurs. Possible states include: `Active`, `Inactive`, `Foreground`, and `Background`.| All events
+|`batteryLevel`|The current battery level when the event occurs.| All events
+|`batteryState`|The current battery state when the event occurs. Possible states include: `Charging`, `Discharging`, `NotCharging`, `Full`, and `Unknown`.| All events
 
 ### Device attributes
 The following table describes attributes for the microphone and camera.


### PR DESCRIPTION
## ℹ️ Description
 - Add battery level and state to meeting event attributes

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [x] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - manually verified

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
