### PR TITLE
fix: prevent NPE when creating camera capture session in DefaultCameraCaptureSource

### DIFF
--- a/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
+++ b/amazon-chime-sdk/src/main/java/com/amazonaws/services/chime/sdk/meetings/audiovideo/video/capture/DefaultCameraCaptureSource.kt
@@ -305,10 +305,18 @@ class DefaultCameraCaptureSource @JvmOverloads constructor(
                 isCameraInterrupted = false
                 eventAnalyticsController?.publishEvent(EventName.videoCaptureSessionInterruptionEnded, mutableMapOf(), false)
             }
+            
+            val surface = surfaceTextureSource?.surface
+            if (surface == null) {
+                logger.error(TAG, "Surface is null, cannot create capture session")
+                device.close()
+                handleCameraCaptureFail(CaptureSourceError.SystemFailure)
+                return
+            }
 
             try {
                 cameraDevice?.createCaptureSession(
-                    listOf(surfaceTextureSource?.surface),
+                    listOf(surface),
                     cameraCaptureSessionStateCallback,
                     handler
                 )


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*


Fix: prevent NPE during camera capture session creation

During a cold start or when camera permissions are granted for the first
time, a race condition can occur where `surfaceTextureSource.surface` is 
null because the video render target setup has not yet completed. Passing 
a null surface to `CameraDevice.createCaptureSession` causes a fatal 
NullPointerException that crashes the camera thread and the application.

This fix adds a defensive check in `CameraDevice.StateCallback.onOpened` 
to verify the surface is not null before session creation. If the surface 
is missing, the code now:
1. Safely closes the camera device to prevent hardware resource leaks.
2. Emits a `CaptureSourceError.SystemFailure` to the capture observers.
3. Aborts the session creation gracefully.

### Issue #703 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Unit test coverage
* Class coverage: 
* Line coverage: 

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
