### PR TITLE
Bump version to 0.25.5

### DIFF
--- a/amazon-chime-sdk/version.properties
+++ b/amazon-chime-sdk/version.properties
@@ -1,3 +1,3 @@
 versionMajor=0
 versionMinor=25
-versionPatch=4
+versionPatch=5


### PR DESCRIPTION
## Overview
Bump the Android SDK version from 0.25.4 to 0.25.5 for the Mobile SDK release using Media 0.25.4 and Machine Learning 0.3.3.

## Testing
- Verified the branch contains one version-only change in `amazon-chime-sdk/version.properties`.
- Verified the branch is based on the current `development` tip.
