### PR TITLE
Guard video client stop with a mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## PENDING
+
+### Changed
+* Guard video client stop with a mutex
+
 ## [0.25.1] - 2025-10-02
 
 ### Added

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -34,6 +34,8 @@ import com.xodee.client.video.VideoSubscriptionConfigurationInternal
 import java.security.InvalidParameterException
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 class DefaultVideoClientController(
     private val context: Context,
@@ -64,7 +66,7 @@ class DefaultVideoClientController(
     private val cameraCaptureSource: DefaultCameraCaptureSource
     private var videoSourceAdapter = VideoSourceAdapter()
     private var isUsingInternalCaptureSource = false
-
+    private val videoClientStopMutex = Mutex()
     init {
         videoClientStateController.bindLifecycleHandler(this)
 
@@ -102,10 +104,12 @@ class DefaultVideoClientController(
             // So it doesn't call it spuriously
             videoClientObserver.primaryMeetingPromotionObserver = null
 
-            videoClientStateController.stop()
+            videoClientStopMutex.withLock {
+                videoClientStateController.stop()
 
-            eglCore?.release()
-            eglCore = null
+                eglCore?.release()
+                eglCore = null
+            }
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/DefaultVideoClientController.kt
@@ -105,8 +105,12 @@ class DefaultVideoClientController(
             videoClientObserver.primaryMeetingPromotionObserver = null
 
             videoClientStopMutex.withLock {
+                // Race conditions in video client stop functions may lead to crashes at pointer deallocation
+                // if multiple such threads are called at the same time.
                 videoClientStateController.stop()
 
+                // We put release eglCore under mutex as a race condition may decrease its reference counter
+                // below 0 and cause crashes if multiple such calls happen together.
                 eglCore?.release()
                 eglCore = null
             }


### PR DESCRIPTION
## ℹ️ Description
There are race conditions in video client stop function that may lead to a crashes if multiple threads of video client stop are triggered at the same time (e.g., pointer deallocation, reference counter update). The purpose of this change is to avoid such crashes.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Smoke tested and verified crash doesn't happen when ending a meeting
1. Have an android attendee join a meeting
2. Leave the meeting by pressing the red hang up button
3. Verify no crash happens

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
