### PR TITLE
Fix/test main dispatcher race

### DIFF
--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/DefaultAudioVideoControllerTest.kt
@@ -40,13 +40,16 @@ import io.mockk.mockkObject
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import io.mockk.verify
 import java.util.Timer
 import java.util.TimerTask
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
@@ -134,6 +137,8 @@ class DefaultAudioVideoControllerTest {
         every { AppInfoUtil.initializeVideoClientAppDetailedInfo(any()) } just runs
         Dispatchers.setMain(testDispatcher)
         MockKAnnotations.init(this, relaxUnitFun = true)
+        mockkConstructor(Timer::class)
+        every { anyConstructed<Timer>().schedule(any<TimerTask>(), 5000L) } just runs
         val logger = ConsoleLogger(LogLevel.INFO)
 
         audioVideoController =
@@ -166,6 +171,15 @@ class DefaultAudioVideoControllerTest {
                 videoClientObserver,
                 logger
             )
+    }
+
+    @ExperimentalCoroutinesApi
+    @After
+    fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+        unmockkConstructor(Timer::class)
     }
 
     @Test
@@ -523,7 +537,6 @@ class DefaultAudioVideoControllerTest {
 
     @Test
     fun `promoteToPrimaryMeeting returns failure if either times out`() {
-        mockkConstructor(Timer::class)
         val timerTaskSlot = slot<TimerTask>()
         every { anyConstructed<Timer>().schedule(capture(timerTaskSlot), 5000L) } returns Unit
         val audioObserver = slot<PrimaryMeetingPromotionObserver>()

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
@@ -256,6 +256,7 @@ class DefaultDeviceControllerTest {
 
     @After
     fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
         unmockkAll()

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/device/DefaultDeviceControllerTest.kt
@@ -256,7 +256,6 @@ class DefaultDeviceControllerTest {
 
     @After
     fun tearDown() {
-        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
         unmockkAll()


### PR DESCRIPTION
## ℹ️ Description
This change:

- Mocks Timer construction for every DefaultAudioVideoControllerTest.
- Prevents timeout tasks from escaping into later test classes.
- Preserves timeout coverage by explicitly capturing and executing the timer task in the timeout test.
- Drains and resets the test Main dispatcher after every test.
- Removes constructor mocks during teardown to maintain test isolation.

There are no production-code changes.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
- Ran Jenkins Android adhoc build pipeline and passed
- Ran `DefaultAudioVideoControllerTest` and `DefaultDeviceControllerTest` together.
- Verified the generated JUnit results contained no leaked timer-thread or Main-dispatcher exceptions.
- Ran the complete unit-test suite three times from clean builds.
- Ran ./gradlew clean build bundle.
- Ran the repository pre-commit ktlint checks.

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
