### PR TITLE
feat(demo): Add Enable Higher Definition video toggle

### DIFF
--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/activity/HomeActivity.kt
@@ -54,6 +54,8 @@ class HomeActivity : AppCompatActivity() {
     private var audioMode: AppCompatSpinner? = null
     private var audioDeviceCapabilitiesSpinner: AppCompatSpinner? = null
     private var audioRedundancySwitch: SwitchCompat? = null
+    private var fhdSwitch: SwitchCompat? = null
+    private var enableHigherDefinitionVideo: Boolean = false
     private var reconnectTimeoutSpinner: AppCompatSpinner? = null
     private var authenticationProgressBar: ProgressBar? = null
     private var meetingID: String? = null
@@ -88,6 +90,7 @@ class HomeActivity : AppCompatActivity() {
         audioDeviceCapabilitiesSpinner = findViewById(R.id.audioDeviceCapabilitiesSpinner)
         audioRedundancySwitch = findViewById(R.id.audioRedundancySwitch)
         audioRedundancySwitch?.setChecked(true)
+        fhdSwitch = findViewById(R.id.fhdSwitch)
         authenticationProgressBar = findViewById(R.id.progressAuthentication)
         debugSettingsViewModel = ViewModelProvider(this).get(DebugSettingsViewModel::class.java)
 
@@ -128,6 +131,7 @@ class HomeActivity : AppCompatActivity() {
         val reconnectTimeoutMs = reconnectTimeoutOptions[reconnectTimeoutSpinner?.selectedItemPosition ?: 0]
 
         val redundancyEnabled = audioRedundancySwitch?.isChecked as Boolean
+        enableHigherDefinitionVideo = fhdSwitch?.isChecked ?: false
         audioVideoConfig = AudioVideoConfiguration(audioMode = mode, audioDeviceCapabilities = audioDeviceCapabilities, enableAudioRedundancy = redundancyEnabled, reconnectTimeoutMs = reconnectTimeoutMs)
 
         meetingID = meetingEditText?.text.toString().trim().replace("\\s+".toRegex(), "+")
@@ -233,6 +237,10 @@ class HomeActivity : AppCompatActivity() {
             attendeeName)}&region=${encodeURLParam(MEETING_REGION)}"
         if (!primaryMeetingId.isNullOrEmpty()) {
             url += "&primaryExternalMeetingId=${encodeURLParam(primaryMeetingId)}"
+        }
+        if (enableHigherDefinitionVideo) {
+            // FHD video + UHD content both require the max-attendee-count param; FHD is capped at 25.
+            url += "&v_rs=FHD&c_rs=UHD&a_cnt=25"
         }
         val response = HttpUtils.post(URL(url), "", DefaultBackOffRetry(), logger)
         return if (response.httpException == null) {

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/fragment/MeetingFragment.kt
@@ -62,6 +62,7 @@ import com.amazonaws.services.chime.sdk.meetings.audiovideo.contentshare.Content
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.MetricsObserver
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.metric.ObservableMetric
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.LocalVideoConfiguration
+import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.RemoteVideoSource
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPauseState
 import com.amazonaws.services.chime.sdk.meetings.audiovideo.video.VideoPriority
@@ -1178,7 +1179,7 @@ class MeetingFragment : Fragment(),
 
         videoConfigDialogBuilder.setView(maxBitRateInput)
         videoConfigDialogBuilder.setPositiveButton("Done", DialogInterface.OnClickListener { dialog, which ->
-            meetingModel.localVideoMaxBitRateKbps = maxBitRateInput.text.toString().toIntOrNull() ?: 0
+            meetingModel.localVideoMaxBitRateKbps = maxBitRateInput.text.toString().toIntOrNull()
             // If local video is started, restart
             if (meetingModel.isLocalVideoStarted) {
                 startLocalVideo()
@@ -1210,29 +1211,32 @@ class MeetingFragment : Fragment(),
     private fun startLocalVideo() {
         if (meetingModel.isCameraSendAvailable) {
             meetingModel.isLocalVideoStarted = true
-            val localVideoConfig = LocalVideoConfiguration(meetingModel.localVideoMaxBitRateKbps)
+            // Only build a LocalVideoConfiguration when a max bitrate was set; otherwise call the
+            // no-config overload so the SDK picks its defaults (keeps that path covered).
+            val localVideoConfig = meetingModel.localVideoMaxBitRateKbps?.let { LocalVideoConfiguration(it) }
+            fun startWith(source: VideoSource) =
+                if (localVideoConfig != null) audioVideo.startLocalVideo(source, localVideoConfig)
+                else audioVideo.startLocalVideo(source)
             if (meetingModel.isUsingCameraCaptureSource) {
                 if (meetingModel.isUsingGpuVideoProcessor) {
                     cameraCaptureSource.addVideoSink(gpuVideoProcessor)
-                    audioVideo.startLocalVideo(gpuVideoProcessor, localVideoConfig)
+                    startWith(gpuVideoProcessor)
                 } else if (meetingModel.isUsingCpuVideoProcessor) {
                     cameraCaptureSource.addVideoSink(cpuVideoProcessor)
-                    audioVideo.startLocalVideo(cpuVideoProcessor, localVideoConfig)
+                    startWith(cpuVideoProcessor)
                 } else if (meetingModel.isUsingBackgroundBlur) {
                     cameraCaptureSource.addVideoSink(backgroundBlurVideoFrameProcessor)
-                    audioVideo.startLocalVideo(backgroundBlurVideoFrameProcessor, localVideoConfig)
+                    startWith(backgroundBlurVideoFrameProcessor)
                 } else if (meetingModel.isUsingBackgroundReplacement) {
                     cameraCaptureSource.addVideoSink(backgroundReplacementVideoFrameProcessor)
-                    audioVideo.startLocalVideo(
-                        backgroundReplacementVideoFrameProcessor,
-                        localVideoConfig
-                    )
+                    startWith(backgroundReplacementVideoFrameProcessor)
                 } else {
-                    audioVideo.startLocalVideo(cameraCaptureSource, localVideoConfig)
+                    startWith(cameraCaptureSource)
                 }
                 cameraCaptureSource.start()
             } else {
-                audioVideo.startLocalVideo(localVideoConfig)
+                if (localVideoConfig != null) audioVideo.startLocalVideo(localVideoConfig)
+                else audioVideo.startLocalVideo()
             }
             buttonCamera.setImageResource(R.drawable.button_camera_on)
         }

--- a/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
+++ b/app/src/main/java/com/amazonaws/services/chime/sdkdemo/model/MeetingModel.kt
@@ -80,7 +80,7 @@ class MeetingModel : ViewModel() {
     var isUsingCpuVideoProcessor = false
     var isUsingBackgroundBlur = false
     var isUsingBackgroundReplacement = false
-    var localVideoMaxBitRateKbps = 0
+    var localVideoMaxBitRateKbps: Int? = null
     var isCameraSendAvailable = false
     var isMicrophoneServiceBound = false
     val microphoneServiceConnection = object : ServiceConnection {

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -64,6 +64,14 @@
         android:text="@string/audio_redundancy_switch"
         android:layout_gravity="center"/>
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/fhdSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@string/enable_fhd_switch"
+        android:text="@string/enable_fhd_switch"
+        android:layout_gravity="center"/>
+
     <androidx.appcompat.widget.AppCompatSpinner
             android:id="@+id/reconnectTimeoutSpinner"
             android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="audio_mode_spinner">Audio Mode</string>
     <string name="audio_device_capabilities_spinner">Audio Device Capabilities</string>
     <string name="audio_redundancy_switch">Audio Redundancy</string>
+    <string name="enable_fhd_switch">Enable Higher Definition Video</string>
     <string name="reconnect_timeout_spinner">Reconnect Timeout MS</string>
     <string name="main_continue">Continue</string>
     <string name="main_continue_without_audio">Continue without audio</string>


### PR DESCRIPTION
Add an "Enable Higher Definition Video" switch to the demo home screen that requests FHD video and UHD content on join (v_rs=FHD, c_rs=UHD, a_cnt=25 - the demo backend requires the max-attendee count alongside the resolution params, capped at 25). The enable flag is enableHigherDefinitionVideo.

## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
