### PR TITLE
fix(audio): Defer Bluetooth audio route changes until connection is r…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Fixed
+* Fixed Bluetooth audio routing race condition where the SDK would change the audio route before the Bluetooth connection was established, causing Android to reject Bluetooth routing and fall back to Handset. The fix introduces a `BluetoothAudioRouter` abstraction that defers route changes until the Bluetooth connection is confirmed ready. On API 31+ (Android 12+), the SDK now uses `setCommunicationDevice` API for Bluetooth routing. The deprecated `startBluetoothSco`/`stopBluetoothSco` APIs are only used on older Android versions (API 23-30).
+
 ## [0.25.2] - 2025-12-09
 
 ### Changed

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceController.kt
@@ -22,28 +22,58 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientState
+import com.amazonaws.services.chime.sdk.meetings.internal.audio.BluetoothAudioRouter
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.DefaultAudioClientController
+import com.amazonaws.services.chime.sdk.meetings.internal.audio.DefaultBluetoothAudioRouterFactory
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ConcurrentSet
 import com.amazonaws.services.chime.sdk.meetings.internal.utils.ObserverUtils
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientController
 import com.amazonaws.services.chime.sdk.meetings.utils.MediaError
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
-import kotlin.Any
 
-class DefaultDeviceController(
+class DefaultDeviceController @VisibleForTesting internal constructor(
     private val context: Context,
     private val audioClientController: AudioClientController,
     private val videoClientController: VideoClientController,
     private val eventAnalyticsController: EventAnalyticsController,
     private val logger: Logger,
-    private val audioManager: AudioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
-    private val buildVersion: Int = Build.VERSION.SDK_INT
+    private val audioManager: AudioManager,
+    private val buildVersion: Int,
+    private val bluetoothAudioRouter: BluetoothAudioRouter
 ) : DeviceController {
+
+    /**
+     * Public constructor for production use.
+     */
+    constructor(
+        context: Context,
+        audioClientController: AudioClientController,
+        videoClientController: VideoClientController,
+        eventAnalyticsController: EventAnalyticsController,
+        logger: Logger
+    ) : this(
+        context,
+        audioClientController,
+        videoClientController,
+        eventAnalyticsController,
+        logger,
+        context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
+        Build.VERSION.SDK_INT,
+        DefaultBluetoothAudioRouterFactory().create(
+            context,
+            context.getSystemService(Context.AUDIO_SERVICE) as AudioManager,
+            logger
+        )
+    )
+
     private val deviceChangeObservers = ConcurrentSet.createConcurrentSet<DeviceChangeObserver>()
 
     // TODO: remove code blocks for lower API level after the minimum SDK version becomes 23
     private val AUDIO_MANAGER_API_LEVEL = 23
+
+    // API level constant for setCommunicationDevice support (Android 12+)
+    private val COMMUNICATION_DEVICE_API_LEVEL = Build.VERSION_CODES.S
 
     private var receiver: BroadcastReceiver? = null
 
@@ -52,18 +82,8 @@ class DefaultDeviceController(
     private val TAG = "DefaultDeviceController"
 
     init {
-        @SuppressLint("NewApi")
         if (buildVersion >= AUDIO_MANAGER_API_LEVEL) {
-            audioDeviceCallback = object : AudioDeviceCallback() {
-                override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
-                    notifyAudioDeviceChange()
-                }
-
-                override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
-                    notifyAudioDeviceChange()
-                }
-            }
-            audioManager.registerAudioDeviceCallback(audioDeviceCallback, null)
+            registerAudioDeviceCallback()
         } else {
             receiver = object : BroadcastReceiver() {
                 override fun onReceive(context: Context?, intent: Intent?) {
@@ -82,8 +102,8 @@ class DefaultDeviceController(
         }
     }
 
+    @SuppressLint("NewApi")
     override fun listAudioDevices(): List<MediaDevice> {
-        @SuppressLint("NewApi")
         if (buildVersion >= AUDIO_MANAGER_API_LEVEL) {
             var isWiredHeadsetOn = false
             var isHandsetAvailable = false
@@ -120,7 +140,8 @@ class DefaultDeviceController(
                         "${device.productName} (${getReadableType(device.type)})",
                         MediaDeviceType.fromAudioDeviceInfo(
                             device.type
-                        )
+                        ),
+                        id = device.id.toString()
                     )
                 )
             }
@@ -170,24 +191,33 @@ class DefaultDeviceController(
         }
     }
 
+    @SuppressLint("NewApi")
     override fun chooseAudioDevice(mediaDevice: MediaDevice) {
         if (DefaultAudioClientController.audioClientState != AudioClientState.STARTED) {
             return
         }
-        setupAudioDevice(mediaDevice.type)
-        val route = when (mediaDevice.type) {
-            MediaDeviceType.AUDIO_BUILTIN_SPEAKER -> AudioClient.SPK_STREAM_ROUTE_SPEAKER
-            MediaDeviceType.AUDIO_BLUETOOTH -> AudioClient.SPK_STREAM_ROUTE_BT_AUDIO
-            MediaDeviceType.AUDIO_WIRED_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
-            MediaDeviceType.AUDIO_USB_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
-            else -> AudioClient.SPK_STREAM_ROUTE_RECEIVER
-        }
 
-        val selected = audioClientController.setRoute(route)
-        if (selected) {
-            eventAnalyticsController.publishEvent(EventName.audioInputSelected, mutableMapOf(
-                EventAttributeName.audioDeviceType to mediaDevice.type.toString()
-            ), false)
+        logger.info(TAG, "chooseAudioDevice() called for device id: ${mediaDevice.id} with type: ${mediaDevice.type}")
+        bluetoothAudioRouter.cancelPendingOperation()
+
+        val route = getRouteForDeviceType(mediaDevice.type)
+
+        if (mediaDevice.type == MediaDeviceType.AUDIO_BLUETOOTH) {
+            // Delegate Bluetooth routing to the router
+            bluetoothAudioRouter.routeToBluetoothDevice(
+                mediaDevice = mediaDevice,
+                route = route,
+                onSuccess = { r, deviceType -> executeSetRoute(r, deviceType) },
+                onFailure = { notifyAudioDeviceChange() }
+            )
+        } else {
+            // Non-Bluetooth: handle directly
+            if (buildVersion >= COMMUNICATION_DEVICE_API_LEVEL) {
+                setupAudioDevice(mediaDevice)
+            } else {
+                setupAudioDevice(mediaDevice.type)
+            }
+            executeSetRoute(route, mediaDevice.type)
         }
     }
 
@@ -250,6 +280,24 @@ class DefaultDeviceController(
         }
     }
 
+    /**
+     * Sets up audio device routing using the API 31+ setCommunicationDevice() API.
+     *
+     * @param mediaDevice The media device to route audio to
+     */
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun setupAudioDevice(mediaDevice: MediaDevice) {
+        val audioDeviceInfo = findAudioDeviceById(mediaDevice.id)
+
+        if (audioDeviceInfo == null) {
+            logger.error(TAG, "Failed to setup audio device. AudioDeviceInfo not found for id: ${mediaDevice.id}, type: ${mediaDevice.type}")
+            return
+        }
+
+        val success = audioManager.setCommunicationDevice(audioDeviceInfo)
+        logger.info(TAG, "setCommunicationDevice(${audioDeviceInfo.productName}, id=${audioDeviceInfo.id}) returned $success")
+    }
+
     private fun getReadableType(type: Int): String {
         return when (type) {
             AudioDeviceInfo.TYPE_WIRED_HEADSET -> "Wired Headset"
@@ -287,5 +335,77 @@ class DefaultDeviceController(
                 listAudioDevices()
             )
         }
+    }
+
+    /**
+     * Executes the setRoute call and records the event.
+     *
+     * @param route The audio route value to set
+     * @param deviceType The device type for analytics event
+     */
+    private fun executeSetRoute(route: Int, deviceType: MediaDeviceType) {
+        val selected = audioClientController.setRoute(route)
+        if (selected) {
+            eventAnalyticsController.publishEvent(EventName.audioInputSelected, mutableMapOf(
+                EventAttributeName.audioDeviceType to deviceType.toString()
+            ), false)
+        }
+    }
+
+    /**
+     * Maps a MediaDeviceType to the corresponding AudioClient route constant.
+     *
+     * @param type The media device type
+     * @return The corresponding AudioClient route constant
+     */
+    private fun getRouteForDeviceType(type: MediaDeviceType): Int {
+        return when (type) {
+            MediaDeviceType.AUDIO_BUILTIN_SPEAKER -> AudioClient.SPK_STREAM_ROUTE_SPEAKER
+            MediaDeviceType.AUDIO_BLUETOOTH -> AudioClient.SPK_STREAM_ROUTE_BT_AUDIO
+            MediaDeviceType.AUDIO_WIRED_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
+            MediaDeviceType.AUDIO_USB_HEADSET -> AudioClient.SPK_STREAM_ROUTE_HEADSET
+            else -> AudioClient.SPK_STREAM_ROUTE_RECEIVER
+        }
+    }
+
+    /**
+     * Finds an AudioDeviceInfo by its ID from available communication devices.
+     *
+     * @param id The AudioDeviceInfo ID as a String (converted to Int for lookup)
+     * @return The matching AudioDeviceInfo, or null if not found
+     */
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun findAudioDeviceById(id: String?): AudioDeviceInfo? {
+        val deviceId = id?.toIntOrNull() ?: return null
+        return audioManager.availableCommunicationDevices.firstOrNull { it.id == deviceId }
+    }
+
+    /**
+     * Creates an AudioDeviceCallback for listening to audio device changes.
+     * Requires API level 23+.
+     *
+     * @return The created AudioDeviceCallback
+     */
+    @SuppressLint("NewApi")
+    private fun createAudioDeviceCallback(): AudioDeviceCallback {
+        return object : AudioDeviceCallback() {
+            override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>?) {
+                notifyAudioDeviceChange()
+            }
+
+            override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>?) {
+                notifyAudioDeviceChange()
+            }
+        }
+    }
+
+    /**
+     * Registers the AudioDeviceCallback with the AudioManager.
+     * Requires API level 23+.
+     */
+    @SuppressLint("NewApi")
+    private fun registerAudioDeviceCallback() {
+        audioDeviceCallback = createAudioDeviceCallback()
+        audioManager.registerAudioDeviceCallback(audioDeviceCallback, null)
     }
 }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/device/MediaDevice.kt
@@ -17,7 +17,9 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.capture.VideoC
  *
  * @property label: String - human readable string describing the device.
  * @property type: [MediaDeviceType] - media device type
- * @property id: String - Unique ID, if applicable
+ * @property id: String - Unique device identifier. For video devices, this is the camera ID from CameraManager.
+ *                        For audio devices, this is the AudioDeviceInfo.id converted to String.
+ *                        It's never null when returned by the SDK's APIs
  */
 data class MediaDevice(
     val label: String,

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothAudioRouter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothAudioRouter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+
+/**
+ * [BluetoothAudioRouter] abstracts Bluetooth audio routing operations across different Android API levels.
+ *
+ * This interface provides a unified contract for Bluetooth audio routing, with implementations
+ * handling the API-specific details:
+ * - API 23-30: Uses SCO-based routing via [android.media.AudioManager.startBluetoothSco]
+ * - API 31+: Uses Communication Device API via [android.media.AudioManager.setCommunicationDevice]
+ *
+ * The routing operation is asynchronous - success or failure is reported via callbacks.
+ */
+internal interface BluetoothAudioRouter {
+    /**
+     * Routes audio to the specified Bluetooth device.
+     *
+     * The operation is asynchronous - success/failure is reported via callbacks.
+     * Only one routing operation can be pending at a time; calling this method
+     * while an operation is pending will cancel the previous operation.
+     *
+     * @param mediaDevice The target Bluetooth [MediaDevice]
+     * @param route The AudioClient route constant for Bluetooth
+     * @param onSuccess Callback invoked when routing succeeds, with route and device type
+     * @param onFailure Callback invoked when routing fails or times out
+     */
+    fun routeToBluetoothDevice(
+        mediaDevice: MediaDevice,
+        route: Int,
+        onSuccess: (route: Int, deviceType: MediaDeviceType) -> Unit,
+        onFailure: () -> Unit
+    )
+
+    /**
+     * Cancels any pending Bluetooth routing operation.
+     *
+     * Called when the user selects a different device or the audio session ends.
+     * After cancellation, neither the success nor failure callback will be invoked.
+     */
+    fun cancelPendingOperation()
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothAudioRouterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothAudioRouterFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.Context
+import android.media.AudioManager
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+/**
+ * Factory interface for creating [BluetoothAudioRouter] implementations.
+ */
+internal interface BluetoothAudioRouterFactory {
+    /**
+     * Creates a BluetoothAudioRouter implementation.
+     *
+     * @param context The application context
+     * @param audioManager The AudioManager for controlling audio routing
+     * @param logger The logger for debug and error messages
+     * @return The appropriate BluetoothAudioRouter implementation
+     */
+    fun create(
+        context: Context,
+        audioManager: AudioManager,
+        logger: Logger
+    ): BluetoothAudioRouter
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothRoutingConfig.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/BluetoothRoutingConfig.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+/**
+ * Configuration constants for Bluetooth audio routing operations.
+ *
+ * Contains timeout and retry parameters used by [BluetoothAudioRouter] implementations.
+ */
+internal object BluetoothRoutingConfig {
+    /**
+     * Timeout duration for SCO connection (API 23-30).
+     *
+     * This timeout is a reasonable estimate and can be tuned further if needed.
+     */
+    const val SCO_CONNECTION_TIMEOUT_MS = 3000L
+
+    /**
+     * Timeout duration for API 31+ Bluetooth device switching.
+     *
+     * Android documentation recommends up to 30 seconds for Bluetooth device changes.
+     * See: https://developer.android.com/develop/connectivity/bluetooth/ble-audio/audio-manager#set_communication_device
+     *
+     * Since 30 seconds is too long for a voice call, we use 5 seconds instead.
+     */
+    const val COMMUNICATION_DEVICE_TIMEOUT_MS = 5000L
+
+    /**
+     * Delay between retry attempts for Bluetooth routing mismatch recovery (API 31+).
+     *
+     * When setCommunicationDevice() returns true but the listener fires with a different device,
+     * we retry after this delay to allow the Bluetooth SCO teardown to complete.
+     */
+    const val BLUETOOTH_ROUTING_MISMATCH_RETRY_DELAY_MS = 500L
+
+    /**
+     * Maximum number of retry attempts for Bluetooth routing mismatch recovery (API 31+).
+     */
+    const val BLUETOOTH_ROUTING_MISMATCH_MAX_RETRIES = 3
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/CommunicationDeviceBluetoothAudioRouter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/CommunicationDeviceBluetoothAudioRouter.kt
@@ -1,0 +1,280 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.Context
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import androidx.annotation.RequiresApi
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+/**
+ * [CommunicationDeviceBluetoothAudioRouter] handles Bluetooth audio routing for API 31+ using
+ * the Communication Device API.
+ *
+ * This implementation uses [AudioManager.setCommunicationDevice] to route audio to Bluetooth
+ * devices and monitors [AudioManager.OnCommunicationDeviceChangedListener] to track device changes.
+ *
+ * The routing operation is asynchronous:
+ * - Success is reported when the listener confirms a Bluetooth SCO device
+ * - Failure is reported when max retries are exceeded, device becomes unavailable,
+ *   or when the operation times out after [BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS]
+ *
+ * Implements the "retry-on-mismatch" pattern to handle race conditions during rapid
+ * Bluetooth device transitions. When setCommunicationDevice() returns true but the
+ * listener fires with a different device (e.g., Handset instead of Bluetooth), this
+ * indicates the Bluetooth SCO channel from the previous device is still being torn down.
+ *
+ * @param context The application context for accessing system services
+ * @param audioManager The AudioManager for controlling communication devices
+ * @param logger The logger for debug and error messages
+ * @param handler The handler for posting timeout and retry callbacks (defaults to main looper)
+ */
+@RequiresApi(Build.VERSION_CODES.S)
+internal class CommunicationDeviceBluetoothAudioRouter(
+    private val context: Context,
+    private val audioManager: AudioManager,
+    private val logger: Logger,
+    private val handler: Handler = Handler(Looper.getMainLooper())
+) : BluetoothAudioRouter {
+
+    private val TAG = "CommunicationDeviceBluetoothAudioRouter"
+
+    // Pending Bluetooth operation state for deferred routing
+    private var pendingOperation: PendingBluetoothOperation? = null
+    private var timeoutRunnable: Runnable? = null
+
+    // Retry state for Bluetooth routing mismatch recovery
+    private var retryCount: Int = 0
+    private var retryRunnable: Runnable? = null
+
+    // Communication device change listener
+    private var communicationDeviceChangedListener: AudioManager.OnCommunicationDeviceChangedListener? = null
+
+    init {
+        setupCommunicationDeviceListener()
+    }
+
+    /**
+     * Sets up the OnCommunicationDeviceChangedListener for monitoring device changes.
+     */
+    private fun setupCommunicationDeviceListener() {
+        communicationDeviceChangedListener = AudioManager.OnCommunicationDeviceChangedListener { device ->
+            logger.debug(TAG, "Communication device changed: ${device?.productName}, type=${device?.type}, id=${device?.id}")
+            onCommunicationDeviceChanged(device)
+        }
+        audioManager.addOnCommunicationDeviceChangedListener(
+            context.mainExecutor,
+            communicationDeviceChangedListener!!
+        )
+    }
+
+    override fun routeToBluetoothDevice(
+        mediaDevice: MediaDevice,
+        route: Int,
+        onSuccess: (route: Int, deviceType: MediaDeviceType) -> Unit,
+        onFailure: () -> Unit
+    ) {
+        logger.info(TAG, "routeToBluetoothDevice() called for device: ${mediaDevice.id}, type: ${mediaDevice.type}")
+
+        // Cancel any existing pending operation
+        cancelPendingOperation()
+
+        // Find the AudioDeviceInfo by ID from available communication devices
+        val audioDeviceInfo = findAudioDeviceById(mediaDevice.id)
+
+        if (audioDeviceInfo == null) {
+            logger.error(TAG, "Failed to route to Bluetooth device. AudioDeviceInfo not found for id: ${mediaDevice.id}")
+            onFailure()
+            return
+        }
+
+        // Call setCommunicationDevice
+        val success = audioManager.setCommunicationDevice(audioDeviceInfo)
+        logger.info(TAG, "setCommunicationDevice(${audioDeviceInfo.productName}, id=${audioDeviceInfo.id}) returned $success")
+
+        if (!success) {
+            logger.error(TAG, "setCommunicationDevice failed for device: ${mediaDevice.id}")
+            onFailure()
+            return
+        }
+
+        // Store pending operation with callbacks
+        pendingOperation = PendingBluetoothOperation(
+            route = route,
+            deviceType = mediaDevice.type,
+            deviceId = audioDeviceInfo.id,
+            onSuccess = onSuccess,
+            onFailure = onFailure
+        )
+
+        // Start timeout
+        startTimeout()
+        logger.info(TAG, "Bluetooth device selected - waiting for communication device change confirmation")
+    }
+
+    override fun cancelPendingOperation() {
+        if (pendingOperation != null) {
+            logger.debug(TAG, "Cancelling pending Bluetooth operation")
+            pendingOperation = null
+            retryCount = 0
+            timeoutRunnable?.let { handler.removeCallbacks(it) }
+            timeoutRunnable = null
+            retryRunnable?.let { handler.removeCallbacks(it) }
+            retryRunnable = null
+        }
+    }
+
+    /**
+     * Finds an AudioDeviceInfo by its ID from available communication devices.
+     *
+     * @param id The AudioDeviceInfo ID as a String (converted to Int for lookup)
+     * @return The matching AudioDeviceInfo, or null if not found
+     */
+    private fun findAudioDeviceById(id: String?): AudioDeviceInfo? {
+        val deviceId = id?.toIntOrNull() ?: return null
+        return audioManager.availableCommunicationDevices.firstOrNull { it.id == deviceId }
+    }
+
+    /**
+     * Starts a timeout for the pending Bluetooth operation.
+     * If the operation does not complete within [BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS],
+     * the pending operation is cancelled and the failure callback is invoked.
+     */
+    private fun startTimeout() {
+        timeoutRunnable?.let { handler.removeCallbacks(it) }
+        timeoutRunnable = Runnable {
+            // Check if audio client is stopped - if so, just cancel silently
+            if (DefaultAudioClientController.audioClientState == AudioClientState.STOPPED) {
+                logger.debug(TAG, "AudioClient is stopped. Cancelling pending bluetooth operations")
+                cancelPendingOperation()
+                return@Runnable
+            }
+
+            val pending = pendingOperation
+            if (pending != null) {
+                logger.warn(TAG, "Bluetooth communication device timeout after ${BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS}ms")
+                val onFailure = pending.onFailure
+                cancelPendingOperation()
+                onFailure()
+            }
+        }
+        handler.postDelayed(timeoutRunnable!!, BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS)
+    }
+
+    /**
+     * Handles communication device change events for Bluetooth routing.
+     *
+     * Implements the "retry-on-mismatch" pattern to handle race conditions during rapid
+     * Bluetooth device transitions. When setCommunicationDevice() returns true but the
+     * listener fires with a different device (e.g., Handset instead of Bluetooth), this
+     * indicates the Bluetooth SCO channel from the previous device is still being torn down.
+     *
+     * In this case, we retry the setCommunicationDevice() call after a short delay to allow
+     * the Bluetooth stack to release the audio hardware lock.
+     *
+     * @param device The new communication device, or null if cleared
+     */
+    private fun onCommunicationDeviceChanged(device: AudioDeviceInfo?) {
+        // Check if audio client is stopped - if so, just cancel silently
+        if (DefaultAudioClientController.audioClientState == AudioClientState.STOPPED) {
+            logger.debug(TAG, "AudioClient is stopped. Cancelling pending bluetooth operations")
+            cancelPendingOperation()
+            return
+        }
+
+        val pending = pendingOperation ?: return
+        val pendingDeviceId = pending.deviceId ?: return
+
+        if (device != null && device.type == AudioDeviceInfo.TYPE_BLUETOOTH_SCO) {
+            // Success: Bluetooth SCO device confirmed
+            val waitTime = System.currentTimeMillis() - pending.timestamp
+            logger.info(TAG, "Bluetooth communication device confirmed with id: ${device.id} after ${waitTime}ms" +
+                    " (retries: $retryCount) - invoking success callback")
+            val onSuccess = pending.onSuccess
+            val route = pending.route
+            val deviceType = pending.deviceType
+            cancelPendingOperation()
+            onSuccess(route, deviceType)
+        } else {
+            // MISMATCH: We got Handset/Speaker instead of Bluetooth
+            // This may happen during rapid Bluetooth device transitions when the SCO channel
+            // from the previous device is still being torn down
+            if (retryCount < BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_MAX_RETRIES) {
+                retryCount++
+                logger.info(TAG, "Bluetooth routing mismatch. Expected Bluetooth (id=$pendingDeviceId), " +
+                        "got ${device?.id} (type=${device?.type}). Retrying ($retryCount/${BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_MAX_RETRIES}) " +
+                        "after ${BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_RETRY_DELAY_MS}ms...")
+
+                // Cancel any existing retry runnable
+                retryRunnable?.let { handler.removeCallbacks(it) }
+
+                // Schedule a retry after a short delay
+                retryRunnable = Runnable {
+                    retryBluetoothRouting(pendingDeviceId)
+                }
+                handler.postDelayed(retryRunnable!!, BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_RETRY_DELAY_MS)
+            } else {
+                // Max retries exceeded - invoke failure callback
+                logger.error(TAG, "Failed to route to Bluetooth device (id=$pendingDeviceId) after ${BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_MAX_RETRIES} retries. Giving up.")
+                val onFailure = pending.onFailure
+                cancelPendingOperation()
+                onFailure()
+            }
+        }
+    }
+
+    /**
+     * Retries setting the communication device to Bluetooth after a mismatch.
+     *
+     * Re-verifies that the target device is still available before retrying to handle
+     * cases where the device may have disconnected during the retry delay.
+     *
+     * @param targetDeviceId The AudioDeviceInfo ID of the target Bluetooth device
+     */
+    private fun retryBluetoothRouting(targetDeviceId: Int) {
+        // Check if audio client is stopped - if so, just cancel silently
+        if (DefaultAudioClientController.audioClientState == AudioClientState.STOPPED) {
+            logger.debug(TAG, "AudioClient is stopped. Cancelling pending bluetooth operations")
+            cancelPendingOperation()
+            return
+        }
+
+        val pending = pendingOperation
+        if (pending == null) {
+            logger.debug(TAG, "No pending operation during retry. Aborting.")
+            return
+        }
+
+        // Re-verify device is still available before retrying
+        val audioDeviceInfo = audioManager.availableCommunicationDevices.firstOrNull { it.id == targetDeviceId }
+
+        if (audioDeviceInfo == null) {
+            logger.warn(TAG, "Target Bluetooth device (id=$targetDeviceId) no longer available. Aborting retry.")
+            val onFailure = pending.onFailure
+            cancelPendingOperation()
+            onFailure()
+            return
+        }
+
+        logger.info(TAG, "Retrying setCommunicationDevice(${audioDeviceInfo.productName}, id=${audioDeviceInfo.id})")
+        val success = audioManager.setCommunicationDevice(audioDeviceInfo)
+        logger.info(TAG, "Retry setCommunicationDevice returned $success")
+
+        if (!success) {
+            logger.error(TAG, "Retry setCommunicationDevice failed. Giving up.")
+            val onFailure = pending.onFailure
+            cancelPendingOperation()
+            onFailure()
+        }
+        // If success, wait for the next OnCommunicationDeviceChangedListener callback
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientController.kt
@@ -5,11 +5,13 @@
 
 package com.amazonaws.services.chime.sdk.meetings.internal.audio
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioTrack
+import android.os.Build
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
@@ -41,7 +43,8 @@ class DefaultAudioClientController(
     private val audioClientObserver: AudioClientObserver,
     private val audioClient: AudioClient,
     private val meetingStatsCollector: MeetingStatsCollector,
-    private val eventAnalyticsController: EventAnalyticsController
+    private val eventAnalyticsController: EventAnalyticsController,
+    private val buildVersion: Int = Build.VERSION.SDK_INT
 ) : AudioClientController {
     private val TAG = "DefaultAudioClientController"
     private val DEFAULT_PORT = 0 // In case the URL does not have port
@@ -300,10 +303,17 @@ class DefaultAudioClientController(
         meetingStatsCollector.resetMeetingStats()
     }
 
+    @SuppressLint("NewApi")
     private fun resetAudioManager() {
         audioManager.apply {
             isBluetoothScoOn = false
             stopBluetoothSco()
+        }
+        // Clear communication device on API 31+ to release audio routing
+        // Unlike stopBluetoothSco(), setCommunicationDevice() is tied to the app process
+        // and must be cleared to avoid breaking audio for other apps
+        if (buildVersion >= Build.VERSION_CODES.S) {
+            audioManager.clearCommunicationDevice()
         }
         audioManager.mode = audioModePreCall
         audioManager.isSpeakerphoneOn = speakerphoneStatePreCall

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultBluetoothAudioRouterFactory.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultBluetoothAudioRouterFactory.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+/**
+ * Default implementation of [BluetoothAudioRouterFactory] that creates the appropriate
+ * [BluetoothAudioRouter] implementation based on API level.
+ *
+ * - API 23-30: Returns [ScoBluetoothAudioRouter] (SCO-based routing)
+ * - API 31+: Returns [CommunicationDeviceBluetoothAudioRouter] (setCommunicationDevice-based routing)
+ *
+ * @param buildVersion The Android SDK version (defaults to Build.VERSION.SDK_INT)
+ */
+internal class DefaultBluetoothAudioRouterFactory(
+    private val buildVersion: Int = Build.VERSION.SDK_INT
+) : BluetoothAudioRouterFactory {
+
+    @SuppressLint("NewApi")
+    override fun create(
+        context: Context,
+        audioManager: AudioManager,
+        logger: Logger
+    ): BluetoothAudioRouter {
+        return if (buildVersion >= Build.VERSION_CODES.S) {
+            CommunicationDeviceBluetoothAudioRouter(context, audioManager, logger)
+        } else {
+            ScoBluetoothAudioRouter(context, audioManager, logger)
+        }
+    }
+}

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/PendingBluetoothOperation.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/PendingBluetoothOperation.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+
+/**
+ * Encapsulates state for a pending Bluetooth audio route operation.
+ *
+ * This is used to defer setRoute() calls until Bluetooth connection is confirmed.
+ * The operation is considered complete when either [onSuccess] or [onFailure] is invoked.
+ *
+ * @property route The AudioClient route constant for Bluetooth
+ * @property deviceType The type of the target Bluetooth device
+ * @property deviceId The AudioDeviceInfo ID (only used for API 31+ retry-on-mismatch)
+ * @property onSuccess Callback invoked when routing succeeds, with route and device type
+ * @property onFailure Callback invoked when routing fails or times out
+ * @property timestamp The time when this operation was created, used for timeout tracking
+ */
+internal data class PendingBluetoothOperation(
+    val route: Int,
+    val deviceType: MediaDeviceType,
+    val deviceId: Int?,
+    val onSuccess: (route: Int, deviceType: MediaDeviceType) -> Unit,
+    val onFailure: () -> Unit,
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/ScoBluetoothAudioRouter.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/ScoBluetoothAudioRouter.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioManager
+import android.os.Handler
+import android.os.Looper
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+
+/**
+ * [ScoBluetoothAudioRouter] handles Bluetooth audio routing for API 23-30 using SCO-based APIs.
+ *
+ * This implementation uses [AudioManager.startBluetoothSco] to initiate Bluetooth SCO connection
+ * and monitors [AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED] broadcasts to track connection state.
+ *
+ * The routing operation is asynchronous:
+ * - Success is reported when SCO state transitions to [AudioManager.SCO_AUDIO_STATE_CONNECTED]
+ * - Failure is reported when SCO state transitions to ERROR, or DISCONNECTED from CONNECTING,
+ *   or when the operation times out after [BluetoothRoutingConfig.SCO_CONNECTION_TIMEOUT_MS]
+ *
+ * @param context The application context for registering broadcast receivers
+ * @param audioManager The AudioManager for controlling Bluetooth SCO
+ * @param logger The logger for debug and error messages
+ * @param handler The handler for posting timeout callbacks (defaults to main looper)
+ */
+internal class ScoBluetoothAudioRouter(
+    private val context: Context,
+    private val audioManager: AudioManager,
+    private val logger: Logger,
+    private val handler: Handler = Handler(Looper.getMainLooper())
+) : BluetoothAudioRouter {
+
+    private val TAG = "ScoBluetoothAudioRouter"
+
+    // Pending Bluetooth operation state for deferred routing
+    private var pendingOperation: PendingBluetoothOperation? = null
+    private var timeoutRunnable: Runnable? = null
+
+    // Track last SCO state to distinguish device switching from connection failure
+    private var lastScoState: Int = AudioManager.SCO_AUDIO_STATE_DISCONNECTED
+
+    // BroadcastReceiver for SCO state changes
+    private var scoStateReceiver: BroadcastReceiver? = null
+
+    init {
+        setupScoStateReceiver()
+    }
+
+    /**
+     * Sets up the BroadcastReceiver for ACTION_SCO_AUDIO_STATE_UPDATED.
+     */
+    private fun setupScoStateReceiver() {
+        scoStateReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                val state = intent?.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1) ?: return
+                val previousState = intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_PREVIOUS_STATE, -1)
+                onScoStateChanged(state, previousState)
+            }
+        }
+
+        context.registerReceiver(
+            scoStateReceiver,
+            IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED)
+        )
+    }
+
+    override fun routeToBluetoothDevice(
+        mediaDevice: MediaDevice,
+        route: Int,
+        onSuccess: (route: Int, deviceType: MediaDeviceType) -> Unit,
+        onFailure: () -> Unit
+    ) {
+        logger.info(TAG, "routeToBluetoothDevice() called for device: ${mediaDevice.id}, type: ${mediaDevice.type}")
+
+        // Cancel any existing pending operation
+        cancelPendingOperation()
+
+        // Start Bluetooth SCO connection
+        audioManager.apply {
+            mode = AudioManager.MODE_IN_COMMUNICATION
+            isSpeakerphoneOn = false
+            startBluetoothSco()
+            isBluetoothScoOn = true
+        }
+
+        // Store pending operation with callbacks
+        pendingOperation = PendingBluetoothOperation(
+            route = route,
+            deviceType = mediaDevice.type,
+            deviceId = null, // Not used for SCO-based routing
+            onSuccess = onSuccess,
+            onFailure = onFailure
+        )
+
+        // Start timeout
+        startTimeout()
+        logger.info(TAG, "Bluetooth SCO started, waiting for connection confirmation")
+    }
+
+    override fun cancelPendingOperation() {
+        if (pendingOperation != null) {
+            logger.debug(TAG, "Cancelling pending Bluetooth operation")
+            pendingOperation = null
+            timeoutRunnable?.let { handler.removeCallbacks(it) }
+            timeoutRunnable = null
+        }
+    }
+
+    /**
+     * Starts a timeout for the pending Bluetooth operation.
+     * If the operation does not complete within [BluetoothRoutingConfig.SCO_CONNECTION_TIMEOUT_MS],
+     * the pending operation is cancelled and the failure callback is invoked.
+     */
+    private fun startTimeout() {
+        timeoutRunnable?.let { handler.removeCallbacks(it) }
+        timeoutRunnable = Runnable {
+            // Check if audio client is stopped - if so, just cancel silently
+            if (DefaultAudioClientController.audioClientState == AudioClientState.STOPPED) {
+                logger.debug(TAG, "AudioClient is stopped. Cancelling pending bluetooth operations")
+                cancelPendingOperation()
+                return@Runnable
+            }
+
+            val pending = pendingOperation
+            if (pending != null) {
+                logger.warn(TAG, "Bluetooth SCO connection timeout after ${BluetoothRoutingConfig.SCO_CONNECTION_TIMEOUT_MS}ms")
+                val onFailure = pending.onFailure
+                cancelPendingOperation()
+                onFailure()
+            }
+        }
+        handler.postDelayed(timeoutRunnable!!, BluetoothRoutingConfig.SCO_CONNECTION_TIMEOUT_MS)
+    }
+
+    /**
+     * Handles SCO state transitions for pending Bluetooth operations.
+     *
+     * When SCO reaches CONNECTED state and there's a pending Bluetooth operation,
+     * the success callback is invoked.
+     *
+     * When SCO transitions to DISCONNECTED from CONNECTING (connection attempt failed),
+     * the failure callback is invoked. However, DISCONNECTED from CONNECTED is
+     * expected during Bluetooth device switching and should NOT trigger failure.
+     *
+     * @param state The new SCO audio state
+     * @param previousState The previous SCO audio state
+     */
+    private fun onScoStateChanged(state: Int, previousState: Int) {
+        // Check if audio client is stopped - if so, just cancel silently
+        if (DefaultAudioClientController.audioClientState == AudioClientState.STOPPED) {
+            logger.debug(TAG, "AudioClient is stopped. Cancelling pending bluetooth operations")
+            cancelPendingOperation()
+            lastScoState = state
+            return
+        }
+
+        val pending = pendingOperation ?: run {
+            lastScoState = state
+            return
+        }
+
+        when (state) {
+            AudioManager.SCO_AUDIO_STATE_CONNECTED -> {
+                val timeToConnect = System.currentTimeMillis() - pending.timestamp
+                logger.info(TAG, "Bluetooth SCO connected in ${timeToConnect}ms, invoking success callback")
+                val onSuccess = pending.onSuccess
+                val route = pending.route
+                val deviceType = pending.deviceType
+                cancelPendingOperation()
+                onSuccess(route, deviceType)
+            }
+            AudioManager.SCO_AUDIO_STATE_DISCONNECTED -> {
+                // Only treat as failure if transitioning from CONNECTING (connection attempt failed)
+                // CONNECTED → DISCONNECTED is expected during Bluetooth device switching
+                if (previousState == AudioManager.SCO_AUDIO_STATE_CONNECTING) {
+                    logger.warn(TAG, "Bluetooth SCO connection failed (DISCONNECTED from CONNECTING)")
+                    val onFailure = pending.onFailure
+                    cancelPendingOperation()
+                    onFailure()
+                }
+            }
+            AudioManager.SCO_AUDIO_STATE_ERROR -> {
+                logger.warn(TAG, "Bluetooth SCO error")
+                val onFailure = pending.onFailure
+                cancelPendingOperation()
+                onFailure()
+            }
+        }
+
+        lastScoState = state
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
@@ -15,18 +15,22 @@ import com.amazonaws.services.chime.sdk.meetings.analytics.EventAttributeName
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventName
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.AudioClientState
+import com.amazonaws.services.chime.sdk.meetings.internal.audio.BluetoothAudioRouter
 import com.amazonaws.services.chime.sdk.meetings.internal.audio.DefaultAudioClientController
 import com.amazonaws.services.chime.sdk.meetings.internal.video.VideoClientController
 import com.amazonaws.services.chime.sdk.meetings.utils.MediaError
 import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
 import com.xodee.client.audio.audioclient.AudioClient
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.just
 import io.mockk.mockkClass
 import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
 import io.mockk.verify
-import kotlin.Any
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -83,12 +87,23 @@ class DefaultDeviceControllerTest {
     @MockK
     private lateinit var mockLogger: Logger
 
+    @MockK
+    private lateinit var bluetoothInfo2: AudioDeviceInfo
+
+    @MockK
+    private lateinit var mockBluetoothAudioRouter: BluetoothAudioRouter
+
     private lateinit var deviceController: DefaultDeviceController
 
     private val testDispatcher = TestCoroutineDispatcher()
 
+    // Captured callbacks for Bluetooth routing tests
+    private var capturedOnSuccess: ((Int, MediaDeviceType) -> Unit)? = null
+    private var capturedOnFailure: (() -> Unit)? = null
+
     private fun setupForNewAPILevel() {
         MockKAnnotations.init(this, relaxUnitFun = true)
+        every { context.registerReceiver(any(), any()) } returns Intent()
         deviceController = DefaultDeviceController(
             context,
             audioClientController,
@@ -96,7 +111,8 @@ class DefaultDeviceControllerTest {
             eventAnalyticsController,
             mockLogger,
             audioManager,
-            24
+            24,
+            mockBluetoothAudioRouter
         )
         commonSetup()
     }
@@ -111,24 +127,122 @@ class DefaultDeviceControllerTest {
             eventAnalyticsController,
             mockLogger,
             audioManager,
-            21
+            21,
+            mockBluetoothAudioRouter
         )
         commonSetup()
+    }
+
+    /**
+     * Sets up the test environment for API 31+ (Android 12+) tests.
+     */
+    private fun setupForAPI31Plus(apiLevel: Int = 31) {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { context.registerReceiver(any(), any()) } returns Intent()
+
+        // Capture Bluetooth routing callbacks
+        val onSuccessSlot = slot<(Int, MediaDeviceType) -> Unit>()
+        val onFailureSlot = slot<() -> Unit>()
+        every {
+            mockBluetoothAudioRouter.routeToBluetoothDevice(any(), any(), capture(onSuccessSlot), capture(onFailureSlot))
+        } answers {
+            capturedOnSuccess = onSuccessSlot.captured
+            capturedOnFailure = onFailureSlot.captured
+        }
+
+        deviceController = DefaultDeviceController(
+            context,
+            audioClientController,
+            videoClientController,
+            eventAnalyticsController,
+            mockLogger,
+            audioManager,
+            apiLevel,
+            mockBluetoothAudioRouter
+        )
+        commonSetupForBluetooth()
+    }
+
+    /**
+     * Sets up the test environment for API < 31 (Android 11 and below) tests.
+     */
+    private fun setupForAPI30AndBelow(apiLevel: Int = 30) {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        every { context.registerReceiver(any(), any()) } returns Intent()
+
+        // Capture Bluetooth routing callbacks
+        val onSuccessSlot = slot<(Int, MediaDeviceType) -> Unit>()
+        val onFailureSlot = slot<() -> Unit>()
+        every {
+            mockBluetoothAudioRouter.routeToBluetoothDevice(any(), any(), capture(onSuccessSlot), capture(onFailureSlot))
+        } answers {
+            capturedOnSuccess = onSuccessSlot.captured
+            capturedOnFailure = onFailureSlot.captured
+        }
+
+        deviceController = DefaultDeviceController(
+            context,
+            audioClientController,
+            videoClientController,
+            eventAnalyticsController,
+            mockLogger,
+            audioManager,
+            apiLevel,
+            mockBluetoothAudioRouter
+        )
+        commonSetupForBluetooth()
+    }
+
+    private fun commonSetupForBluetooth() {
+        every { speakerInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
+        every { speakerInfo.productName } returns "Speaker"
+        every { speakerInfo.id } returns 1
+        every { earpieceInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
+        every { earpieceInfo.productName } returns "Handset"
+        every { earpieceInfo.id } returns 2
+        every { wiredHeadsetInfo.type } returns AudioDeviceInfo.TYPE_WIRED_HEADSET
+        every { wiredHeadsetInfo.productName } returns "Wired Headset"
+        every { wiredHeadsetInfo.id } returns 3
+        every { bluetoothInfo.type } returns AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+        every { bluetoothInfo.productName } returns "Bluetooth Headset"
+        every { bluetoothInfo.id } returns 4
+        every { bluetoothInfo2.type } returns AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+        every { bluetoothInfo2.productName } returns "Bluetooth Headset 2"
+        every { bluetoothInfo2.id } returns 5
+
+        every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns arrayOf(
+            speakerInfo, earpieceInfo, bluetoothInfo
+        )
+        every { audioManager.availableCommunicationDevices } returns listOf(
+            speakerInfo, earpieceInfo, bluetoothInfo
+        )
+        every { audioManager.setCommunicationDevice(any()) } returns true
+        every { audioManager.clearCommunicationDevice() } just Runs
+
+        mockkStatic(DefaultAudioClientController::class)
+        DefaultAudioClientController.audioClientState = AudioClientState.STARTED
+        every { audioClientController.setRoute(any()) } returns true
     }
 
     private fun commonSetup() {
         every { speakerInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_SPEAKER
         every { speakerInfo.productName } returns "default speaker"
+        every { speakerInfo.id } returns 1
         every { earpieceInfo.type } returns AudioDeviceInfo.TYPE_BUILTIN_EARPIECE
         every { earpieceInfo.productName } returns "default receiver"
+        every { earpieceInfo.id } returns 2
         every { telephonyInfo.type } returns AudioDeviceInfo.TYPE_TELEPHONY
         every { telephonyInfo.productName } returns "telephony receiver"
+        every { telephonyInfo.id } returns 3
         every { wiredHeadsetInfo.type } returns AudioDeviceInfo.TYPE_WIRED_HEADSET
         every { wiredHeadsetInfo.productName } returns "my wired headset"
+        every { wiredHeadsetInfo.id } returns 4
         every { bluetoothInfo.type } returns AudioDeviceInfo.TYPE_BLUETOOTH_SCO
         every { bluetoothInfo.productName } returns "my bluetooth headphone"
+        every { bluetoothInfo.id } returns 5
         every { audioDevice.productName } returns "my product name"
         every { audioDevice.type } returns AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+        every { audioDevice.id } returns 6
         every { activeConfiguration.audioDevice } returns audioDevice
         every { audioManager.activeRecordingConfigurations } returns listOf(activeConfiguration)
     }
@@ -136,12 +250,15 @@ class DefaultDeviceControllerTest {
     @Before
     fun setup() {
         Dispatchers.setMain(testDispatcher)
+        capturedOnSuccess = null
+        capturedOnFailure = null
     }
 
     @After
     fun tearDown() {
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
+        unmockkAll()
     }
 
     @Test
@@ -166,7 +283,7 @@ class DefaultDeviceControllerTest {
         every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns arrayOf(
             speakerInfo, earpieceInfo, audioDevice
         )
-        val expected = MediaDevice("my product name (Bluetooth)", MediaDeviceType.AUDIO_BLUETOOTH)
+        val expected = MediaDevice("my product name (Bluetooth)", MediaDeviceType.AUDIO_BLUETOOTH, id = "6")
         val mediaDevice = deviceController.getActiveAudioDevice()
         assertEquals(expected, mediaDevice)
     }
@@ -312,19 +429,16 @@ class DefaultDeviceControllerTest {
     }
 
     @Test
-    fun `chooseAudioDevice should call audioManager startBluetoothSco when choosing bluetooth device`() {
+    fun `chooseAudioDevice should delegate to BluetoothAudioRouter when choosing bluetooth device`() {
         setupForOldAPILevel()
         every { audioClientController.setRoute(any()) } returns true
         mockkStatic(DefaultAudioClientController::class)
         DefaultAudioClientController.audioClientState = AudioClientState.STARTED
-        deviceController.chooseAudioDevice(
-            MediaDevice(
-                "bluetooth",
-                MediaDeviceType.AUDIO_BLUETOOTH
-            )
-        )
+        val bluetoothDevice = MediaDevice("bluetooth", MediaDeviceType.AUDIO_BLUETOOTH)
 
-        verify { audioManager.startBluetoothSco() }
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        verify { mockBluetoothAudioRouter.routeToBluetoothDevice(bluetoothDevice, AudioClient.SPK_STREAM_ROUTE_BT_AUDIO, any(), any()) }
     }
 
     @Test
@@ -466,5 +580,214 @@ class DefaultDeviceControllerTest {
     @Test
     fun `deviceController stopListening should call BluetoothDeviceController stopListening for old API level`() {
         setupForOldAPILevel()
+    }
+
+    // ==================== Bluetooth Routing Delegation Tests - API 31+ ====================
+
+    @Test
+    fun `chooseAudioDevice should immediately call setRoute for speaker on API 31+`() {
+        setupForAPI31Plus(31)
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER, id = "1")
+
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_SPEAKER) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should immediately call setRoute for wired headset on API 31+`() {
+        setupForAPI31Plus(31)
+        every { audioManager.availableCommunicationDevices } returns listOf(
+            speakerInfo, earpieceInfo, bluetoothInfo, wiredHeadsetInfo
+        )
+        val wiredDevice = MediaDevice("Wired Headset", MediaDeviceType.AUDIO_WIRED_HEADSET, id = "3")
+
+        deviceController.chooseAudioDevice(wiredDevice)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_HEADSET) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should immediately call setRoute for handset on API 31+`() {
+        setupForAPI31Plus(31)
+        val handsetDevice = MediaDevice("Handset", MediaDeviceType.AUDIO_HANDSET, id = "2")
+
+        deviceController.chooseAudioDevice(handsetDevice)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_RECEIVER) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should delegate to BluetoothAudioRouter for Bluetooth on API 31+`() {
+        setupForAPI31Plus(31)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH, id = "4")
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        verify { mockBluetoothAudioRouter.routeToBluetoothDevice(bluetoothDevice, AudioClient.SPK_STREAM_ROUTE_BT_AUDIO, any(), any()) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should not call setRoute directly for Bluetooth on API 31+`() {
+        setupForAPI31Plus(31)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH, id = "4")
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        verify(exactly = 0) { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_BT_AUDIO) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should cancel pending Bluetooth operation on device change on API 31+`() {
+        setupForAPI31Plus(31)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH, id = "4")
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER, id = "1")
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify(exactly = 2) { mockBluetoothAudioRouter.cancelPendingOperation() }
+    }
+
+    @Test
+    fun `Bluetooth success callback should call setRoute and publish event on API 31+`() {
+        setupForAPI31Plus(31)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH, id = "4")
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        // Simulate success callback from BluetoothAudioRouter
+        capturedOnSuccess?.invoke(AudioClient.SPK_STREAM_ROUTE_BT_AUDIO, MediaDeviceType.AUDIO_BLUETOOTH)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_BT_AUDIO) }
+        verify {
+            eventAnalyticsController.publishEvent(
+                EventName.audioInputSelected,
+                mutableMapOf(EventAttributeName.audioDeviceType to MediaDeviceType.AUDIO_BLUETOOTH.toString()),
+                false
+            )
+        }
+    }
+
+    @Test
+    fun `Bluetooth failure callback should notify observers on API 31+`() {
+        setupForAPI31Plus(31)
+        deviceController.addDeviceChangeObserver(deviceChangeObserver)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH, id = "4")
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        // Simulate failure callback from BluetoothAudioRouter
+        capturedOnFailure?.invoke()
+
+        verify { deviceChangeObserver.onAudioDeviceChanged(any()) }
+    }
+
+    // ==================== Bluetooth Routing Delegation Tests - API < 31 ====================
+
+    @Test
+    fun `chooseAudioDevice should delegate to BluetoothAudioRouter for Bluetooth on API below 31`() {
+        setupForAPI30AndBelow(30)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH)
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        verify { mockBluetoothAudioRouter.routeToBluetoothDevice(bluetoothDevice, AudioClient.SPK_STREAM_ROUTE_BT_AUDIO, any(), any()) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should immediately call setRoute for speaker on API below 31`() {
+        setupForAPI30AndBelow(30)
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER)
+
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_SPEAKER) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should cancel pending Bluetooth operation on device change on API below 31`() {
+        setupForAPI30AndBelow(30)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH)
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER)
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify(exactly = 2) { mockBluetoothAudioRouter.cancelPendingOperation() }
+    }
+
+    @Test
+    fun `Bluetooth success callback should call setRoute and publish event on API below 31`() {
+        setupForAPI30AndBelow(30)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH)
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        // Simulate success callback from BluetoothAudioRouter
+        capturedOnSuccess?.invoke(AudioClient.SPK_STREAM_ROUTE_BT_AUDIO, MediaDeviceType.AUDIO_BLUETOOTH)
+
+        verify { audioClientController.setRoute(AudioClient.SPK_STREAM_ROUTE_BT_AUDIO) }
+        verify {
+            eventAnalyticsController.publishEvent(
+                EventName.audioInputSelected,
+                mutableMapOf(EventAttributeName.audioDeviceType to MediaDeviceType.AUDIO_BLUETOOTH.toString()),
+                false
+            )
+        }
+    }
+
+    @Test
+    fun `Bluetooth failure callback should notify observers on API below 31`() {
+        setupForAPI30AndBelow(30)
+        deviceController.addDeviceChangeObserver(deviceChangeObserver)
+        val bluetoothDevice = MediaDevice("Bluetooth Headset", MediaDeviceType.AUDIO_BLUETOOTH)
+
+        deviceController.chooseAudioDevice(bluetoothDevice)
+
+        // Simulate failure callback from BluetoothAudioRouter
+        capturedOnFailure?.invoke()
+
+        verify { deviceChangeObserver.onAudioDeviceChanged(any()) }
+    }
+
+    // ==================== Cross-API Tests ====================
+
+    @Test
+    fun `listAudioDevices should include device IDs for API 23+`() {
+        setupForAPI31Plus(23)
+
+        val devices = deviceController.listAudioDevices()
+
+        devices.forEach { device ->
+            assert(device.id != null) { "Device ${device.label} should have an ID" }
+        }
+    }
+
+    @Test
+    fun `chooseAudioDevice should not proceed when AudioClient is not STARTED on API 31+`() {
+        setupForAPI31Plus(31)
+        DefaultAudioClientController.audioClientState = AudioClientState.STOPPED
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER, id = "1")
+
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify(exactly = 0) { audioClientController.setRoute(any()) }
+    }
+
+    @Test
+    fun `chooseAudioDevice should call publishEvent when audio device is selected on API 31+`() {
+        setupForAPI31Plus(31)
+        val speakerDevice = MediaDevice("Speaker", MediaDeviceType.AUDIO_BUILTIN_SPEAKER, id = "1")
+
+        deviceController.chooseAudioDevice(speakerDevice)
+
+        verify {
+            eventAnalyticsController.publishEvent(
+                EventName.audioInputSelected,
+                mutableMapOf(EventAttributeName.audioDeviceType to MediaDeviceType.AUDIO_BUILTIN_SPEAKER.toString()),
+                false
+            )
+        }
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/CommunicationDeviceBluetoothAudioRouterTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/CommunicationDeviceBluetoothAudioRouterTest.kt
@@ -1,0 +1,496 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.Context
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Handler
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import java.util.concurrent.Executor
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [CommunicationDeviceBluetoothAudioRouter].
+ *
+ * **Validates: Invariants 2, 3, 4, 5** from the design document:
+ * - Invariant 2: Success callback invocation on connection
+ * - Invariant 3: Failure callback invocation on error or timeout
+ * - Invariant 4: Cancel clears pending state
+ * - Invariant 5: Retry-on-mismatch behavior (API 31+)
+ */
+class CommunicationDeviceBluetoothAudioRouterTest {
+
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var audioManager: AudioManager
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var handler: Handler
+
+    @MockK
+    private lateinit var mainExecutor: Executor
+
+    private lateinit var router: CommunicationDeviceBluetoothAudioRouter
+
+    // Captured communication device listener for simulating device changes
+    private var capturedListener: AudioManager.OnCommunicationDeviceChangedListener? = null
+
+    // Captured timeout runnable
+    private var capturedTimeoutRunnable: Runnable? = null
+    private var capturedTimeoutDelay: Long = 0
+
+    // Captured retry runnable
+    private var capturedRetryRunnable: Runnable? = null
+    private var capturedRetryDelay: Long = 0
+
+    // Test callback tracking
+    private var successCallbackInvoked = false
+    private var successRoute: Int = -1
+    private var successDeviceType: MediaDeviceType? = null
+    private var failureCallbackInvoked = false
+
+    private val testRoute = 3 // AudioClient.SPK_STREAM_ROUTE_BT_AUDIO
+    private val testDeviceId = 42
+    private val testMediaDevice = MediaDevice(
+        label = "Test Bluetooth Device",
+        type = MediaDeviceType.AUDIO_BLUETOOTH,
+        id = testDeviceId.toString()
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        // Reset callback tracking
+        successCallbackInvoked = false
+        successRoute = -1
+        successDeviceType = null
+        failureCallbackInvoked = false
+        capturedRetryRunnable = null
+        capturedRetryDelay = 0
+
+        // Mock context.mainExecutor
+        every { context.mainExecutor } returns mainExecutor
+
+        // Capture the communication device listener registration
+        val listenerSlot = slot<AudioManager.OnCommunicationDeviceChangedListener>()
+        every { audioManager.addOnCommunicationDeviceChangedListener(any(), capture(listenerSlot)) } answers {
+            capturedListener = listenerSlot.captured
+        }
+        every { audioManager.removeOnCommunicationDeviceChangedListener(any()) } just Runs
+
+        // Capture timeout runnable
+        val runnableSlot = slot<Runnable>()
+        val delaySlot = slot<Long>()
+        every { handler.postDelayed(capture(runnableSlot), capture(delaySlot)) } answers {
+            val delay = delaySlot.captured
+            if (delay == BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS) {
+                capturedTimeoutRunnable = runnableSlot.captured
+                capturedTimeoutDelay = delay
+            } else if (delay == BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_RETRY_DELAY_MS) {
+                capturedRetryRunnable = runnableSlot.captured
+                capturedRetryDelay = delay
+            }
+            true
+        }
+        every { handler.removeCallbacks(any<Runnable>()) } just Runs
+
+        // Create the router
+        router = CommunicationDeviceBluetoothAudioRouter(context, audioManager, logger, handler)
+    }
+
+    @After
+    fun teardown() {
+        capturedListener = null
+        capturedTimeoutRunnable = null
+        capturedRetryRunnable = null
+    }
+
+    // ========== Test: Bluetooth device confirmed triggers success callback ==========
+    // **Validates: Invariant 2 - Success callback invocation on connection**
+    // _Requirements: 7.3_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke success callback when Bluetooth SCO device is confirmed`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { route, deviceType ->
+                successCallbackInvoked = true
+                successRoute = route
+                successDeviceType = deviceType
+            },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Communication device changes to Bluetooth SCO
+        simulateCommunicationDeviceChanged(bluetoothDevice)
+
+        // Then: Success callback should be invoked with correct parameters
+        assertTrue("Success callback should be invoked", successCallbackInvoked)
+        assertEquals("Route should match", testRoute, successRoute)
+        assertEquals("Device type should match", MediaDeviceType.AUDIO_BLUETOOTH, successDeviceType)
+        assertFalse("Failure callback should not be invoked", failureCallbackInvoked)
+    }
+
+    // ========== Test: Device mismatch triggers retry ==========
+    // **Validates: Invariant 5 - Retry-on-mismatch behavior (API 31+)**
+    // _Requirements: 7.4_
+
+    @Test
+    fun `routeToBluetoothDevice should schedule retry when device mismatch occurs`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        val handsetDevice = createMockAudioDeviceInfo(99, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice, handsetDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Communication device changes to Handset instead of Bluetooth (mismatch)
+        simulateCommunicationDeviceChanged(handsetDevice)
+
+        // Then: Retry should be scheduled
+        assertEquals(
+            "Retry should be scheduled with correct delay",
+            BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_RETRY_DELAY_MS,
+            capturedRetryDelay
+        )
+        assertFalse("Success callback should not be invoked yet", successCallbackInvoked)
+        assertFalse("Failure callback should not be invoked yet", failureCallbackInvoked)
+    }
+
+    @Test
+    fun `retry should call setCommunicationDevice again when device is still available`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        val handsetDevice = createMockAudioDeviceInfo(99, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice, handsetDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Communication device changes to Handset (mismatch)
+        simulateCommunicationDeviceChanged(handsetDevice)
+
+        // And: Retry runnable executes
+        capturedRetryRunnable?.run()
+
+        // Then: setCommunicationDevice should be called again
+        verify(exactly = 2) { audioManager.setCommunicationDevice(bluetoothDevice) }
+    }
+
+    // ========== Test: Max retries exceeded triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation after max retries**
+    // _Requirements: 7.5_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback after max retries exceeded`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        val handsetDevice = createMockAudioDeviceInfo(99, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice, handsetDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Device mismatch occurs MAX_RETRIES + 1 times
+        repeat(BluetoothRoutingConfig.BLUETOOTH_ROUTING_MISMATCH_MAX_RETRIES + 1) {
+            simulateCommunicationDeviceChanged(handsetDevice)
+            if (capturedRetryRunnable != null) {
+                capturedRetryRunnable?.run()
+                capturedRetryRunnable = null
+            }
+        }
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked after max retries", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Device unavailable on retry triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation when device unavailable**
+    // _Requirements: 7.5_
+
+    @Test
+    fun `retry should invoke failure callback when device is no longer available`() {
+        // Given: A Bluetooth device is initially available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        val handsetDevice = createMockAudioDeviceInfo(99, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice, handsetDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Communication device changes to Handset (mismatch)
+        simulateCommunicationDeviceChanged(handsetDevice)
+
+        // And: Bluetooth device becomes unavailable before retry
+        every { audioManager.availableCommunicationDevices } returns listOf(handsetDevice)
+
+        // And: Retry runnable executes
+        capturedRetryRunnable?.run()
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked when device unavailable", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Timeout triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation on timeout**
+    // _Requirements: 7.6_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when timeout expires`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // Verify timeout was scheduled with correct delay
+        assertEquals(
+            "Timeout should be scheduled with COMMUNICATION_DEVICE_TIMEOUT_MS",
+            BluetoothRoutingConfig.COMMUNICATION_DEVICE_TIMEOUT_MS,
+            capturedTimeoutDelay
+        )
+
+        // When: Timeout expires
+        capturedTimeoutRunnable?.run()
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Cancel prevents callbacks ==========
+    // **Validates: Invariant 4 - Cancel clears pending state**
+    // _Requirements: 7.6_
+
+    @Test
+    fun `cancelPendingOperation should prevent success callback from being invoked`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // And: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: Operation is cancelled before device confirmation
+        router.cancelPendingOperation()
+
+        // And: Communication device changes to Bluetooth SCO
+        simulateCommunicationDeviceChanged(bluetoothDevice)
+
+        // Then: Neither callback should be invoked
+        assertFalse("Success callback should not be invoked after cancel", successCallbackInvoked)
+        assertFalse("Failure callback should not be invoked after cancel", failureCallbackInvoked)
+    }
+
+    @Test
+    fun `cancelPendingOperation should prevent failure callback from being invoked on timeout`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // And: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: Operation is cancelled before timeout
+        router.cancelPendingOperation()
+
+        // And: Timeout expires
+        capturedTimeoutRunnable?.run()
+
+        // Then: Neither callback should be invoked
+        assertFalse("Success callback should not be invoked after cancel", successCallbackInvoked)
+        assertFalse("Failure callback should not be invoked after cancel", failureCallbackInvoked)
+    }
+
+    @Test
+    fun `cancelPendingOperation should remove timeout and retry callbacks from handler`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // And: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> },
+            onFailure = { }
+        )
+
+        // When: Operation is cancelled
+        router.cancelPendingOperation()
+
+        // Then: Callbacks should be removed from handler
+        verify(atLeast = 1) { handler.removeCallbacks(any<Runnable>()) }
+    }
+
+    // ========== Test: setCommunicationDevice failure invokes failure callback ==========
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when setCommunicationDevice returns false`() {
+        // Given: A Bluetooth device is available but setCommunicationDevice fails
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns false
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // Then: Failure callback should be invoked immediately
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when device not found`() {
+        // Given: No Bluetooth device is available
+        every { audioManager.availableCommunicationDevices } returns emptyList()
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // Then: Failure callback should be invoked immediately
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Retry setCommunicationDevice failure invokes failure callback ==========
+
+    @Test
+    fun `retry should invoke failure callback when setCommunicationDevice returns false`() {
+        // Given: A Bluetooth device is available
+        val bluetoothDevice = createMockAudioDeviceInfo(testDeviceId, AudioDeviceInfo.TYPE_BLUETOOTH_SCO)
+        val handsetDevice = createMockAudioDeviceInfo(99, AudioDeviceInfo.TYPE_BUILTIN_EARPIECE)
+        every { audioManager.availableCommunicationDevices } returns listOf(bluetoothDevice, handsetDevice)
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns true
+
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // And: Communication device changes to Handset (mismatch)
+        simulateCommunicationDeviceChanged(handsetDevice)
+
+        // And: setCommunicationDevice will fail on retry
+        every { audioManager.setCommunicationDevice(bluetoothDevice) } returns false
+
+        // And: Retry runnable executes
+        capturedRetryRunnable?.run()
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked when retry fails", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Helper methods ==========
+
+    /**
+     * Creates a mock AudioDeviceInfo with the specified ID and type.
+     */
+    private fun createMockAudioDeviceInfo(id: Int, type: Int): AudioDeviceInfo {
+        val device = mockk<AudioDeviceInfo>()
+        every { device.id } returns id
+        every { device.type } returns type
+        every { device.productName } returns "Mock Device $id"
+        return device
+    }
+
+    /**
+     * Simulates a communication device change by invoking the captured listener.
+     */
+    private fun simulateCommunicationDeviceChanged(device: AudioDeviceInfo?) {
+        capturedListener?.onCommunicationDeviceChanged(device)
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientControllerTest.kt
@@ -10,6 +10,7 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.AudioTrack
+import android.os.Build
 import android.util.Log
 import com.amazonaws.services.chime.sdk.meetings.TestConstant
 import com.amazonaws.services.chime.sdk.meetings.analytics.EventAnalyticsController
@@ -921,5 +922,78 @@ class DefaultAudioClientControllerTest {
             true,
             reconnectTimeoutMs = 180000
         )
+    }
+
+    @Test
+    fun `stop should call clearCommunicationDevice on API 31+ when audio client is started`() {
+        setupStartTests()
+        every { audioManager.clearCommunicationDevice() } just runs
+
+        // Create controller with buildVersion = API 31 (S)
+        val audioClientControllerApi31 = DefaultAudioClientController(
+            context,
+            mockLogger,
+            mockAudioClientObserver,
+            mockAudioClient,
+            mockEventAnlyticsStateController,
+            mockEventAnalyticsController,
+            buildVersion = Build.VERSION_CODES.S
+        )
+
+        audioClientControllerApi31.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.None,
+            true,
+            reconnectTimeoutMs = 180000
+        )
+        every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
+
+        audioClientControllerApi31.stop()
+
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { audioManager.clearCommunicationDevice() }
+    }
+
+    @Test
+    fun `stop should NOT call clearCommunicationDevice on API less than 31 when audio client is started`() {
+        setupStartTests()
+        every { audioManager.clearCommunicationDevice() } just runs
+
+        // Create controller with buildVersion = API 30 (R)
+        val audioClientControllerApi30 = DefaultAudioClientController(
+            context,
+            mockLogger,
+            mockAudioClientObserver,
+            mockAudioClient,
+            mockEventAnlyticsStateController,
+            mockEventAnalyticsController,
+            buildVersion = Build.VERSION_CODES.R
+        )
+
+        audioClientControllerApi30.start(
+            testAudioFallbackUrl,
+            testAudioHostUrl,
+            testMeetingId,
+            testAttendeeId,
+            testJoinToken,
+            AudioMode.Stereo48K,
+            AudioDeviceCapabilities.InputAndOutput,
+            AudioStreamType.VoiceCall,
+            AudioRecordingPresetOverride.None,
+            true,
+            reconnectTimeoutMs = 180000
+        )
+        every { mockAudioClient.stopSession() } returns testAudioClientSuccessCode
+
+        audioClientControllerApi30.stop()
+
+        verify(exactly = 1, timeout = TestConstant.globalScopeTimeoutMs) { mockAudioClient.stopSession() }
+        verify(exactly = 0) { audioManager.clearCommunicationDevice() }
     }
 }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultBluetoothAudioRouterFactoryTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultBluetoothAudioRouterFactoryTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import java.util.concurrent.Executor
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [DefaultBluetoothAudioRouterFactory].
+ *
+ * **Validates: Invariant 1** from the design document:
+ * - On API 23-30, the ScoBluetoothAudioRouter is used
+ * - On API 31+, the CommunicationDeviceBluetoothAudioRouter is used
+ *
+ * _Requirements: 1.2, 1.3_
+ */
+class DefaultBluetoothAudioRouterFactoryTest {
+
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var audioManager: AudioManager
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var mainExecutor: Executor
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        // Mock context to return itself for registerReceiver (needed by ScoBluetoothAudioRouter)
+        every { context.registerReceiver(any(), any()) } returns mockk()
+
+        // Mock context.mainExecutor (needed by CommunicationDeviceBluetoothAudioRouter)
+        every { context.mainExecutor } returns mainExecutor
+    }
+
+    // ========== Test: API < 31 returns ScoBluetoothAudioRouter ==========
+    // **Validates: Invariant 1 - API-level routing delegation**
+    // _Requirements: 1.2_
+
+    @Test
+    fun `create should return ScoBluetoothAudioRouter for API 30`() {
+        // Given: Factory configured for API 30
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = Build.VERSION_CODES.R)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return ScoBluetoothAudioRouter
+        assertTrue(
+            "Factory should return ScoBluetoothAudioRouter for API 30",
+            router is ScoBluetoothAudioRouter
+        )
+    }
+
+    @Test
+    fun `create should return ScoBluetoothAudioRouter for API 29`() {
+        // Given: Factory configured for API 29
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = Build.VERSION_CODES.Q)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return ScoBluetoothAudioRouter
+        assertTrue(
+            "Factory should return ScoBluetoothAudioRouter for API 29",
+            router is ScoBluetoothAudioRouter
+        )
+    }
+
+    @Test
+    fun `create should return ScoBluetoothAudioRouter for API 23`() {
+        // Given: Factory configured for API 23 (minimum supported)
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = Build.VERSION_CODES.M)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return ScoBluetoothAudioRouter
+        assertTrue(
+            "Factory should return ScoBluetoothAudioRouter for API 23",
+            router is ScoBluetoothAudioRouter
+        )
+    }
+
+    // ========== Test: API >= 31 returns CommunicationDeviceBluetoothAudioRouter ==========
+    // **Validates: Invariant 1 - API-level routing delegation**
+    // _Requirements: 1.3_
+
+    @Test
+    fun `create should return CommunicationDeviceBluetoothAudioRouter for API 31`() {
+        // Given: Factory configured for API 31
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = Build.VERSION_CODES.S)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return CommunicationDeviceBluetoothAudioRouter
+        assertTrue(
+            "Factory should return CommunicationDeviceBluetoothAudioRouter for API 31",
+            router is CommunicationDeviceBluetoothAudioRouter
+        )
+    }
+
+    @Test
+    fun `create should return CommunicationDeviceBluetoothAudioRouter for API 33`() {
+        // Given: Factory configured for API 33
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = Build.VERSION_CODES.TIRAMISU)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return CommunicationDeviceBluetoothAudioRouter
+        assertTrue(
+            "Factory should return CommunicationDeviceBluetoothAudioRouter for API 33",
+            router is CommunicationDeviceBluetoothAudioRouter
+        )
+    }
+
+    @Test
+    fun `create should return CommunicationDeviceBluetoothAudioRouter for API 34`() {
+        // Given: Factory configured for API 34
+        val factory = DefaultBluetoothAudioRouterFactory(buildVersion = 34)
+
+        // When: Creating router
+        val router = factory.create(
+            context = context,
+            audioManager = audioManager,
+            logger = logger
+        )
+
+        // Then: Should return CommunicationDeviceBluetoothAudioRouter
+        assertTrue(
+            "Factory should return CommunicationDeviceBluetoothAudioRouter for API 34",
+            router is CommunicationDeviceBluetoothAudioRouter
+        )
+    }
+}

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/ScoBluetoothAudioRouterTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/ScoBluetoothAudioRouterTest.kt
@@ -1,0 +1,344 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.amazonaws.services.chime.sdk.meetings.internal.audio
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioManager
+import android.os.Handler
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDevice
+import com.amazonaws.services.chime.sdk.meetings.device.MediaDeviceType
+import com.amazonaws.services.chime.sdk.meetings.utils.logger.Logger
+import io.mockk.MockKAnnotations
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [ScoBluetoothAudioRouter].
+ *
+ * **Validates: Invariants 2, 3, 4** from the design document:
+ * - Invariant 2: Success callback invocation on connection
+ * - Invariant 3: Failure callback invocation on error or timeout
+ * - Invariant 4: Cancel clears pending state
+ */
+class ScoBluetoothAudioRouterTest {
+
+    @MockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var audioManager: AudioManager
+
+    @MockK
+    private lateinit var logger: Logger
+
+    @MockK
+    private lateinit var handler: Handler
+
+    private lateinit var router: ScoBluetoothAudioRouter
+
+    // Captured broadcast receiver for simulating SCO state changes
+    private var capturedReceiver: BroadcastReceiver? = null
+
+    // Captured timeout runnable
+    private var capturedTimeoutRunnable: Runnable? = null
+    private var capturedTimeoutDelay: Long = 0
+
+    // Test callback tracking
+    private var successCallbackInvoked = false
+    private var successRoute: Int = -1
+    private var successDeviceType: MediaDeviceType? = null
+    private var failureCallbackInvoked = false
+
+    private val testRoute = 3 // AudioClient.SPK_STREAM_ROUTE_BT_AUDIO
+    private val testMediaDevice = MediaDevice(
+        label = "Test Bluetooth Device",
+        type = MediaDeviceType.AUDIO_BLUETOOTH,
+        id = "bt-device-1"
+    )
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        // Reset callback tracking
+        successCallbackInvoked = false
+        successRoute = -1
+        successDeviceType = null
+        failureCallbackInvoked = false
+
+        // Capture the broadcast receiver registration
+        val receiverSlot = slot<BroadcastReceiver>()
+        every { context.registerReceiver(capture(receiverSlot), any<IntentFilter>()) } answers {
+            capturedReceiver = receiverSlot.captured
+            Intent()
+        }
+
+        // Capture timeout runnable
+        val runnableSlot = slot<Runnable>()
+        val delaySlot = slot<Long>()
+        every { handler.postDelayed(capture(runnableSlot), capture(delaySlot)) } answers {
+            capturedTimeoutRunnable = runnableSlot.captured
+            capturedTimeoutDelay = delaySlot.captured
+            true
+        }
+        every { handler.removeCallbacks(any<Runnable>()) } just Runs
+
+        // Create the router
+        router = ScoBluetoothAudioRouter(context, audioManager, logger, handler)
+    }
+
+    @After
+    fun teardown() {
+        capturedReceiver = null
+        capturedTimeoutRunnable = null
+    }
+
+    // ========== Test: SCO CONNECTED triggers success callback ==========
+    // **Validates: Invariant 2 - Success callback invocation on connection**
+    // _Requirements: 7.1_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke success callback when SCO state transitions to CONNECTED`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { route, deviceType ->
+                successCallbackInvoked = true
+                successRoute = route
+                successDeviceType = deviceType
+            },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: SCO state transitions to CONNECTED
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_CONNECTED,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTING
+        )
+
+        // Then: Success callback should be invoked with correct parameters
+        assertTrue("Success callback should be invoked", successCallbackInvoked)
+        assertEquals("Route should match", testRoute, successRoute)
+        assertEquals("Device type should match", MediaDeviceType.AUDIO_BLUETOOTH, successDeviceType)
+        assertFalse("Failure callback should not be invoked", failureCallbackInvoked)
+    }
+
+    // ========== Test: SCO ERROR triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation on error**
+    // _Requirements: 7.2_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when SCO state transitions to ERROR`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: SCO state transitions to ERROR
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_ERROR,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTING
+        )
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: SCO DISCONNECTED from CONNECTING triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation on connection failure**
+    // _Requirements: 7.2_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when SCO transitions from CONNECTING to DISCONNECTED`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: SCO state transitions from CONNECTING to DISCONNECTED (connection attempt failed)
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_DISCONNECTED,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTING
+        )
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    @Test
+    fun `routeToBluetoothDevice should NOT invoke failure callback when SCO transitions from CONNECTED to DISCONNECTED`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: SCO state transitions from CONNECTED to DISCONNECTED (expected during device switching)
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_DISCONNECTED,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTED
+        )
+
+        // Then: Neither callback should be invoked (waiting for new device to connect)
+        assertFalse("Failure callback should not be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Timeout triggers failure callback ==========
+    // **Validates: Invariant 3 - Failure callback invocation on timeout**
+    // _Requirements: 7.6_
+
+    @Test
+    fun `routeToBluetoothDevice should invoke failure callback when timeout expires`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // Verify timeout was scheduled with correct delay
+        assertEquals(
+            "Timeout should be scheduled with SCO_CONNECTION_TIMEOUT_MS",
+            BluetoothRoutingConfig.SCO_CONNECTION_TIMEOUT_MS,
+            capturedTimeoutDelay
+        )
+
+        // When: Timeout expires
+        capturedTimeoutRunnable?.run()
+
+        // Then: Failure callback should be invoked
+        assertTrue("Failure callback should be invoked", failureCallbackInvoked)
+        assertFalse("Success callback should not be invoked", successCallbackInvoked)
+    }
+
+    // ========== Test: Cancel prevents callbacks ==========
+    // **Validates: Invariant 4 - Cancel clears pending state**
+    // _Requirements: 7.6_
+
+    @Test
+    fun `cancelPendingOperation should prevent success callback from being invoked`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: Operation is cancelled before SCO connects
+        router.cancelPendingOperation()
+
+        // And: SCO state transitions to CONNECTED
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_CONNECTED,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTING
+        )
+
+        // Then: Neither callback should be invoked
+        assertFalse("Success callback should not be invoked after cancel", successCallbackInvoked)
+        assertFalse("Failure callback should not be invoked after cancel", failureCallbackInvoked)
+    }
+
+    @Test
+    fun `cancelPendingOperation should prevent failure callback from being invoked`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> successCallbackInvoked = true },
+            onFailure = { failureCallbackInvoked = true }
+        )
+
+        // When: Operation is cancelled before SCO error
+        router.cancelPendingOperation()
+
+        // And: SCO state transitions to ERROR
+        simulateScoStateChange(
+            state = AudioManager.SCO_AUDIO_STATE_ERROR,
+            previousState = AudioManager.SCO_AUDIO_STATE_CONNECTING
+        )
+
+        // Then: Neither callback should be invoked
+        assertFalse("Success callback should not be invoked after cancel", successCallbackInvoked)
+        assertFalse("Failure callback should not be invoked after cancel", failureCallbackInvoked)
+    }
+
+    @Test
+    fun `cancelPendingOperation should remove timeout callback from handler`() {
+        // Given: A pending Bluetooth routing operation
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> },
+            onFailure = { }
+        )
+
+        // When: Operation is cancelled
+        router.cancelPendingOperation()
+
+        // Then: Timeout callback should be removed from handler
+        verify { handler.removeCallbacks(any<Runnable>()) }
+    }
+
+    // ========== Test: routeToBluetoothDevice starts SCO ==========
+
+    @Test
+    fun `routeToBluetoothDevice should call startBluetoothSco on audioManager`() {
+        // When: Routing to Bluetooth device
+        router.routeToBluetoothDevice(
+            mediaDevice = testMediaDevice,
+            route = testRoute,
+            onSuccess = { _, _ -> },
+            onFailure = { }
+        )
+
+        // Then: AudioManager should be configured for Bluetooth SCO
+        verify { audioManager.mode = AudioManager.MODE_IN_COMMUNICATION }
+        verify { audioManager.isSpeakerphoneOn = false }
+        verify { audioManager.startBluetoothSco() }
+        verify { audioManager.isBluetoothScoOn = true }
+    }
+
+    // ========== Helper methods ==========
+
+    /**
+     * Simulates an SCO state change by invoking the captured broadcast receiver.
+     */
+    private fun simulateScoStateChange(state: Int, previousState: Int) {
+        val intent = mockk<Intent>()
+        every { intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1) } returns state
+        every { intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_PREVIOUS_STATE, -1) } returns previousState
+
+        capturedReceiver?.onReceive(context, intent)
+    }
+}


### PR DESCRIPTION
## ℹ️ Description

When switching to a Bluetooth audio device, the SDK was changing the audio
route before the Bluetooth connection was established. This caused a race
condition where Android would reject Bluetooth routing and fall back to
Handset.

This fix introduces the BluetoothAudioRouter abstraction to encapsulate Bluetooth
connection management. The router defers route changes until the Bluetooth
connection is confirmed ready, with implementations selected via
BluetoothAudioRouterFactory based on API level. This design isolates the
complex asynchronous Bluetooth handling from DefaultDeviceController and
allows each platform path to be tested independently.

ScoBluetoothAudioRouter (API < 31):
- Monitor ACTION_SCO_AUDIO_STATE_UPDATED broadcasts for connection state
- Execute deferred setRoute() only when SCO reaches CONNECTED state
- Handle SCO connection failures and timeouts (3 seconds)
- Distinguish connection failure from device switching for multi-device support

CommunicationDeviceBluetoothAudioRouter (API 31+):
- Use OnCommunicationDeviceChangedListener for connection confirmation
- Retry on mismatch when setCommunicationDevice() succeeds but listener
  reports a different device (500ms delay, max 3 retries)
- 5-second timeout for device switching per Android documentation

Additional changes:
- Update MediaDevice to track device IDs for API 31+ routing
- Add test coverage for both API paths

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Manually verified with a Pixel 8 device running Android 

### Unit test coverage
Added comprehensive unit tests

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
