### PR TITLE
fix(video): Prevent crash and ANR during content share stop

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultSurfaceTextureCaptureSource.kt
@@ -140,6 +140,7 @@ class DefaultSurfaceTextureCaptureSource(
         runBlocking(handler.asCoroutineDispatcher().immediate) {
             logger.info(TAG, "Setting on frame available listener to null")
             surfaceTexture.setOnFrameAvailableListener(null)
+            handler.removeCallbacksAndMessages(null)
         }
     }
 

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -141,12 +141,16 @@ class DefaultContentShareVideoClientController(
     }
 
     override fun stopVideoShare() {
+        if (!isSharing) return
+        isSharing = false
+
         logger.info(TAG, "Stopping content share video client")
+        videoSourceAdapter.source = null
+        videoClient?.setSending(false)
         videoClient?.javaStopService()
         videoClient?.destroy()
         videoClient = null
 
-        isSharing = false
         eglCore?.release()
         eglCore = null
     }

--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/contentshare/DefaultContentShareVideoClientController.kt
@@ -146,13 +146,18 @@ class DefaultContentShareVideoClientController(
 
         logger.info(TAG, "Stopping content share video client")
         videoSourceAdapter.source = null
-        videoClient?.setSending(false)
-        videoClient?.javaStopService()
-        videoClient?.destroy()
-        videoClient = null
 
-        eglCore?.release()
+        val client = videoClient
+        val core = eglCore
+        videoClient = null
         eglCore = null
+
+        Thread {
+            client?.setSending(false)
+            client?.javaStopService()
+            client?.destroy()
+            core?.release()
+        }.start()
     }
 
     override fun subscribeToVideoClientStateChange(observer: ContentShareObserver) {


### PR DESCRIPTION
## ℹ️ Description
Three fixes for content share teardown:

1. DefaultContentShareVideoClientController: Guard stopVideoShare() with isSharing check to prevent re-entrant calls. The callback from MediaProjection.onStop() and onContentShareStopped both trigger additional stopVideoShare() calls, causing javaStopService()+destroy() to execute 3-4 times on the main thread, blocking it past the 5s ANR threshold.

2. DefaultContentShareVideoClientController: Disconnect the video source adapter and stop sending BEFORE destroying the video client. Prevents frames flowing into freed native objects.

3. DefaultSurfaceTextureCaptureSource: Cancel pending handler messages (minFps resend timer) in stop() to prevent delayed frame delivery into a torn-down pipeline.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
