### PR TITLE
feat(demo): Add playback mute toggle to replica meeting mode

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -627,12 +627,14 @@ class MeetingFragment : Fragment(),
     private fun refreshAdditionalOptionsDialogItems() {
         if (inReplicaMeeting() && !hasJoinedPrimaryMeeting) {
             val additionalToggles = arrayOf(
-                context?.getString(R.string.promote_to_primary_meeting)
+                context?.getString(R.string.promote_to_primary_meeting),
+                context?.getString(if (meetingModel.isPlaybackMuted) R.string.unmute_playback else R.string.mute_playback)
             )
 
             additionalOptionsAlertDialogBuilder.setItems(additionalToggles) { _, which ->
                 when (which) {
                     0 -> promoteToPrimaryMeeting()
+                    1 -> togglePlaybackMute()
                 }
             }
             return


### PR DESCRIPTION
Add unmute/mute playback option to the additional options menu when in replica meeting mode (before promoting to primary). This allows users to control audio playback without needing to promote first.

## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - Tested the change with demo for both replica and non replica meetings

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
