### PR TITLE
Don't synchronize on java.lang.Float

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/internal/video/gl/DefaultEglRenderer.kt
@@ -189,7 +189,7 @@ class DefaultEglRenderer(private val logger: Logger) : EglRenderer {
             // Setup draw matrix transformations
             val frameAspectRatio = frame.getRotatedWidth().toFloat() / frame.getRotatedHeight()
             var drawnAspectRatio = frameAspectRatio
-            synchronized(aspectRatio) {
+            synchronized(ShareEglLock.Lock) {
                 if (aspectRatio != 0f) {
                     drawnAspectRatio = aspectRatio
                 }


### PR DESCRIPTION
## ℹ️ Description

Writes to `aspectRatio` field are done holding `ShareEglLock.Lock` and I assume the original intent was to use to to guard all `aspectRatio` accesses with that monitor.

Also, once JEP-401 is implemented, such synchronizations will throw an exception.

### #713 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
