### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -19,7 +19,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       # Modify build.gradle file to build for x86_64
       - name: Add x86_64 in gradle build
@@ -61,7 +61,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: AVD cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         id: avd-cache
         with:
           path: |

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout test package
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         if: always()
         with:
           repository: awslabs/amazon-chime-sdk-apple
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Setup Node.js - 15.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         if: always()
         with:
           node-version: 15.x
@@ -97,7 +97,7 @@ jobs:
           aws-region: ${{ env.REGION }}
 
       - name: Setup Node.js - 18.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         if: always()
         with:
           node-version: 18.x


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`v3`](https://github.com/actions/cache/releases/tag/v3) | [`v5`](https://github.com/actions/cache/releases/tag/v5) | [Release](https://github.com/actions/cache/releases/tag/v5) | codecov.yml |
| `actions/checkout` | [`v2`](https://github.com/actions/checkout/releases/tag/v2), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Release](https://github.com/actions/checkout/releases/tag/v6) | codecov.yml, daily-test.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | daily-test.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/cache** (v3 → v5):
  - ⚠️ v4 uses a new caching backend - existing caches may not be reused on first run

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
