### PR TITLE
test: Drain Main dispatcher before reset in observer test classes

### DIFF
--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/audio/DefaultAudioClientObserverTest.kt
@@ -170,6 +170,7 @@ class DefaultAudioClientObserverTest {
 
     @After
     fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollectorTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/metric/DefaultClientMetricsCollectorTest.kt
@@ -17,6 +17,7 @@ import io.mockk.mockkStatic
 import io.mockk.verify
 import java.util.Calendar
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
@@ -47,8 +48,10 @@ class DefaultClientMetricsCollectorTest {
             DefaultClientMetricsCollector()
     }
 
+    @ExperimentalCoroutinesApi
     @After
     fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
     }

--- a/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/ObserverUtilsTest.kt
+++ b/amazon-chime-sdk/src/test/java/com/amazonaws/services/chime/sdk/meetings/internal/utils/ObserverUtilsTest.kt
@@ -9,6 +9,7 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestCoroutineDispatcher
@@ -39,8 +40,10 @@ class ObserverUtilsTest {
         mockObservers.add(mockObserver)
     }
 
+    @ExperimentalCoroutinesApi
     @After
     fun tearDown() {
+        testDispatcher.scheduler.advanceUntilIdle()
         Dispatchers.resetMain()
         testDispatcher.cleanupTestCoroutines()
     }


### PR DESCRIPTION
Extend the fix from #710 to the three remaining test classes that swap Dispatchers.Main without draining queued work first.

ObserverUtils.notifyObserverOnMainThread posts observer callbacks to a companion-object CoroutineScope bound to Dispatchers.Main at class load. DefaultAudioClientObserverTest, DefaultClientMetricsCollectorTest, and ObserverUtilsTest each call Dispatchers.setMain in @Before and resetMain in @After but never advance the test dispatcher, so callbacks queued by one class can still be pending when the next class calls setMain, failing that class's verifies. Under CI scheduler contention this surfaced as ~84 intermittent failures across these three classes; on an unloaded machine the suite passes, which hid it.

Add testDispatcher.scheduler.advanceUntilIdle() before resetMain in each tearDown (matching #710), and the @ExperimentalCoroutinesApi opt-in the two classes that lacked it.

## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
